### PR TITLE
feat: add Windows binary distribution packaging

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,9 +59,7 @@ jobs:
         run: |
           cd build
           ctest -j4
-      - name: Setup (detached) tmate session if enabled
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
       - name: Upload Test Result Report
         uses: actions/upload-artifact@v5
         if: ${{ always() }}
@@ -70,3 +68,61 @@ jobs:
           path: |
             build/Testing/Temporary/*_report.html
             build/Testing/Temporary/LastTest.log
+
+      - name: Install NSIS for packaging
+        if: github.event_name != 'pull_request'
+        run: |
+          pacman --noconfirm -S mingw-w64-ucrt-x86_64-nsis
+
+      - name: Create distribution packages
+        if: github.event_name != 'pull_request'
+        run: |
+          cd build
+          cpack -G "ZIP;NSIS"
+
+      - name: Find generated packages
+        if: github.event_name != 'pull_request'
+        id: packages
+        shell: bash
+        env:
+          QT_VERSION: ${{ matrix.qt }}
+        run: |
+          cd build
+          ZIP_FILE=$(ls *.zip 2>/dev/null | head -1 || echo "")
+          EXE_FILE=$(ls *.exe 2>/dev/null | head -1 || echo "")
+
+          if [ -n "$ZIP_FILE" ]; then
+            # Insert Qt version after "PythonSCAD-" in artifact name
+            ARTIFACT_NAME="${ZIP_FILE/PythonSCAD-/PythonSCAD-${QT_VERSION}-}"
+            echo "zip_path=build/$ZIP_FILE" >> $GITHUB_OUTPUT
+            echo "zip_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+            echo "Found ZIP: $ZIP_FILE (artifact: $ARTIFACT_NAME)"
+          fi
+
+          if [ -n "$EXE_FILE" ]; then
+            # Insert Qt version after "PythonSCAD-" in artifact name
+            ARTIFACT_NAME="${EXE_FILE/PythonSCAD-/PythonSCAD-${QT_VERSION}-}"
+            echo "exe_path=build/$EXE_FILE" >> $GITHUB_OUTPUT
+            echo "exe_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+            echo "Found EXE: $EXE_FILE (artifact: $ARTIFACT_NAME)"
+          fi
+
+      - name: Upload ZIP package
+        if: github.event_name != 'pull_request' && steps.packages.outputs.zip_name != ''
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ steps.packages.outputs.zip_name }}
+          path: ${{ steps.packages.outputs.zip_path }}
+          retention-days: 30
+
+      - name: Upload NSIS installer
+        if: github.event_name != 'pull_request' && steps.packages.outputs.exe_name != ''
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ steps.packages.outputs.exe_name }}
+          path: ${{ steps.packages.outputs.exe_path }}
+          retention-days: 30
+
+      - name: Setup (detached) tmate session if enabled
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}


### PR DESCRIPTION
## Summary

Add packaging capabilities to the Windows MSYS2 workflow to automatically generate Windows binary distributions (ZIP archives and NSIS installers) for both Qt5 and Qt6 variants.

## Changes

- **NSIS Installation**: Install NSIS package manager for creating Windows installers
- **CPack Integration**: Run CPack after successful test suite completion to generate distributions
- **Artifact Discovery**: Automatically find and identify generated package files
- **Unique Naming**: Insert Qt version into artifact names to prevent conflicts between qt5/qt6 builds
- **Conditional Packaging**: Only create packages on pushes to master and manual dispatches (not on PRs)
- **Test Results**: Upload test result reports immediately after test execution

## Artifact Details

Packages are uploaded as GitHub Actions artifacts with 30-day retention:
- `PythonSCAD-qt5-{VERSION}-win64.zip`
- `PythonSCAD-qt6-{VERSION}-win64.zip`
- `PythonSCAD-qt5-{VERSION}-win64-Installer.exe`
- `PythonSCAD-qt6-{VERSION}-win64-Installer.exe`

## Testing

Workflow has been tested and successfully generates all four artifacts. Packaging steps are skipped on pull requests to reduce CI time.