### PR TITLE
fix: trust unsaved Python files to prevent segfault after canceled Sa…

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2400,6 +2400,11 @@ bool MainWindow::trust_python_file(const std::string& file, const std::string& c
   if (python_trusted) return true;
   if (Settings::SettingsPython::globalTrustPython.value() == true) return true;
 
+  // Trust unsaved files (empty filepath) - they're created by the user, not loaded from disk
+  if (file.empty()) {
+    return true;
+  }
+
   std::string act_hash, ref_hash;
   snprintf(setting_key, sizeof(setting_key) - 1, "python_hash/%s", file.c_str());
   act_hash = SHA256HashString(content);


### PR DESCRIPTION
…ve-As

Fix a bug where unsaved Python files (with empty filepath) would fail the trust check after canceling a Save-As dialog, leading to "Python is not enabled" warning and eventual segfault on subsequent renders.

Root Cause:
1. New file created as "Untitled.py" (not a real file path)
2. User presses Ctrl+S, triggering save() which sets filepath to ""
3. User cancels Save-As dialog, filepath remains empty
4. On next render, trust_python_file() is called with empty filename
5. Trust check fails because empty string isn't in trusted files list
6. Python interpreter not initialized, causing crash

Solution:
Add explicit check at the beginning of trust_python_file() to always trust files with empty filenames. These represent unsaved files that the user is actively creating in the editor, not files loaded from disk, so they don't pose a security risk.

Reproduction:
1. Start PythonSCAD, select "New" in welcome dialog
2. Press F5 to preview (works fine)
3. Press Ctrl+S, then ESC to cancel Save-As
4. Press F5 again -> "WARNING: Python is not enabled"
5. Press F5 again -> segfault

This fix resolves the issue by treating unsaved files as inherently trusted since they originate from user input, not external sources.