### PR TITLE
Add Python cheat-sheet to help menu

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -721,6 +721,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   connect(this->helpActionHomepage, &QAction::triggered, this, &MainWindow::helpHomepage);
   connect(this->helpActionManual, &QAction::triggered, this, &MainWindow::helpManual);
   connect(this->helpActionCheatSheet, &QAction::triggered, this, &MainWindow::helpCheatSheet);
+  connect(this->helpActionPythonCheatSheet, &QAction::triggered, this, &MainWindow::helpPythonCheatSheet);
   connect(this->helpActionLibraryInfo, &QAction::triggered, this, &MainWindow::helpLibrary);
   connect(this->helpActionFontInfo, &QAction::triggered, this, &MainWindow::helpFontInfo);
 
@@ -4191,6 +4192,11 @@ void MainWindow::helpOfflineManual()
 void MainWindow::helpCheatSheet()
 {
   UIUtils::openCheatSheetURL();
+}
+
+void MainWindow::helpPythonCheatSheet()
+{
+  UIUtils::openPythonCheatSheetURL();
 }
 
 void MainWindow::helpOfflineCheatSheet()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -407,6 +407,7 @@ public slots:
   void helpManual();
   void helpOfflineManual();
   void helpCheatSheet();
+  void helpPythonCheatSheet();
   void helpOfflineCheatSheet();
   void helpLibrary();
   void helpFontInfo();

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -383,6 +383,7 @@
     <addaction name="helpActionManual"/>
     <addaction name="helpActionOfflineManual"/>
     <addaction name="helpActionCheatSheet"/>
+    <addaction name="helpActionPythonCheatSheet"/>
     <addaction name="helpActionOfflineCheatSheet"/>
     <addaction name="helpActionLibraryInfo"/>
     <addaction name="helpActionFontInfo"/>
@@ -1617,6 +1618,11 @@
   <action name="helpActionCheatSheet">
    <property name="text">
     <string>&amp;Cheat Sheet</string>
+   </property>
+  </action>
+  <action name="helpActionPythonCheatSheet">
+   <property name="text">
+    <string>&amp;Python Cheat Sheet</string>
    </property>
   </action>
   <action name="fileActionExportPDF">

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -276,6 +276,11 @@ void UIUtils::openCheatSheetURL()
 #endif
 }
 
+void UIUtils::openPythonCheatSheetURL()
+{
+  openURL("https://pythonscad.org/pythonscadhelper.html");
+}
+
 fs::path UIUtils::returnOfflineCheatSheetPath()
 {
   fs::path resPath = PlatformUtils::resourcePath("resources");

--- a/src/gui/UIUtils.h
+++ b/src/gui/UIUtils.h
@@ -80,6 +80,8 @@ void openOfflineUserManual();
 
 void openCheatSheetURL();
 
+void openPythonCheatSheetURL();
+
 fs::path returnOfflineCheatSheetPath();
 
 bool hasOfflineCheatSheet();


### PR DESCRIPTION
This adds an option to the help menu which opens the cheat-sheet for Python mode in the default browser.

I still need to check though whether translations need to be added in the translation files.