### PR TITLE
Openscad wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .uuid
 .cache/
+__pycache__/
+*.pyc
 .vs/
 .vscode/
 .idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1679,6 +1679,8 @@ if(NOT APPLE OR APPLE_UNIX)
   install(TARGETS OpenSCAD RUNTIME DESTINATION "${OPENSCAD_BINDIR}")
   if(ENABLE_PYTHON)
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pythonscad-python DESTINATION "${OPENSCAD_BINDIR}")
+    # Install Python wrapper module
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/python/openscad.py DESTINATION "${OPENSCAD_INSTALL_RESOURCEDIR}/libraries/python")
   endif()
   if(WIN32)
     if(ENABLE_PYTHON)

--- a/libraries/python/openscad.py
+++ b/libraries/python/openscad.py
@@ -1,0 +1,1 @@
+../../src/python/openscad.py

--- a/src/python/openscad.py
+++ b/src/python/openscad.py
@@ -60,7 +60,22 @@ def _create_wrapper_function(func_name):
     original_func = getattr(_openscad, func_name)
 
     def wrapper(*args, **kwargs):
-        result = original_func(*args, **kwargs)
+        # Unwrap OpenSCADWrapper objects in arguments
+        unwrapped_args = []
+        for arg in args:
+            if isinstance(arg, OpenSCADWrapper):
+                unwrapped_args.append(arg._obj)
+            else:
+                unwrapped_args.append(arg)
+
+        unwrapped_kwargs = {}
+        for key, value in kwargs.items():
+            if isinstance(value, OpenSCADWrapper):
+                unwrapped_kwargs[key] = value._obj
+            else:
+                unwrapped_kwargs[key] = value
+
+        result = original_func(*unwrapped_args, **unwrapped_kwargs)
         # Check if result is a PyOpenSCAD object that should be wrapped
         if hasattr(result, '__class__') and result.__class__.__name__ == 'PyOpenSCAD':
             return OpenSCADWrapper(result)

--- a/src/python/openscad.py
+++ b/src/python/openscad.py
@@ -1,0 +1,75 @@
+import _openscad
+
+class OpenSCADWrapper:
+    def __init__(self, openscad_obj):
+        self._obj = openscad_obj
+
+    def __getattr__(self, name):
+        attr = getattr(self._obj, name)
+        # If it's a method that returns a PyOpenSCAD object, wrap the result
+        if callable(attr):
+            def wrapped_method(*args, **kwargs):
+                result = attr(*args, **kwargs)
+                # Check if result is a PyOpenSCAD object that should be wrapped
+                if hasattr(result, '__class__') and result.__class__.__name__ == 'PyOpenSCAD':
+                    return OpenSCADWrapper(result)
+                return result
+            return wrapped_method
+        return attr
+
+    def _wrap_if_needed(self, result):
+        """Helper to wrap PyOpenSCAD objects"""
+        if hasattr(result, '__class__') and result.__class__.__name__ == 'PyOpenSCAD':
+            return OpenSCADWrapper(result)
+        return result
+
+    # Operator overloads - delegate to the wrapped object and wrap results
+    def __or__(self, other):
+        """Union operator |"""
+        other_obj = other._obj if isinstance(other, OpenSCADWrapper) else other
+        return self._wrap_if_needed(self._obj | other_obj)
+
+    def __and__(self, other):
+        """Intersection operator &"""
+        other_obj = other._obj if isinstance(other, OpenSCADWrapper) else other
+        return self._wrap_if_needed(self._obj & other_obj)
+
+    def __sub__(self, other):
+        """Difference operator -"""
+        other_obj = other._obj if isinstance(other, OpenSCADWrapper) else other
+        return self._wrap_if_needed(self._obj - other_obj)
+
+    def __add__(self, other):
+        """Addition operator + (if defined)"""
+        other_obj = other._obj if isinstance(other, OpenSCADWrapper) else other
+        return self._wrap_if_needed(self._obj + other_obj)
+
+    def center(self):
+        return OpenSCADWrapper(self._obj.translate([0 - (self._obj.position[i] + self._obj.size[i] / 2) for i in range(3)]))
+
+    def hello_world(self):
+        # Your convenience method
+        return "Hello, World!"
+
+# Get all callable functions from _openscad module
+_openscad_functions = [name for name in dir(_openscad) if callable(getattr(_openscad, name)) and not name.startswith('_')]
+
+# Dynamically create wrapper functions
+def _create_wrapper_function(func_name):
+    """Creates a wrapper function for the given openscad function"""
+    original_func = getattr(_openscad, func_name)
+
+    def wrapper(*args, **kwargs):
+        result = original_func(*args, **kwargs)
+        # Check if result is a PyOpenSCAD object that should be wrapped
+        if hasattr(result, '__class__') and result.__class__.__name__ == 'PyOpenSCAD':
+            return OpenSCADWrapper(result)
+        return result
+
+    # Copy function metadata
+    wrapper.__name__ = func_name
+    wrapper.__doc__ = getattr(original_func, '__doc__', None)
+    return wrapper
+
+# Add all openscad functions to this module's namespace
+globals().update({func_name: _create_wrapper_function(func_name) for func_name in _openscad_functions})

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -43,7 +43,7 @@
 namespace fs = std::filesystem;
 
 // #define HAVE_PYTHON_YIELD
