### PR TITLE
fix(ci): add GPG passphrase support for repository signing

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -194,6 +194,7 @@ jobs:
         env:
           REPO_DIR: /tmp/apt-repo
           GPG_KEY: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           KEEP_VERSIONS: ${{ vars.REPO_KEEP_VERSIONS || '3' }}
           REPO_BASE_URL: ${{ secrets.REPO_BASE_URL }}
         run: |

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -228,6 +228,7 @@ jobs:
         env:
           REPO_DIR: /tmp/yum-repo
           GPG_KEY: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           KEEP_VERSIONS: ${{ vars.REPO_KEEP_VERSIONS || '3' }}
           REPO_BASE_URL: ${{ secrets.REPO_BASE_URL }}
         run: |


### PR DESCRIPTION
## Problem

Both APT and RPM repository signing workflows were experiencing issues:

- **APT workflow**: Failing with `gpg: Sorry, we are in batchmode - can't get input` because GPG couldn't read the passphrase in non-interactive mode
- **RPM workflow**: Not failing, but **silently not signing** the repository metadata (using `|| warn` instead of proper error handling)

## Solution

This PR updates both repository signing scripts and workflows to handle GPG passphrases correctly in CI/CD environments:

### Changes

- **scripts/update-apt-repo.sh**: 
  - Add `GPG_PASSPHRASE` environment variable support
  - Always use `--passphrase-fd 0` for consistent passphrase handling
  - Works with both password-protected and passwordless GPG keys

- **scripts/update-yum-repo.sh**:
  - Add `GPG_PASSPHRASE` environment variable support
  - Change signing failures from warnings (`|| warn`) to errors (`|| die`)
  - Ensures repositories are properly signed or the workflow fails

- **Workflows**:
  - `.github/workflows/build-debian-packages.yml`: Pass `GPG_PASSPHRASE` to script
  - `.github/workflows/build-rpm-packages.yml`: Pass `GPG_PASSPHRASE` to script

### How It Works

The scripts now:
1. Always use `--passphrase-fd 0` to read passphrases from stdin
2. Pipe the passphrase (or empty string for passwordless keys) via `echo`
3. Work consistently in both interactive and non-interactive environments

### Testing

Tested locally with:
- Passwordless GPG keys (simulating CI environment) ✅
- Password-protected GPG keys with passphrase ✅

### Required Setup

After merging, add the `GPG_PASSPHRASE` secret to the repository:
1. Go to Settings → Secrets and variables → Actions
2. Add secret named `GPG_PASSPHRASE`
3. Set value to the GPG key passphrase (or empty string for passwordless keys)

Fixes the APT repository publishing workflow failures and ensures RPM repositories are properly signed.