### PR TITLE
fix: add include-component-in-tag setting to maintain tag compatibility

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "pythonscad",
+      "include-component-in-tag": false,
       "version-file": "VERSION.txt",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary

Fixes the issue where release-please is creating version 0.6.0 instead of continuing from 0.8.0.

## Root Cause

After PR #260 switched the workflow to use config files, release-please started reading `package-name: "pythonscad"` from the config and treating this as a component-based release. This caused it to look for tags with the component prefix:

- **Looking for:** `pythonscad-v0.8.0` 
- **Actually exists:** `v0.8.0`

From the release-please logs:
```
❯ looking for tagName: pythonscad-v0.8.0
⚠ Found release tag with component '', but not configured in manifest
✔ No latest release found for path: ., component: pythonscad
```

Since it couldn't find any previous releases with the component-prefixed tag format, it started fresh and tried to create a release from all historical commits.

## Solution

Added `"include-component-in-tag": false` to [.release-please-config.json](.release-please-config.json#L6) to maintain compatibility with the existing simple tag format (`v0.8.0`).

This setting tells release-please to use simple tags without the component prefix, matching all existing releases in the repository.

## Test Plan

- [ ] Merge this PR
- [x] Close the incorrect release PR #265 if not already closed
- [ ] Trigger release-please workflow (either manually or by merging a commit to master)
- [ ] Verify that release-please creates a PR for version 0.8.1 (or appropriate next version)
- [ ] Verify the PR only includes commits since v0.8.0, not historical commits
- [ ] Verify VERSION.txt is updated in the release PR

## Related Issues

- Fixes the issue reported where release-please created PR #265 with version 0.6.0
- Complements PR #260 which fixed VERSION.txt not being updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)