### PR TITLE
fix: change release trigger from published to created

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -2,7 +2,7 @@ name: Build and Upload AppImage
 
 on:
   release:
-    types: [published]
+    types: [created]
   workflow_dispatch:
     inputs:
       upload_to_release:

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -2,7 +2,7 @@ name: Build and upload macOS build
 
 on:
   release:
-    types: [published]
+    types: [created]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -2,7 +2,7 @@ name: Build and upload Windows build (MXE Cross-Compile)
 
 on:
   release:
-    types: [published]
+    types: [created]
   workflow_dispatch:
     inputs:
       upload_to_release:


### PR DESCRIPTION
Release Please creates releases with the 'created' event, not 'published'. The build workflows were listening for 'published' events, so they never ran automatically when releases were created. Changed all three build workflows to trigger on 'created' events to ensure artifacts are automatically built and uploaded to new releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)