### PR TITLE
Fix: Hardcoded clipper path in #include

### DIFF
--- a/src/libsvg/shape.cc
+++ b/src/libsvg/shape.cc
@@ -53,7 +53,7 @@
 #include "libsvg/use.h"
 
 #include "libsvg/transformation.h"
-#include "submodules/Clipper2/CPP/Clipper2Lib/include/clipper2/clipper.offset.h"
+#include "clipper2/clipper.offset.h"
 #include "utils/degree_trig.h"
 #include "utils/calc.h"
 


### PR DESCRIPTION
When using `-DUSE_BUILTIN_CLIPPER2=OFF` Build fails this error:

```plaintext
[ 62%] Building CXX object CMakeFiles/OpenSCAD.dir/src/libsvg/tspan.cc.o
/gnu/store/86fc8bi3mciljxz7c79jx8zr4wsx7xw8-gcc-11.4.0/bin/c++ -DBOOST_DLL_USE_STD_FS -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DCGAL_DEBUG -DCGAL_USE_CORE=1 -DCGAL_USE_GMPXX -DCGAL_USE_GMPXX=1 -DCLIPPER2_MAX_DECIMAL_PRECISION=8 -DEIGEN_DONT_ALIGN -DENABLE_CAIRO -DENABLE_CGAL -DENABLE_DBUS -DENABLE_EGL -DENABLE_EXPERIMENTAL -DENABLE_HIDAPI -DENABLE_JOYSTICK -DENABLE_LIB3MF -DENABLE_LIBZIP -DENABLE_MANIFOLD -DENABLE_OPENCSG -DENABLE_PYTHON -DENABLE_QGAMEPAD -DENABLE_SPNAV -DGLEW_EGL -DOPENCSG_GLEW -DOPENSCAD_COMMIT=d7686eed2ed779bf6c2ee01e8c36f2d51db19ce5 -DOPENSCAD_DAY=9 -DOPENSCAD_MONTH=6 -DOPENSCAD_OS=\"Unix\" -DOPENSCAD_SHORTVERSION=2025.06.09 -DOPENSCAD_VERSION=2025.06.09 -DOPENSCAD_YEAR=2025 -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GAMEPAD_LIB -DQT_GUI_LIB -DQT_MULTIMEDIA_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_SVG_LIB -DQT_WIDGETS_LIB -DSTACKSIZE=8388608 -DUNICODE -DUSE_GLEW -DUSE_MANIFOLD_TRIANGULATOR -DUSE_QOPENGLWIDGET -D_REENTRANT -D_UNICODE -D_USE_MATH_DEFINES -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/build -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/build/OpenSCAD_autogen/include -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source/src -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source/src/python -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source/src/ext -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source/src/ext/lexertl/include -I/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source/src/ext/libtess2/Include -isystem /gnu/store/cnk2cxb1ggcbmrg75fyjagxk6l6y4qhi-eigen-3.4.0/include/eigen3 -isystem /gnu/store/4l66m7h6laqdfzcpdkb2j9a32pb1iidx-harfbuzz-8.3.0/include/harfbuzz -isystem /gnu/store/5csw0jn2lfkzavkq1fjjl7s7bdgmzjjk-glib-2.82.1/include/glib-2.0 -isystem /gnu/store/5csw0jn2lfkzavkq1fjjl7s7bdgmzjjk-glib-2.82.1/lib/glib-2.0/include -isystem /gnu/store/7ah6i5829f5ha6bdfzcj1gf21115xyyd-freetype-2.13.0/include/freetype2 -isystem /gnu/store/dqym4cqjc0pgwhiaqim3gwz18yh5fqrc-libxml2-2.9.14/include/libxml2 -isystem /gnu/store/n2rphbkasv05gahnjknamyqrvckiqcvb-hidapi-0.14.0/include/hidapi -isystem /gnu/store/zv420d7jscbcwkzndxb9n9dma4xhmf43-pixman-0.42.2/include/pixman-1 -isystem /gnu/store/gh9cgprk2x0zq7xw44dal0v8s3wixpj3-cairo-1.18.2/include/cairo -isystem /gnu/store/qj9jhgqn2b9g7yxdhyw6ki1vz241apkd-libpng-1.6.39/include/libpng16 -isystem /gnu/store/2l3vxv2dxwvpgc29jv4h349v9yzsad38-lib3mf-2.2.0/include/Bindings/Cpp -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5 -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5/QtCore -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/lib/qt5/mkspecs/linux-g++ -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5/QtWidgets -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5/QtGui -isystem /gnu/store/zqm1cfddaqn0nkmpilishiw1w3mxz0b3-qtmultimedia-5.15.15/include/qt5 -isystem /gnu/store/zqm1cfddaqn0nkmpilishiw1w3mxz0b3-qtmultimedia-5.15.15/include/qt5/QtMultimedia -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5/QtNetwork -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5/QtOpenGL -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5/QtConcurrent -isystem /gnu/store/4nw1p55g0yz522p4h4dhk2q1hcjz15ax-qtsvg-5.15.15/include/qt5 -isystem /gnu/store/4nw1p55g0yz522p4h4dhk2q1hcjz15ax-qtsvg-5.15.15/include/qt5/QtSvg -isystem /gnu/store/ikbvv74m9iv8jkiccv9k9vijkdnsmyr1-qtbase-5.15.15/include/qt5/QtDBus -isystem /gnu/store/206wkijm1if27d9g4sdkw9izdkz97y4z-qtgamepad-5.15.15/include/qt5 -isystem /gnu/store/206wkijm1if27d9g4sdkw9izdkz97y4z-qtgamepad-5.15.15/include/qt5/QtGamepad -frounding-math -O3 -DNDEBUG -fPIE -DENABLE_TBB -frounding-math -DMANIFOLD_CROSS_SECTION -DMANIFOLD_PAR=-1 -fPIC -std=c++17 -MD -MT CMakeFiles/OpenSCAD.dir/src/libsvg/tspan.cc.o -MF CMakeFiles/OpenSCAD.dir/src/libsvg/tspan.cc.o.d -o CMakeFiles/OpenSCAD.dir/src/libsvg/tspan.cc.o -c /tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source/src/libsvg/tspan.cc
/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/source/src/libsvg/shape.cc:56:10: fatal error: submodules/Clipper2/CPP/Clipper2Lib/include/clipper2/clipper.offset.h: No such file or directory
   56 | #include "submodules/Clipper2/CPP/Clipper2Lib/include/clipper2/clipper.offset.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/OpenSCAD.dir/build.make:2533: CMakeFiles/OpenSCAD.dir/src/libsvg/shape.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/build'
make[1]: *** [CMakeFiles/Makefile2:111: CMakeFiles/OpenSCAD.dir/all] Error 2
make[1]: Leaving directory '/tmp/guix-build-pythonscad-2025.06.01-0.7245089.drv-0/build'
make: *** [Makefile:169: all] Error 2
```

This patch fixes that.