### PR TITLE
fix: use config files for release-please to enable VERSION.txt updates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,13 +17,9 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # Use simple release type for C++ projects
-          release-type: simple
-          # Package name for releases
-          package-name: pythonscad
-          # Bump minor version for features, patch for fixes
-          bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true
+          # Use config files for all release-please configuration
+          config-file: .release-please-config.json
+          manifest-file: .release-please-manifest.json
 
       - name: Checkout code
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary

This PR fixes the issue where `VERSION.txt` was not being updated during releases.

### Problem

The release-please workflow was using inline parameters (`package-name`, `bump-minor-pre-major`, `bump-patch-for-minor-pre-major`) which are **not valid inputs** for `release-please-action@v4`. This caused:

1. The action to ignore the `.release-please-config.json` file
2. Release-please to look for a lowercase `version.txt` instead of the uppercase `VERSION.txt` that exists in the repository
3. `VERSION.txt` to remain at version 0.7.0 even after release 0.8.0 was created

### Solution

Changed the workflow to use `config-file` and `manifest-file` parameters instead of inline configuration. This ensures release-please reads the `.release-please-config.json` file, which correctly specifies `VERSION.txt` as the version file.

### Evidence

From the release-please action logs (run #20606487524):
```
##[warning]Unexpected input(s) 'package-name', 'bump-minor-pre-major', 'bump-patch-for-minor-pre-major'
...
❯ Fetching version.txt from branch master
⚠ file version.txt did not exist
```

The release commit for 0.8.0 only updated `.release-please-manifest.json` and `CHANGELOG.md`, but not `VERSION.txt`.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to create the next release PR
- [ ] Verify that the release PR includes an update to `VERSION.txt`
- [ ] Merge the release PR and verify `VERSION.txt` is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)