### PR TITLE
fix: disable qt5 builds in Windows workflows

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        qt: [qt5, qt6]
+        qt: [qt6]
     container:
       image: openscad/mxe-x86_64-gui:latest
     name: Windows MXE 64-bit (${{ matrix.qt }})

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        qt: [ qt5, qt6 ]
+        qt: [ qt6 ]
     runs-on: windows-latest
     name: windows-latest ${{ matrix.qt }}
     defaults:


### PR DESCRIPTION
qt5 is [EOL](https://www.qt.io/blog/extended-security-maintenance-for-qt-5.15-begins-may-2025) and MSYS2 just [broke qt5-base](https://github.com/msys2/MINGW-packages/commit/389f888cf9cf6dfe8281899258d49e884e4407f6), so it's time to say goodbye to qt5 builds on MSYS2.