-extern "C" PyObject *PyInit_openscad(void);
+extern "C" PyObject *PyInit__openscad(void);
 PyMODINIT_FUNC PyInit_PyOpenSCAD(void);
 
 bool python_active;
@@ -851,7 +851,7 @@ void initPython(const std::string& binDir, const std::string& scriptpath, double
 #ifdef HAVE_PYTHON_YIELD
     set_object_callback(openscad_object_callback);
 #endif
-    PyImport_AppendInittab("openscad", &PyInit_PyOpenSCAD);
+    PyImport_AppendInittab("_openscad", &PyInit_PyOpenSCAD);
     PyImport_AppendInittab("libfive", &PyInit_data);
     PyConfig config;
     PyConfig_InitPythonConfig(&config);
@@ -862,16 +862,18 @@ void initPython(const std::string& binDir, const std::string& scriptpath, double
     char sepchar = ';';
     sep = sepchar;
     stream << PlatformUtils::applicationPath() << "\\..\\libraries\\python";
+    stream << sep << PlatformUtils::applicationPath() << "\\python";
 #else
     char sepchar = ':';
     const auto pythonXY =
       "python" + std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION);
-    const std::array<std::string, 5> paths = {
+    const std::array<std::string, 6> paths = {
       "../libraries/python",
       "../lib/" + pythonXY,
       "../python/lib/" + pythonXY,
       "../Frameworks/" + pythonXY,
       "../Frameworks/" + pythonXY + "/site-packages",
+      std::string("../share/") + EXECUTABLE_NAME + "/python",
     };
     for (const auto& path : paths) {
       const auto p = fs::path(PlatformUtils::applicationPath() + fs::path::preferred_separator + path);
@@ -906,6 +908,9 @@ void initPython(const std::string& binDir, const std::string& scriptpath, double
     pythonRuntimeInitialized = pythonInitDict != nullptr;
     PyInit_PyData();
     PyRun_String("from builtins import *\n", Py_file_input, pythonInitDict.get(), pythonInitDict.get());
+    // Import the openscad wrapper module to make it available as 'openscad'
+    PyRun_String("try:\n    import openscad\nexcept ImportError:\n    pass\n", Py_file_input,
+                 pythonInitDict.get(), pythonInitDict.get());
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     PyObject *maindict = PyModule_GetDict(pythonMainModule.get());
@@ -1164,7 +1169,7 @@ PyTypeObject PyOpenSCADType = {
 };
 
 static PyModuleDef OpenSCADModule = {PyModuleDef_HEAD_INIT,
-                                     "openscad",
+                                     "_openscad",
                                      "OpenSCAD Python Module",
                                      -1,
                                      PyOpenSCADFunctions,
@@ -1173,7 +1178,7 @@ static PyModuleDef OpenSCADModule = {PyModuleDef_HEAD_INIT,
                                      NULL,
                                      NULL};
 
-extern "C" PyObject *PyInit_openscad(void) { return PyModule_Create(&OpenSCADModule); }
+extern "C" PyObject *PyInit__openscad(void) { return PyModule_Create(&OpenSCADModule); }
 
 PyMODINIT_FUNC PyInit_PyOpenSCAD(void)
 {
@@ -1181,7 +1186,7 @@ PyMODINIT_FUNC PyInit_PyOpenSCAD(void)
 
   if (PyType_Ready(&PyOpenSCADType) < 0) return NULL;
 
-  m = PyInit_openscad();
+  m = PyInit__openscad();
   if (m == NULL) return NULL;
 
   Py_INCREF(&PyOpenSCADType);


### PR DESCRIPTION
This renames the internal module `openscad` to `_openscad`.
A pure python wrapper module named `openscad` is added.

This allows for methods to conveniently be implemented in Python instead of C++. Additionally users can easily extend the class with their own methods and properties directly by adding them to the wrapper class directly.

Stuff like this becomes possible:
```python
from openscad import *

pole = cylinder(h=20, d=5)
sphere = sphere(d=10).up(pole.size[2])

print(pole.hello_world())
(pole | sphere).center().show()
```

The `hello_world()` and `center()` methods have been implemented in the wrapper class as an example.

This is a very early draft which isn't well tested at all and surely a lot of things are not yet working and need some TLC.
But it's a good start IMHO.