### PR TITLE
fix: add GPG pinentry-mode loopback for non-interactive signing

### DIFF
--- a/scripts/update-apt-repo.sh
+++ b/scripts/update-apt-repo.sh
@@ -133,7 +133,7 @@ info "Release file generated"
 # Sign Release file with GPG
 info "Signing Release file..."
 
-GPG_OPTS="--batch --yes"
+GPG_OPTS="--batch --yes --pinentry-mode loopback"
 if [ -n "$GPG_KEY" ]; then
     GPG_OPTS="$GPG_OPTS --local-user $GPG_KEY"
     info "Using GPG key: $GPG_KEY"
@@ -160,12 +160,12 @@ cd - > /dev/null
 # Export public GPG key for users
 info "Exporting public GPG key..."
 if [ -n "$GPG_KEY" ]; then
-    gpg --armor --export "$GPG_KEY" > pythonscad-archive-keyring.gpg
+    gpg --batch --pinentry-mode loopback --armor --export "$GPG_KEY" > pythonscad-archive-keyring.gpg
 else
     # Export default key
-    DEFAULT_KEY=$(gpg --list-secret-keys --keyid-format LONG | grep sec | head -n1 | awk '{print $2}' | cut -d'/' -f2)
+    DEFAULT_KEY=$(gpg --batch --list-secret-keys --keyid-format LONG | grep sec | head -n1 | awk '{print $2}' | cut -d'/' -f2)
     if [ -n "$DEFAULT_KEY" ]; then
-        gpg --armor --export "$DEFAULT_KEY" > pythonscad-archive-keyring.gpg
+        gpg --batch --pinentry-mode loopback --armor --export "$DEFAULT_KEY" > pythonscad-archive-keyring.gpg
     else
         warn "No GPG key found, skipping keyring export"
     fi

--- a/scripts/update-yum-repo.sh
+++ b/scripts/update-yum-repo.sh
@@ -176,7 +176,7 @@ for distro_dir in "${REPO_DIR}/packages"/*/*; do
         # Sign repository metadata if GPG key is provided
         if [ -n "$GPG_KEY" ] && command_exists gpg; then
             info "Signing repository metadata in $arch_dir"
-            gpg --batch --yes --detach-sign --armor \
+            gpg --batch --yes --pinentry-mode loopback --detach-sign --armor \
                 --local-user "$GPG_KEY" \
                 "$arch_dir/repodata/repomd.xml" || warn "Failed to sign repomd.xml"
         fi
@@ -186,7 +186,7 @@ done
 # Export GPG public key
 if [ -n "$GPG_KEY" ] && command_exists gpg; then
     info "Exporting GPG public key..."
-    gpg --export --armor "$GPG_KEY" > "${REPO_DIR}/RPM-GPG-KEY-pythonscad"
+    gpg --batch --pinentry-mode loopback --export --armor "$GPG_KEY" > "${REPO_DIR}/RPM-GPG-KEY-pythonscad"
 fi
 
 # Create .repo file for users


### PR DESCRIPTION
## Summary

Fixes GPG signing failures in GitHub Actions with "Inappropriate ioctl for device" error.

## Problem

The APT and YUM repository workflows were failing when trying to sign packages because GPG attempted to use a pinentry program in the non-interactive GitHub Actions environment.

Error:
```
gpg: signing failed: Inappropriate ioctl for device
[ERROR] Failed to create detached signature
```

## Solution

Added `--pinentry-mode loopback` to all GPG operations:
- APT Release file signing (detached and clearsigned)
- APT GPG key export  
- YUM repomd.xml signing
- YUM GPG key export

This tells GPG to use the loopback pinentry which works without a TTY.

## Testing

- [x] Local test with temporary GPG key - all operations succeed
- [ ] Verify in GitHub Actions workflow

## Related

- Fixes workflow failure from https://github.com/pythonscad/pythonscad/actions/runs/20753534796/job/59593138699
- Required after merging #282