### PR TITLE
feat(python): make add_parameter return value and add feature toggle

### DIFF
--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -51,6 +51,10 @@ const Feature Feature::ExperimentalVectorSwizzle(
 #ifdef ENABLE_PYTHON
 const Feature Feature::ExperimentalPythonEngine(
   "python-engine", "Enable experimental Python Engine (implies risk of malicious scripts downloaded).");
+const Feature Feature::ExperimentalAddParameterPureFunction(
+  "add-parameter-pure-function",
+  "Make <code>add_parameter()</code> a pure function that only returns the value without creating a "
+  "global variable.");
 #endif
 
 Feature::Feature(const std::string& name, std::string description, bool hidden)

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -25,6 +25,7 @@ public:
   static const Feature ExperimentalVectorSwizzle;
 #ifdef ENABLE_PYTHON
   static const Feature ExperimentalPythonEngine;
+  static const Feature ExperimentalAddParameterPureFunction;
 #endif
 
 #ifdef ENABLE_GUI_TESTS

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -86,6 +86,7 @@ extern bool parse(SourceFile *& file, const std::string& text, const std::string
 #include <boost/functional/hash.hpp>
 #include <ScopeContext.h>
 #include "PlatformUtils.h"
+#include "Feature.h"
 #include <iostream>
 #include <filesystem>
 
@@ -5337,8 +5338,14 @@ PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs,
         }
       }
     }
