### PR TITLE
Improve create appimage

### DIFF
--- a/create_appimage.sh
+++ b/create_appimage.sh
@@ -1,9 +1,8 @@
-#! /bin/sh
+#!/bin/sh -e
 export PYTHON_VERSION=$(python3 -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 cd build
 cmake  -DCMAKE_INSTALL_PREFIX=/usr -DEXPERIMENTAL=1 -DENABLE_PYTHON=1 -DPYTHON_VERSION=${PYTHON_VERSION} -DENABLE_LIBFIVE=1 ..
 make -j3
-if [ ! $? == 0 ] ; then exit 1 ; fi
 rm -rf ../AppDir
 make install DESTDIR=../AppDir
 cd ..

--- a/create_appimage.sh
+++ b/create_appimage.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
-
+export PYTHON_VERSION=$(python3 -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 cd build
-cmake  -DCMAKE_INSTALL_PREFIX=/usr -DEXPERIMENTAL=1 -DENABLE_PYTHON=1 -DPYTHON_VERSION=3.12 -DENABLE_LIBFIVE=1 ..
+cmake  -DCMAKE_INSTALL_PREFIX=/usr -DEXPERIMENTAL=1 -DENABLE_PYTHON=1 -DPYTHON_VERSION=${PYTHON_VERSION} -DENABLE_LIBFIVE=1 ..
 make -j3
 if [ ! $? == 0 ] ; then exit 1 ; fi
 rm -rf ../AppDir
@@ -11,7 +11,6 @@ cd ..
 export EXTRA_QT_PLUGINS=svg
 /home/gsohler/git/linuxdeploy-plugin-python/linuxdeploy-plugin-python.sh --appdir AppDir
 export PATH=/appimage/usr/local/bin:$PATH
-rm AppDir/usr/lib/python3.12/config-3.12-x86_64-linux-gnu/python.o
+rm AppDir/usr/lib/python${PYTHON_VERSION}/config-${PYTHON_VERSION}-x86_64-linux-gnu/python.o
 linuxdeploy --plugin qt --output appimage --appdir AppDir
 echo finished
-


### PR DESCRIPTION
The AppImage creation script needs an overhaul.

It contains static information (e.g. the PythonVersion) and depends on local nonstandard tools.
It should probably be transformed into a github action.

I've done some initial fixes to the code, but we should add more here.

@gsohler: Could you please shed some light on those `linuxdeploy-plugin-python` thingies? I want to make this self-contained and independent so it can be run and reproduces by others as well.