### PR TITLE
Merge ctest refactoring from OpenSCAD

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -112,7 +112,7 @@ get_debian_deps()
   libharfbuzz-dev libmimalloc-dev libmpfr-dev libopencsg-dev \
   libqt5gamepad5-dev libtbb-dev libxi-dev libxml2-dev libxmu-dev \
   libzip-dev nettle-dev ninja-build nodejs pkg-config python3-dev \
-  python3-setuptools python3-venv ragel xvfb
+  python3-setuptools python3-venv ragel xvfb libcurl4-openssl-dev
  if [ "$USE_QT6" = "1" ]; then
   get_qt6_deps_debian
  else
@@ -140,7 +140,7 @@ get_arch_deps()
   base-devel gcc bison flex make libzip cairo \
   qt5 qscintilla-qt5 cgal gmp mpfr boost opencsg \
   glew eigen glib2 fontconfig freetype2 harfbuzz \
-  double-conversion imagemagick tbb curl cmake freetype2 gcc-libs ghostscript  \
+  double-conversion imagemagick tbb curl libcurl-openssl cmake freetype2 gcc-libs ghostscript  \
   glibc glu  hicolor-icon-themes hicolor-icon-themes  hidapi lib3mf libglvnd \
   libspnav  libx11 libxml2 mimalloc nettle procps-ng python python-pip python-setuptools \
   qt5-base qt5-multimedia qt5-svg  xorg-server-xvfb

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1262,9 +1262,6 @@ add_output_file_test(relative-output FILE ${TEST_SCAD_DIR}/3D/features/cube-test
 add_output_file_test(relative-output FILE ${TEST_SCAD_DIR}/3D/features/cube-tests.scad FORMAT nef3)
 add_output_file_test(relative-output FILE ${TEST_SCAD_DIR}/3D/features/cube-tests.scad FORMAT nefdbg)
 
-  PROPERTIES DISABLED TRUE
-)
-
 if(NOT ENABLE_LIBFIVE)
   message(STATUS "LIBFIVE is not enabled. Skipping related tests.")
   disable_tests_safe(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ function(disable_tests_safe)
     endif()
 endfunction()
 
-# When configuring OpenSCADTests as a top-level project, we 
+# When configuring OpenSCADTests as a top-level project, we
 # expect a self-contained OpenSCAD installation to exist.
 # The location can be specified via the OPENSCAD_BINARY CMake or
 # environment variable.
@@ -99,7 +99,7 @@ if(PROJECT_IS_TOP_LEVEL)
     message(STATUS "Couldn't find the OpenSCAD binary: ${OPENSCAD_BINPATH}")
     message(FATAL_ERROR "Please place an OpenSCAD binary at: ${OPENSCAD_BINPATH}")
     unset(OPENSCAD_BINPATH)
-  else() 
+  else()
     message(STATUS "Found OpenSCAD binary: ${OPENSCAD_BINPATH}")
   endif()
 endif()
@@ -718,8 +718,8 @@ remove_test_config(Bugs FILES
 if(EXAMPLES_DIR)
   set_test_config(Examples FILES ${EXAMPLE_FILES} PREFIXES
     render-cgal render-manifold
-    preview-cgal preview-manifold preview-manifold preview throwntogether-cgal throwntogether-manifold 
-    render-csg-cgal render-monotone 
+    preview-cgal preview-manifold preview-manifold preview throwntogether-cgal throwntogether-manifold
+    render-csg-cgal render-monotone
     preview-off render-off dump-examples)
   set_test_config(Examples FILES ${EXAMPLE_2D_FILES} PREFIXES render-dxf)
 endif(EXAMPLES_DIR)
@@ -1262,20 +1262,13 @@ add_output_file_test(relative-output FILE ${TEST_SCAD_DIR}/3D/features/cube-test
 add_output_file_test(relative-output FILE ${TEST_SCAD_DIR}/3D/features/cube-tests.scad FORMAT nef3)
 add_output_file_test(relative-output FILE ${TEST_SCAD_DIR}/3D/features/cube-tests.scad FORMAT nefdbg)
 
-# Disable tests failing due to https://github.com/openscad/openscad/issues/4632
-set_tests_properties(
-  relative-output_csg_run
-  relative-output_csg_check
-  relative-output_ast_run
-  relative-output_ast_check
   PROPERTIES DISABLED TRUE
 )
 
 if(NOT ENABLE_LIBFIVE)
   message(STATUS "LIBFIVE is not enabled. Skipping related tests.")
-  set_tests_properties(
+  disable_tests_safe(
     pythonscad_sdf
-    PROPERTIES DISABLED TRUE
   )
 endif()
 
@@ -1283,7 +1276,13 @@ endif()
 # Disable Tests with Known Issues #
 ###################################
 
-set_tests_properties(
+disable_tests_safe(
+  # Disable tests failing due to https://github.com/openscad/openscad/issues/4632
+  relative-output_csg_run
+  relative-output_csg_check
+  relative-output_ast_run
+  relative-output_ast_check
+
   # These don't output anything
   render-dxf_text-empty-tests
   render-dxf_nothing-decimal-comma-separated
@@ -1359,128 +1358,84 @@ set_tests_properties(
   preview-cgal_issue2841b
   render-csg-cgal_issue2841b
 
-  PROPERTIES DISABLED TRUE
-)
-if(EXAMPLES_DIR) 
-  set_tests_properties(
-    # OpenCSG z fighting
-    preview-cgal_surface_image
-    throwntogether-cgal_surface_image
+  # OpenCSG z fighting
+  preview-cgal_surface_image
+  throwntogether-cgal_surface_image
 
-    # https://github.com/openscad/openscad/issues/5159
-    render-cgal_projection
-    render-csg-cgal_projection
+  # https://github.com/openscad/openscad/issues/5159
+  render-cgal_projection
+  render-csg-cgal_projection
 
-    # https://github.com/openscad/openscad/issues/5158
-    #render-cgal_example017 
-    #throwntogether-cgal_example017
-    
-    # https://github.com/openscad/openscad/issues/4398
-    render-csg-cgal_logo_and_text
+  # https://github.com/openscad/openscad/issues/5158
+  #render-cgal_example017
+  #throwntogether-cgal_example017
 
-    PROPERTIES DISABLED TRUE
-  )
-endif(EXAMPLES_DIR)
+  # https://github.com/openscad/openscad/issues/4398
+  render-csg-cgal_logo_and_text
 
+  # z-fighting different on different machines
+  preview-manifold_issue1165
+  preview-manifold_issue1215
 
-if (ENABLE_MANIFOLD_TESTS)
-  set_tests_properties(
-    # z-fighting different on different machines
-    preview-manifold_issue1165
-    preview-manifold_issue1215
+  # Manifold triangle order not stable, causes transparent
+  # objects to render differently on different machines
+  render-manifold_color-tests
+  render-manifold_hex-colors-tests
 
-    # Manifold triangle order not stable, causes transparent
-    # objects to render differently on different machines
-    render-manifold_color-tests
-    render-manifold_hex-colors-tests
+  # https://github.com/openscad/openscad/issues/909
+  render-amf-manifold_bad-stl-wing
+  render-amf-manifold_bad-stl-pcbvicebar
+  render-amf-manifold_bad-stl-tardis
 
-    # https://github.com/openscad/openscad/issues/909
-    render-amf-manifold_bad-stl-wing
-    render-amf-manifold_bad-stl-pcbvicebar
-    render-amf-manifold_bad-stl-tardis
+  # https://github.com/openscad/openscad/issues/2841
+  render-manifold_issue2841b
+  preview-manifold_issue2841b
 
-    # https://github.com/openscad/openscad/issues/2841
-    render-manifold_issue2841b
-    preview-manifold_issue2841b
+  # https://github.com/openscad/openscad/issues/5135
+  render-force-manifold_issue5135-bad
 
-    # https://github.com/openscad/openscad/issues/5135
-    render-force-manifold_issue5135-bad
+  # https://github.com/openscad/openscad/issues/5218
+  throwntogether-manifold_issue5218
+  throwntogether-manifold_issue913
 
-    # https://github.com/openscad/openscad/issues/5218
-    throwntogether-manifold_issue5218
-    throwntogether-manifold_issue913
+  # z-fighting different on different machines
+  preview-cgal_example017
+  preview-manifold_example017
 
-    PROPERTIES DISABLED TRUE
-  )
-  if(EXAMPLES_DIR)
-    set_tests_properties(
-      # z-fighting different on different machines
-      preview-cgal_example017
-      preview-manifold_example017
+  # OpenCSG z fighting
+  preview-manifold_surface_image
+  throwntogether-manifold_surface_image
 
-      # OpenCSG z fighting
-      preview-manifold_surface_image
-      throwntogether-manifold_surface_image
+  # Manifold triangle order not stable, causes transparent
+  # objects to render differently on different machines
+  render-manifold_projection
 
-      # Manifold triangle order not stable, causes transparent
-      # objects to render differently on different machines
-      render-manifold_projection
+  # https://github.com/openscad/openscad/issues/5218
+  throwntogether-manifold_example016
 
-      # https://github.com/openscad/openscad/issues/5218
-      throwntogether-manifold_example016
-
-      PROPERTIES DISABLED TRUE
-    )
-  endif(EXAMPLES_DIR)
-endif (ENABLE_MANIFOLD_TESTS)
-
-if (EXPERIMENTAL)
-set_tests_properties(
   # https://github.com/openscad/openscad/issues/5220
   render-cgal_roof
   render-csg-cgal_roof
 
-  PROPERTIES DISABLED TRUE
+  render-off-manifold_issue5216
+
+  # For some reason, only failing on Linux
+  render-manifold_import_3mf-tests
+  preview-cgal_3mf-import-centered
+  preview-manifold_3mf-import-centered
+  preview-manifold_import_3mf-tests
+  render-off-manifold_issue5216
+  export-3mf_3mf-export
+  render-3mf-cgal_bad-stl-tardis
+  render-3mf-cgal_bad-stl-wing
+  render-3mf-manifold_issue5216
+
+  preview-cgal_import_3mf-tests
+  render-cgal_import_3mf-tests
+  render-csg-cgal_import_3mf-tests
+  throwntogether-cgal_import_3mf-tests
+  throwntogether-manifold_import_3mf-tests
 )
-endif (EXPERIMENTAL)
-
-if (ENABLE_LIB3MF_TESTS)
-  if (EXPERIMENTAL)
-    set_tests_properties(
-      # https://github.com/openscad/openscad/issues/5800
-      export-3mf_3mf-export
-
-      PROPERTIES DISABLED TRUE
-    )
-  endif (EXPERIMENTAL)
-  if (ENABLE_MANIFOLD_TESTS)
-    set_tests_properties(
-      # https://github.com/openscad/openscad/issues/5966
-     render-off-manifold_issue5216
-     render-3mf-manifold_issue5216
-
-     PROPERTIES DISABLED TRUE
-    )
-  endif (ENABLE_MANIFOLD_TESTS)  
-  set_tests_properties(
-    # When exported from CGAL, the file cannot be re-imported
-    render-3mf-cgal_bad-stl-wing
-
-    # For some reason, only failing on Linux
-    render-3mf-cgal_bad-stl-tardis
-
-    PROPERTIES DISABLED TRUE
-  )
-else()
-  set_tests_properties(
-    preview-cgal_import_3mf-tests
-    render-cgal_import_3mf-tests
-    render-csg-cgal_import_3mf-tests
-    throwntogether-cgal_import_3mf-tests
-    throwntogether-manifold_import_3mf-tests
-    PROPERTIES DISABLED TRUE
-  )
-endif(ENABLE_LIB3MF_TESTS)
 
 list(APPEND NEF3_BROKEN_TESTS
   render-cgal_nef3_broken


### PR DESCRIPTION
With the previous merge, this change has only partly been merged.
This PR also merges the part where disabling of tests is being cleaned up.