### PR TITLE
refactor: finalize rebrand OpenSCAD to PythonSCAD across codebase

### DIFF
--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -130,7 +130,7 @@ std::string LibraryInfo::info()
   const char *env_path = getenv("OPENSCADPATH");
   const char *env_font_path = getenv("OPENSCAD_FONT_PATH");
 
-  s << "OpenSCAD Version: " << openscad_detailedversionnumber
+  s << "PythonSCAD Version: " << openscad_detailedversionnumber
     << "\nSystem information: " << PlatformUtils::sysinfo()
     << "\nUser Agent: " << PlatformUtils::user_agent() << "\nCompiler: " << compiler_info
     << "\nMinGW build: " << mingwstatus << "\nDebug build: " << debugstatus

--- a/src/gui/AboutDialog.h
+++ b/src/gui/AboutDialog.h
@@ -14,7 +14,7 @@ public:
   AboutDialog(QWidget *)
   {
     setupUi(this);
-    this->setWindowTitle(QString(_("About OpenSCAD")) + " " + openscad_shortversionnumber.c_str());
+    this->setWindowTitle(QString(_("About PythonSCAD")) + " " + openscad_shortversionnumber.c_str());
     QString tmp = this->aboutText->toHtml();
     tmp.replace("__VERSION__", openscad_detailedversionnumber.c_str());
     this->aboutText->setHtml(tmp);

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3118,7 +3118,7 @@ void MainWindow::updateStatusBar(ProgressWidget *progressWidget)
       this->progresswidget = nullptr;
     }
     if (versionLabel == nullptr) {
-      versionLabel = new QLabel("OpenSCAD " + QString::fromStdString(openscad_displayversionnumber));
+      versionLabel = new QLabel("PythonSCAD " + QString::fromStdString(openscad_displayversionnumber));
       sb->addPermanentWidget(this->versionLabel);
     }
   } else {

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -237,7 +237,7 @@ void help_export(const std::array<const Settings::SettingsEntryBase *, size>& op
 
 void help_export()
 {
-  LOG("OpenSCAD version %1$s\n", TOSTRING(OPENSCAD_VERSION));
+  LOG("PythonSCAD version %1$s\n", TOSTRING(OPENSCAD_VERSION));
   LOG("List of settings that can be given using the -O option using the");
   LOG("format '<section>/<key>=value', e.g.:");
   LOG("openscad -O export-pdf/paper-size=a6 -O export-pdf/show-grid=false\n");
@@ -249,7 +249,7 @@ void help_export()
 
 void version()
 {
-  LOG("OpenSCAD version %1$s", TOSTRING(OPENSCAD_VERSION));
+  LOG("PythonSCAD version %1$s", TOSTRING(OPENSCAD_VERSION));
   exit(0);
 }
 

--- a/src/platform/PlatformUtils-mac.mm
+++ b/src/platform/PlatformUtils-mac.mm
@@ -11,35 +11,35 @@
 
 #include "version.h"
 
-std::string PlatformUtils::pathSeparatorChar()
-{
-  return ":";
-}
+std::string PlatformUtils::pathSeparatorChar() { return ":"; }
 
-std::string PlatformUtils::userDocumentsPath()
-{
-  return documentsPath();
-}
+std::string PlatformUtils::userDocumentsPath() { return documentsPath(); }
 
 std::string PlatformUtils::documentsPath()
 {
-  return std::string([[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject] UTF8String]);
+  return std::string([[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)
+    lastObject] UTF8String]);
 }
 
 std::string PlatformUtils::userConfigPath()
 {
   NSError *error = nullptr;
-  NSURL *appSupportDir = [[NSFileManager defaultManager] URLForDirectory:NSApplicationSupportDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:&error];
+  NSURL *appSupportDir = [[NSFileManager defaultManager] URLForDirectory:NSApplicationSupportDirectory
+                                                                inDomain:NSUserDomainMask
+                                                       appropriateForURL:nil
+                                                                  create:YES
+                                                                   error:&error];
   if (error) {
     return "";
   }
-  return std::string([[appSupportDir path] UTF8String]) + std::string("/") + PlatformUtils::OPENSCAD_FOLDER_NAME;
+  return std::string([[appSupportDir path] UTF8String]) + std::string("/") +
+         PlatformUtils::OPENSCAD_FOLDER_NAME;
 }
 
 unsigned long PlatformUtils::stackLimit()
 {
-  struct rlimit limit;        
-  
+  struct rlimit limit;
+
   int ret = getrlimit(RLIMIT_STACK, &limit);
   if (ret == 0) {
     if (limit.rlim_cur > STACK_BUFFER_SIZE) {
@@ -49,7 +49,7 @@ unsigned long PlatformUtils::stackLimit()
       return limit.rlim_max - STACK_BUFFER_SIZE;
     }
   }
-  
+
   return STACK_LIMIT_DEFAULT;
 }
 
@@ -57,8 +57,7 @@ const std::string PlatformUtils::user_agent()
 {
   std::ostringstream result;
 
-  result << "OpenSCAD/" << openscad_detailedversionnumber
-         << " (" << sysinfo(false) << ")";
+  result << "PythonSCAD/" << openscad_detailedversionnumber << " (" << sysinfo(false) << ")";
 
   return result.str();
 }
@@ -66,12 +65,12 @@ const std::string PlatformUtils::user_agent()
 const std::string PlatformUtils::sysinfo(bool extended)
 {
   std::ostringstream result;
-  
+
   NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
   struct utsname name;
   uname(&name);
-  result << "macOS " << version.majorVersion << "." << version.minorVersion << "." << version.patchVersion
-	 << " " << name.machine;
+  result << "macOS " << version.majorVersion << "." << version.minorVersion << "."
+         << version.patchVersion << " " << name.machine;
 
   size_t modellen = 0;
   sysctlbyname("hw.model", nullptr, &modellen, nullptr, 0);
@@ -84,14 +83,15 @@ const std::string PlatformUtils::sysinfo(bool extended)
 
   if (extended) {
     int32_t numcpu;
-    size_t length32 = sizeof(int32_t);;
+    size_t length32 = sizeof(int32_t);
+    ;
     sysctlbyname("hw.physicalcpu", &numcpu, &length32, nullptr, 0);
     int64_t physical_memory;
     size_t length64 = sizeof(int64_t);
     sysctlbyname("hw.memsize", &physical_memory, &length64, nullptr, 0);
-  
+
     result << " " << numcpu << " CPU";
-    if (numcpu > 1) result << "s"; 
+    if (numcpu > 1) result << "s";
     result << " " << PlatformUtils::toMemorySizeString(physical_memory, 2) << " RAM ";
   }
 

--- a/src/platform/PlatformUtils-posix.cc
+++ b/src/platform/PlatformUtils-posix.cc
@@ -230,7 +230,7 @@ const std::string PlatformUtils::user_agent()
   std::lock_guard<std::mutex> lock(user_agent_mutex);
 
   if (result.empty()) {
-    result += "OpenSCAD/";
+    result += "PythonSCAD/";
     result += openscad_detailedversionnumber;
     result += " (";
     result += get_system_info(false);

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -135,7 +135,7 @@ const std::string PlatformUtils::user_agent()
 {
   std::string result;
 
-  result += "OpenSCAD/";
+  result += "PythonSCAD/";
   result += openscad_detailedversionnumber;
   result += " (";
   result += sysinfo(false);


### PR DESCRIPTION
This fixes a few places where the program still self-identified as OpenSCAD