-    PyObject *maindict = PyModule_GetDict(pythonMainModule.get());
-    PyDict_SetItemString(maindict, name, value_effective);
+    // Only set global variable if the pure function feature is not enabled
+    // (default: creates variable for backward compatibility)
+    if (!Feature::ExperimentalAddParameterPureFunction.is_enabled()) {
+      PyObject *maindict = PyModule_GetDict(pythonMainModule.get());
+      PyDict_SetItemString(maindict, name, value_effective);
+    }
+    Py_INCREF(value_effective);
+    return value_effective;
   }
   return Py_None;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -261,6 +261,8 @@ file(GLOB SCAD_DXF_FILES      ${TEST_SCAD_DIR}/dxf/*.scad
 file(GLOB SCAD_PDF_FILES      ${TEST_SCAD_DIR}/pdf/*.scad)
 file(GLOB PYTHONSCAD_FILES    ${TEST_PYTHONSCAD_DIR}/*.py)
 file(GLOB PYTHONSCAD_ECHO_FILES    ${TEST_PYTHONSCAD_ECHO_DIR}/*.py)
+# Exclude add_parameter_pure.py as it has a separate test with feature flag
+list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_pure.py")
 if(NOT MINGW)
   # GhostScript on MSYS2/MINGW can't handle the names.
   list(APPEND SCAD_PDF_FILES
@@ -1303,6 +1305,7 @@ add_cmdline_test(previewmanifoldtest EXPERIMENTAL OPENSCAD SUFFIX png FILES ${EX
 add_cmdline_test(throwntogethertest  EXPERIMENTAL OPENSCAD SUFFIX png FILES ${EXPERIMENTAL_SKIN_FILES} ARGS --preview=throwntogether --enable=skin --trust-python)
 add_cmdline_test(pythonscad          EXPERIMENTAL OPENSCAD SUFFIX png FILES ${PYTHONSCAD_FILES} ARGS --render --trust-python)
 add_cmdline_test(pythonscadecho      EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${PYTHONSCAD_ECHO_FILES} ARGS --trust-python)
+add_cmdline_test(pythonscadecho_pure EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_pure.py ARGS --enable=add-parameter-pure-function --trust-python)
 add_cmdline_test(echo EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${TEST_SCAD_DIR}/misc/vector-swizzling.scad ARGS --enable=vector-swizzle --trust-python)
 
 ############################

--- a/tests/data/pythonscad-echo/add_parameter.py
+++ b/tests/data/pythonscad-echo/add_parameter.py
@@ -1,0 +1,28 @@
+from openscad import *
+
+# Test with default behavior (feature disabled)
+# add_parameter should return the value AND create a global variable
+
+# Test boolean values
+result_true = add_parameter("bool_param_true", True)
+print(f"Return: {result_true}")  # True
+print(f"Global: {bool_param_true}")  # True
+
+result_false = add_parameter("bool_param_false", False)
+print(f"Return: {result_false}")  # False
+print(f"Global: {bool_param_false}")  # False
+
+# Test integer values
+result_int = add_parameter("int_param", 42)
+print(f"Return: {result_int}")  # 42
+print(f"Global: {int_param}")  # 42
+
+# Test float values
+result_float = add_parameter("float_param", 3.14159)
+print(f"Return: {result_float}")  # 3.14159
+print(f"Global: {float_param}")  # 3.14159
+
+# Test string values
+result_str = add_parameter("str_param", "hello")
+print(f"Return: {result_str}")  # hello
+print(f"Global: {str_param}")  # hello

--- a/tests/data/pythonscad-echo/add_parameter_pure.py
+++ b/tests/data/pythonscad-echo/add_parameter_pure.py
@@ -1,0 +1,45 @@
+from openscad import *
+
+# Test with pure function feature enabled
+# add_parameter should ONLY return the value, NOT create a global variable
+
+# Test boolean values
+result_true = add_parameter("bool_param_true", True)
+print(f"Return: {result_true}")  # True
+
+# Verify global variable was NOT created
+try:
+    print(f"Global: {bool_param_true}")
+    print("ERROR: Global variable should not exist")
+except NameError:
+    print("Global: undefined (correct)")
+
+# Test integer values
+result_int = add_parameter("int_param", 42)
+print(f"Return: {result_int}")  # 42
+
+try:
+    print(f"Global: {int_param}")
+    print("ERROR: Global variable should not exist")
+except NameError:
+    print("Global: undefined (correct)")
+
+# Test float values
+result_float = add_parameter("float_param", 3.14159)
+print(f"Return: {result_float}")  # 3.14159
+
+try:
+    print(f"Global: {float_param}")
+    print("ERROR: Global variable should not exist")
+except NameError:
+    print("Global: undefined (correct)")
+
+# Test string values
+result_str = add_parameter("str_param", "hello")
+print(f"Return: {result_str}")  # hello
+
+try:
+    print(f"Global: {str_param}")
+    print("ERROR: Global variable should not exist")
+except NameError:
+    print("Global: undefined (correct)")

--- a/tests/regression/pythonscadecho/add_parameter-expected.echo
+++ b/tests/regression/pythonscadecho/add_parameter-expected.echo
@@ -1,0 +1,10 @@
+Return: True
+Global: True
+Return: False
+Global: False
+Return: 42
+Global: 42
+Return: 3.14159
+Global: 3.14159
+Return: hello
+Global: hello

--- a/tests/regression/pythonscadecho_pure/add_parameter_pure-expected.echo
+++ b/tests/regression/pythonscadecho_pure/add_parameter_pure-expected.echo
@@ -1,0 +1,8 @@
+Return: True
+Global: undefined (correct)
+Return: 42
+Global: undefined (correct)
+Return: 3.14159
+Global: undefined (correct)
+Return: hello
+Global: undefined (correct)


### PR DESCRIPTION
## Summary
- Modified `add_parameter()` to return the parameter value instead of None
- Added feature toggle `add-parameter-pure-function` to control global variable creation
- When feature is disabled (default): returns value AND creates global variable (backward compatible)
- When feature is enabled: returns value WITHOUT creating global variable (pure function)
- Added two test cases to verify both behaviors

## Test plan
- [x] Test default behavior (feature disabled) - `pythonscadecho_add_parameter`
- [x] Test pure function behavior (feature enabled) - `pythonscadecho_pure_add_parameter_pure`
- [x] Both tests passing

This allows gradual deprecation of global variable creation while maintaining backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)