### PR TITLE
enabling variable args in show()

### DIFF
--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -2034,12 +2034,12 @@ PyObject *python_show_core(PyObject *obj)
 PyObject *python_show(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   PyObject *obj = NULL;
-  char *kwlist[] = {"obj", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O", kwlist, &obj)) {
-    PyErr_SetString(PyExc_TypeError, "Error during parsing output(object)");
-    return NULL;
+  PyObject *result = Py_None;
+  if (args == nullptr) return result;
+  for (int i = 0; i < PyTuple_Size(args); i++) {
+    result = python_show_core(PyTuple_GetItem(args, i));
   }
-  return python_show_core(obj);
+  return result;
 }
 
 PyObject *python_oo_show(PyObject *obj, PyObject *args, PyObject *kwargs)


### PR DESCRIPTION
## Summary
Enables the `show()` function to accept multiple arguments (variadic arguments) instead of just a single object, making it more convenient to visualize multiple objects at once.

## Changes
Modified `python_show()` in [src/python/pyfunctions.cc](https://github.com/pythonscad/pythonscad/blob/visualstudio-build/src/python/pyfunctions.cc#L2034) to:
- Remove single-argument keyword parsing with `PyArg_ParseTupleAndKeywords`
- Iterate through all positional arguments in the `args` tuple
- Call `python_show_core()` on each argument
- Return the result of the last call (or `Py_None` if no args)

## Before
```python
show(obj)  # Could only show one object at a time
```

## After
```python
show(obj1, obj2, obj3, ...)  # Can now show multiple objects
```

## Use Case
This makes it more convenient to visualize multiple objects:
```python
# Instead of:
show(sphere(10))
show(cube(20))

# You can now do:
show(sphere(10), cube(20))
```

This matches the behavior of OpenSCAD's built-in functions like `echo()` which also accept multiple arguments.