### PR TITLE
feat(ci): Support multiple Debian/Ubuntu distributions in APT repository

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -20,19 +20,63 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare-matrix:
+    name: Prepare build matrix from supported distributions
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate and prepare matrix
+        id: set-matrix
+        run: |
+          # Validate JSON syntax
+          python3 -c "import json; json.load(open('supported-distributions.json'))"
+
+          # Extract matrix for Debian/Ubuntu only, expand to distro x arch combinations
+          python3 << 'EOF'
+          import json
+          import sys
+
+          with open('supported-distributions.json') as f:
+              config = json.load(f)
+
+          matrix_include = []
+          for dist in config['distributions']:
+              if dist['family'] not in ['debian', 'ubuntu']:
+                  continue
+
+              for arch in dist['architectures']:
+                  entry = {
+                      'distro': dist['codename'],
+                      'distro_name': dist['name'],
+                      'distro_version': dist['version'],
+                      'family': dist['family'],
+                      'arch': arch,
+                      'runner': dist['runner'] if dist['runner'] else 'ubuntu-24.04',
+                      'docker_image': dist['docker_image'],
+                      'qemu': arch == 'arm64'
+                  }
+                  matrix_include.append(entry)
+
+          matrix = {
+              'fail-fast': False,
+              'include': matrix_include
+          }
+
+          # Output as JSON for GitHub Actions
+          import sys
+          print(f"matrix={json.dumps(matrix)}", file=sys.stdout)
+          EOF
+
   build-debian:
-    name: Build .deb (${{ matrix.arch }})
+    name: Build .deb (${{ matrix.distro }} / ${{ matrix.arch }})
+    needs: prepare-matrix
     runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-24.04
-            qemu: false
-          - arch: arm64
-            runner: ubuntu-24.04
-            qemu: true
+    strategy: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+    container: ${{ matrix.docker_image || null }}
 
     steps:
       - name: Checkout code
@@ -53,13 +97,15 @@ jobs:
         with:
           detached: true
           limit-access-to-actor: true
+
       - name: Set up QEMU for ARM64
-        if: matrix.qemu
+        if: matrix.qemu && !matrix.docker_image
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
-      - name: Install build dependencies
+      - name: Install build dependencies (native runner)
+        if: '!matrix.docker_image'
         env:
           DEBIAN_FRONTEND: noninteractive
           TZ: Etc/UTC
@@ -77,32 +123,67 @@ jobs:
           # Install Build-Depends from debian/control
           sudo apt-get install -y libboost-all-dev
 
+      - name: Install build dependencies (Docker container)
+        if: matrix.docker_image
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          TZ: Etc/UTC
+        run: |
+          apt-get update
+          # Install git and Python first (needed for uni-get-dependencies)
+          apt-get install -y git python3
+          # Install base dependencies using uni-get-dependencies
+          ./scripts/uni-get-dependencies.py --yes --profile pythonscad-qt6
+          # Install Debian packaging tools
+          apt-get install -y \
+            debhelper \
+            devscripts \
+            lintian \
+            dpkg-dev \
+            fakeroot \
+            sudo
+          # Install Build-Depends from debian/control
+          apt-get install -y libboost-all-dev
+
       - name: Import GPG signing key
         if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
+          which gpg || (apt-get update && apt-get install -y gnupg)
           echo "${{ secrets.DEB_SIGNING_KEY }}" | gpg --batch --import
           gpg --list-secret-keys
 
-      - name: Build Debian package (amd64)
-        if: matrix.arch == 'amd64'
+      - name: Build Debian package
         env:
           OUTPUT_DIR: /tmp/debs
-        run: ./scripts/build-debian-package.sh
-
-      - name: Build Debian package (arm64 via QEMU)
-        if: matrix.arch == 'arm64'
-        env:
-          OUTPUT_DIR: /tmp/debs
+          DEBIAN_DISTRO: ${{ matrix.distro }}
         run: |
-          # For ARM64, we use QEMU emulation
-          # Note: This is slower but works without native ARM64 runners
-          sudo apt-get install -y qemu-user-static
-
-          # Build in QEMU environment
+          mkdir -p "$OUTPUT_DIR"
+          chmod +x ./scripts/build-debian-package.sh
           ./scripts/build-debian-package.sh
 
-      - name: Test package installation
-        if: matrix.arch == 'amd64'
+      - name: Get version for release upload
+        id: version
+        run: |
+          VERSION=$(cat VERSION.txt | tr -d '\n' | tr -d '\r')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Rename package for GitHub Release (distro + arch)
+        run: |
+          DEB_FILE=$(ls /tmp/debs/pythonscad_*.deb | head -1)
+          if [ -z "$DEB_FILE" ]; then
+            echo "Error: No .deb file found"
+            exit 1
+          fi
+
+          VERSION="${{ steps.version.outputs.version }}"
+          NEW_NAME="pythonscad_${VERSION}-1_${{ matrix.distro }}_${{ matrix.arch }}.deb"
+          mv "$DEB_FILE" "/tmp/debs/$NEW_NAME"
+          ls -lh /tmp/debs/
+
+      - name: Test package installation (amd64 only)
+        if: matrix.arch == 'amd64' && !matrix.docker_image
         run: |
           # Try to install the package to verify it works
           sudo dpkg -i /tmp/debs/pythonscad_*.deb || true
@@ -115,18 +196,19 @@ jobs:
           # Verify library dependencies
           ldd /usr/bin/pythonscad | head -20
 
-      - name: Upload package artifacts
+      - name: Upload build log as artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pythonscad-${{ matrix.arch }}-deb
-          path: /tmp/debs/*
-          retention-days: 30
+          name: build-log-${{ matrix.distro }}-${{ matrix.arch }}
+          path: /tmp/debs/*.log.txt
+          retention-days: 7
 
       - name: Upload to GitHub Release
         if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
         uses: softprops/action-gh-release@v2
         with:
-          files: /tmp/debs/*
+          files: /tmp/debs/pythonscad_*.deb
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -141,24 +223,29 @@ jobs:
       - name: Checkout main repository
         uses: actions/checkout@v4
 
-      - name: Download amd64 packages
-        uses: actions/download-artifact@v4
-        with:
-          name: pythonscad-amd64-deb
-          path: /tmp/debs/amd64
-
-      - name: Download arm64 packages
-        uses: actions/download-artifact@v4
-        with:
-          name: pythonscad-arm64-deb
-          path: /tmp/debs/arm64
-
-      - name: Merge packages
+      - name: Download packages from GitHub Release
         run: |
-          mkdir -p /tmp/debs/all
-          cp /tmp/debs/amd64/*.deb /tmp/debs/all/ || true
-          cp /tmp/debs/arm64/*.deb /tmp/debs/all/ || true
-          ls -lh /tmp/debs/all/
+          mkdir -p /tmp/debs
+          cd /tmp/debs
+
+          # Determine release tag
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ github.event.inputs.upload_to_release }}"
+          fi
+
+          echo "Downloading packages from release: $TAG"
+
+          # Use GitHub CLI to download all .deb files from release
+          gh release download "$TAG" \
+            -R "${{ github.repository }}" \
+            -p "pythonscad_*_*.deb" \
+            --dir /tmp/debs
+
+          ls -lh /tmp/debs/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG signing key
         run: |
@@ -187,7 +274,7 @@ jobs:
           # Copy existing packages to new repo location
           if [ -d /tmp/apt-repo-existing/pool ]; then
             mkdir -p /tmp/apt-repo/pool/main/p/pythonscad
-            cp /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb /tmp/apt-repo/pool/main/p/pythonscad/ || true
+            cp /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb /tmp/apt-repo/pool/main/p/pythonscad/ 2>/dev/null || true
           fi
 
       - name: Build APT repository structure
@@ -201,7 +288,7 @@ jobs:
           # Repository now contains both old and new packages
           # update-apt-repo.sh will clean up old versions based on KEEP_VERSIONS
           chmod +x ./scripts/update-apt-repo.sh
-          ./scripts/update-apt-repo.sh /tmp/debs/all
+          ./scripts/update-apt-repo.sh /tmp/debs
 
       - name: Upload to SFTP server
         run: |

--- a/scripts/update-apt-repo.sh
+++ b/scripts/update-apt-repo.sh
@@ -3,7 +3,8 @@
 # Update APT repository with new packages
 #
 # This script updates the APT repository structure with new .deb packages.
-# It generates the Packages indices and signs the Release file with GPG.
+# It organizes packages by distribution codename and generates Packages indices
+# for each distribution, then signs the Release files with GPG.
 #
 # Usage:
 #   update-apt-repo.sh <packages_dir>
@@ -12,8 +13,8 @@
 #   REPO_DIR         - Repository root directory (default: current directory)
 #   GPG_KEY          - GPG key ID for signing (uses default key if not set)
 #   GPG_PASSPHRASE   - GPG key passphrase (optional, for password-protected keys)
-#   KEEP_VERSIONS    - Number of old versions to keep per architecture (default: 3)
-#
+#   KEEP_VERSIONS    - Number of old versions to keep per architecture per distro (default: 3)
+#   REPO_BASE_URL    - Base URL for the repository (used in HTML index)
 
 set -euo pipefail
 
@@ -36,7 +37,8 @@ REPO_DIR="${REPO_DIR:-.}"
 GPG_KEY="${GPG_KEY:-}"
 GPG_PASSPHRASE="${GPG_PASSPHRASE:-}"
 KEEP_VERSIONS="${KEEP_VERSIONS:-3}"
-REPO_BASE_URL="${REPO_BASE_URL:-https://pythonscad-repos.nomike.org}"
+REPO_BASE_URL="${REPO_BASE_URL:-https://repo.pythonscad.org}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 info "APT Repository Updater"
 info "======================"
@@ -44,6 +46,11 @@ info "======================"
 # Validate packages directory
 if [ ! -d "$PACKAGES_DIR" ]; then
     die "Packages directory not found: $PACKAGES_DIR"
+fi
+
+# Check for supported-distributions.json
+if [ ! -f "$SCRIPT_DIR/supported-distributions.json" ]; then
+    die "supported-distributions.json not found in $SCRIPT_DIR"
 fi
 
 # Check for required tools
@@ -64,131 +71,185 @@ cd "$REPO_DIR"
 info "Repository directory: $(pwd)"
 info "Packages directory: $PACKAGES_DIR"
 
+# Extract distribution codenames from supported-distributions.json
+CODENAMES=$(python3 << 'PYSCRIPT'
+import json
+with open("$SCRIPT_DIR/supported-distributions.json") as f:
+    config = json.load(f)
+codenames = set()
+for dist in config["distributions"]:
+    if dist["family"] in ["debian", "ubuntu"]:
+        codenames.add(dist["codename"])
+for codename in sorted(codenames):
+    print(codename)
+PYSCRIPT
+)
+
 # Create repository structure
 info "Creating repository structure..."
+
+# Create pool directory
 mkdir -p pool/main/p/pythonscad
-mkdir -p dists/stable/main/binary-amd64
-mkdir -p dists/stable/main/binary-arm64
 
-# Copy new packages to pool
-info "Copying packages to pool..."
-find "$PACKAGES_DIR" -name "*.deb" -exec cp -v {} pool/main/p/pythonscad/ \;
+# Copy new packages to pool (they have distro in the filename)
+info "Organizing packages into repository..."
+PACKAGE_COUNT=0
 
-# Count packages
-PACKAGE_COUNT=$(find pool/main/p/pythonscad -name "*.deb" | wc -l)
-info "Total packages in pool: $PACKAGE_COUNT"
+for deb in "$PACKAGES_DIR"/*.deb; do
+    if [ ! -f "$deb" ]; then
+        continue
+    fi
 
-# Clean up old versions (keep last N versions per architecture)
-if [ "$KEEP_VERSIONS" -gt 0 ]; then
-    info "Cleaning up old versions (keeping last ${KEEP_VERSIONS} per architecture)..."
+    BASENAME=$(basename "$deb")
 
-    for arch in amd64 arm64; do
-        OLD_PACKAGES=$(ls -t pool/main/p/pythonscad/pythonscad_*_${arch}.deb 2>/dev/null | tail -n +$((KEEP_VERSIONS + 1)) || true)
-        if [ -n "$OLD_PACKAGES" ]; then
-            echo "$OLD_PACKAGES" | while read -r pkg; do
-                info "  Removing old package: $(basename "$pkg")"
-                rm -f "$pkg"
-            done
-        fi
-    done
-fi
-
-# Generate Packages files for each architecture
-info "Generating Packages indices..."
-
-for arch in amd64 arm64; do
-    BINARY_DIR="dists/stable/main/binary-${arch}"
-
-    if find pool/main/p/pythonscad -name "*_${arch}.deb" | grep -q .; then
-        info "  Generating Packages file for ${arch}..."
-        cd "$BINARY_DIR"
-        dpkg-scanpackages --arch "$arch" ../../../../pool/main/p/pythonscad /dev/null > Packages
-        gzip -k -f Packages
-        info "    $(wc -l < Packages) package entries for ${arch}"
-        cd - > /dev/null
+    # Extract distro from filename: pythonscad_VERSION-1_DISTRO_ARCH.deb
+    # Using sed to extract DISTRO from the filename
+    if [[ $BASENAME =~ pythonscad_[^_]+_([^_]+)_[^_]+\.deb ]]; then
+        DISTRO="${BASH_REMATCH[1]}"
     else
-        warn "  No packages found for ${arch}, skipping"
+        warn "Could not parse distro from filename: $BASENAME (skipping)"
+        continue
+    fi
+
+    # Verify distro is in our supported list
+    if ! echo "$CODENAMES" | grep -q "^${DISTRO}$"; then
+        warn "Distribution '$DISTRO' not in supported-distributions.json (skipping: $BASENAME)"
+        continue
+    fi
+
+    cp "$deb" "pool/main/p/pythonscad/$BASENAME"
+    ((PACKAGE_COUNT++))
+done
+
+info "Total packages copied: $PACKAGE_COUNT"
+
+# Create distribution directories and clean up old versions
+info "Setting up distribution-specific directories..."
+
+for DISTRO in $CODENAMES; do
+    info "  Processing distribution: $DISTRO"
+
+    mkdir -p "dists/$DISTRO/main/binary-amd64"
+    mkdir -p "dists/$DISTRO/main/binary-arm64"
+
+    # Clean up old versions (keep last N versions per architecture)
+    if [ "$KEEP_VERSIONS" -gt 0 ]; then
+        for arch in amd64 arm64; do
+            # Find all packages for this distro and arch, sort by name, keep newest
+            OLD_PACKAGES=$(ls -t pool/main/p/pythonscad/*_${DISTRO}_${arch}.deb 2>/dev/null | tail -n +$((KEEP_VERSIONS + 1)) || true)
+            if [ -n "$OLD_PACKAGES" ]; then
+                while IFS= read -r pkg; do
+                    info "    Removing old: $(basename "$pkg")"
+                    rm -f "$pkg"
+                done <<< "$OLD_PACKAGES"
+            fi
+        done
     fi
 done
 
-# Generate Release file
-info "Generating Release file..."
+# Generate Packages files for each distribution and architecture
+info "Generating Packages indices..."
 
-cd dists/stable
+for DISTRO in $CODENAMES; do
+    for arch in amd64 arm64; do
+        BINARY_DIR="dists/$DISTRO/main/binary-${arch}"
 
-cat > Release <<EOF
+        # Check if there are packages for this distro/arch combination
+        if ls pool/main/p/pythonscad/*_${DISTRO}_${arch}.deb >/dev/null 2>&1; then
+            info "  Generating Packages file for ${DISTRO}/${arch}..."
+
+            cd "$BINARY_DIR"
+            dpkg-scanpackages --arch "$arch" ../../../../pool/main/p/pythonscad /dev/null > Packages
+            gzip -k -f Packages
+
+            # Calculate checksums for Release file
+            md5sum Packages >> ../../../../.checksums_temp || true
+            sha256sum Packages >> ../../../../.checksums_temp || true
+
+            info "    $(wc -l < Packages) package entries for ${DISTRO}/${arch}"
+            cd - > /dev/null
+        else
+            info "  No packages found for ${DISTRO}/${arch}"
+        fi
+    done
+
+    # Generate Release file for this distribution
+    info "  Generating Release file for ${DISTRO}..."
+
+    cd "dists/$DISTRO"
+
+    cat > Release <<EOF
 Origin: PythonSCAD
 Label: PythonSCAD
-Suite: stable
-Codename: stable
+Suite: $DISTRO
+Codename: $DISTRO
 Architectures: amd64 arm64
 Components: main
-Description: PythonSCAD Official Repository
+Description: PythonSCAD Official Repository - $DISTRO
 Date: $(date -Ru)
 EOF
 
-# Add file checksums to Release
-apt-ftparchive release . >> Release
+    # Add file checksums to Release
+    apt-ftparchive release . >> Release
 
-info "Release file generated"
+    info "  Release file generated for $DISTRO"
 
-# Sign Release file with GPG
-info "Signing Release file..."
+    # Sign Release file with GPG
+    info "  Signing Release file for ${DISTRO}..."
 
-GPG_OPTS="--batch --yes --pinentry-mode loopback"
+    GPG_OPTS="--batch --yes --pinentry-mode loopback"
+    GPG_OPTS="$GPG_OPTS --passphrase-fd 0"
 
-# Add passphrase option - always use passphrase-fd for consistency
-# If GPG_PASSPHRASE is not set, we'll use an empty string which works for keys without passphrase
-GPG_OPTS="$GPG_OPTS --passphrase-fd 0"
-
-if [ -n "$GPG_KEY" ]; then
-    GPG_OPTS="$GPG_OPTS --local-user $GPG_KEY"
-    info "Using GPG key: $GPG_KEY"
-else
-    info "Using default GPG key"
-fi
-
-# Use passphrase from environment or empty string
-PASSPHRASE="${GPG_PASSPHRASE:-}"
-
-# Create detached signature
-if echo "$PASSPHRASE" | gpg $GPG_OPTS -abs -o Release.gpg Release; then
-    info "Created Release.gpg (detached signature)"
-else
-    die "Failed to create detached signature"
-fi
-
-# Create clearsigned file
-if echo "$PASSPHRASE" | gpg $GPG_OPTS --clearsign -o InRelease Release; then
-    info "Created InRelease (clearsigned)"
-else
-    die "Failed to create clearsigned InRelease"
-fi
-
-cd - > /dev/null
-
-# Export public GPG key for users
-info "Exporting public GPG key..."
-if [ -n "$GPG_KEY" ]; then
-    gpg --batch --pinentry-mode loopback --armor --export "$GPG_KEY" > pythonscad-archive-keyring.gpg
-else
-    # Export default key
-    DEFAULT_KEY=$(gpg --batch --list-secret-keys --keyid-format LONG | grep sec | head -n1 | awk '{print $2}' | cut -d'/' -f2)
-    if [ -n "$DEFAULT_KEY" ]; then
-        gpg --batch --pinentry-mode loopback --armor --export "$DEFAULT_KEY" > pythonscad-archive-keyring.gpg
+    if [ -n "$GPG_KEY" ]; then
+        GPG_OPTS="$GPG_OPTS --local-user $GPG_KEY"
+        info "    Using GPG key: $GPG_KEY"
     else
-        warn "No GPG key found, skipping keyring export"
+        info "    Using default GPG key"
+    fi
+
+    PASSPHRASE="${GPG_PASSPHRASE:-}"
+
+    # Create detached signature
+    if echo "$PASSPHRASE" | gpg $GPG_OPTS -abs -o Release.gpg Release; then
+        info "    Created Release.gpg"
+    else
+        die "Failed to create detached signature for $DISTRO"
+    fi
+
+    # Create clearsigned file
+    if echo "$PASSPHRASE" | gpg $GPG_OPTS --clearsign -o InRelease Release; then
+        info "    Created InRelease"
+    else
+        die "Failed to create clearsigned InRelease for $DISTRO"
+    fi
+
+    cd - > /dev/null
+done
+
+# Export public GPG key for users (once, at repo root)
+if [ ! -f pythonscad-archive-keyring.gpg ]; then
+    info "Exporting public GPG key..."
+
+    if [ -n "$GPG_KEY" ]; then
+        gpg --batch --pinentry-mode loopback --armor --export "$GPG_KEY" > pythonscad-archive-keyring.gpg
+    else
+        DEFAULT_KEY=$(gpg --batch --list-secret-keys --keyid-format LONG 2>/dev/null | grep sec | head -n1 | awk '{print $2}' | cut -d'/' -f2 || true)
+        if [ -n "$DEFAULT_KEY" ]; then
+            gpg --batch --pinentry-mode loopback --armor --export "$DEFAULT_KEY" > pythonscad-archive-keyring.gpg
+        else
+            warn "No GPG key found, skipping keyring export"
+        fi
     fi
 fi
 
 if [ -f pythonscad-archive-keyring.gpg ]; then
-    info "Public key exported to pythonscad-archive-keyring.gpg"
+    info "Public key available at: pythonscad-archive-keyring.gpg"
 fi
 
-# Create index.html
+# Create index.html with distribution-specific instructions
 info "Creating repository index..."
 
-cat > index.html <<EOF
+cat > index.html <<'HTMLEOF'
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -198,7 +259,7 @@ cat > index.html <<EOF
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            max-width: 800px;
+            max-width: 900px;
             margin: 40px auto;
             padding: 0 20px;
             line-height: 1.6;
@@ -217,6 +278,7 @@ cat > index.html <<EOF
             padding: 15px;
             border-radius: 5px;
             overflow-x: auto;
+            border-left: 4px solid #3498db;
         }
         .warning {
             background: #fff3cd;
@@ -224,60 +286,160 @@ cat > index.html <<EOF
             padding: 12px;
             margin: 20px 0;
         }
+        .distro-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 15px;
+            margin: 20px 0;
+        }
+        .distro-card {
+            border: 1px solid #ddd;
+            padding: 15px;
+            border-radius: 5px;
+            background: #fafafa;
+        }
+        .distro-card h3 {
+            margin-top: 0;
+            color: #2c3e50;
+        }
     </style>
 </head>
 <body>
-    <h1>PythonSCAD APT Repository</h1>
+    <h1>🎉 PythonSCAD APT Repository</h1>
 
     <p>This repository provides Debian packages for PythonSCAD on Debian and Ubuntu-based distributions.</p>
 
-    <h2>Installation</h2>
+    <h2>Quick Setup (Automatic Distro Detection)</h2>
 
-    <h3>Debian/Ubuntu</h3>
-    <pre># Download and install GPG key
-wget -qO - ${REPO_BASE_URL}/apt/pythonscad-archive-keyring.gpg | \\
+    <p>Copy and paste this command to automatically detect your distribution and add the repository:</p>
+
+    <pre><code>wget -qO - REPO_BASE_URL/apt/pythonscad-archive-keyring.gpg | \
   sudo gpg --dearmor -o /usr/share/keyrings/pythonscad-archive-keyring.gpg
 
-# Add repository
-echo "deb [signed-by=/usr/share/keyrings/pythonscad-archive-keyring.gpg] ${REPO_BASE_URL}/apt stable main" | \\
+echo "deb [signed-by=/usr/share/keyrings/pythonscad-archive-keyring.gpg] REPO_BASE_URL/apt $(lsb_release -sc) main" | \
   sudo tee /etc/apt/sources.list.d/pythonscad.list
 
-# Install
 sudo apt update
-sudo apt install pythonscad</pre>
+sudo apt install pythonscad</code></pre>
+
+    <p><strong>Note:</strong> The command above uses <code>$(lsb_release -sc)</code> to automatically detect your distribution codename. If <code>lsb_release</code> is not available, you can manually replace <code>$(lsb_release -sc)</code> with your distribution codename (see list below).</p>
+
+    <h2>Supported Distributions</h2>
+
+    <p>This repository provides packages for the following distributions:</p>
+
+    <div class="distro-list">
+        <div class="distro-card">
+            <h3>Ubuntu 22.04 LTS</h3>
+            <p><strong>Codename:</strong> <code>jammy</code></p>
+            <p>Long-term support until April 2027</p>
+        </div>
+        <div class="distro-card">
+            <h3>Ubuntu 24.04 LTS</h3>
+            <p><strong>Codename:</strong> <code>noble</code></p>
+            <p>Long-term support until April 2029</p>
+        </div>
+        <div class="distro-card">
+            <h3>Ubuntu 24.10</h3>
+            <p><strong>Codename:</strong> <code>oracular</code></p>
+            <p>Support until July 2025</p>
+        </div>
+        <div class="distro-card">
+            <h3>Ubuntu 25.10</h3>
+            <p><strong>Codename:</strong> <code>questing</code></p>
+            <p>Support until July 2026</p>
+        </div>
+        <div class="distro-card">
+            <h3>Debian 11 (Bullseye)</h3>
+            <p><strong>Codename:</strong> <code>bullseye</code></p>
+            <p>Long-term support until August 2026</p>
+        </div>
+        <div class="distro-card">
+            <h3>Debian 12 (Bookworm)</h3>
+            <p><strong>Codename:</strong> <code>bookworm</code></p>
+            <p>Long-term support until June 2028</p>
+        </div>
+        <div class="distro-card">
+            <h3>Debian 13 (Trixie)</h3>
+            <p><strong>Codename:</strong> <code>trixie</code></p>
+            <p>Testing distribution, support until June 2025</p>
+        </div>
+    </div>
+
+    <h2>Check Your Distribution</h2>
+
+    <p>To find your distribution codename, run:</p>
+    <pre><code>lsb_release -sc</code></pre>
 
     <h2>Supported Architectures</h2>
     <ul>
-        <li>amd64 (x86_64)</li>
-        <li>arm64 (aarch64)</li>
+        <li><strong>amd64</strong> - Intel/AMD 64-bit processors</li>
+        <li><strong>arm64</strong> - ARM 64-bit processors (including Apple Silicon, Raspberry Pi 4/5, etc.)</li>
     </ul>
 
-    <h2>Manual Download</h2>
-    <p>You can also download packages directly:</p>
+    <h2>Manual Package Download</h2>
+
+    <p>Alternatively, you can download packages directly:</p>
     <ul>
         <li><a href="pool/main/p/pythonscad/">All packages</a></li>
-        <li><a href="dists/stable/">Repository metadata</a></li>
+        <li><a href="dists/">Repository metadata by distribution</a></li>
     </ul>
 
-    <h2>GPG Key</h2>
-    <p>Packages are signed with the PythonSCAD GPG key:</p>
-    <pre>wget -qO - ${REPO_BASE_URL}/apt/pythonscad-archive-keyring.gpg | \\
-  sudo gpg --dearmor -o /usr/share/keyrings/pythonscad-archive-keyring.gpg</pre>
+    <h2>GPG Key Information</h2>
+
+    <p>Packages are signed with the PythonSCAD GPG key for security. The key is automatically imported in the setup command above.</p>
+
+    <p>To manually import the key:</p>
+    <pre><code>wget -qO - REPO_BASE_URL/apt/pythonscad-archive-keyring.gpg | \
+  sudo gpg --dearmor -o /usr/share/keyrings/pythonscad-archive-keyring.gpg</code></pre>
+
+    <h2>Troubleshooting</h2>
+
+    <h3>Command not found: lsb_release</h3>
+    <p>If <code>lsb_release</code> is not available, you can:</p>
+    <ol>
+        <li>Install it: <code>sudo apt install lsb-release</code></li>
+        <li>Or manually replace <code>$(lsb_release -sc)</code> with your codename from the list above</li>
+        <li>Or check <code>/etc/os-release</code>: <code>grep VERSION_CODENAME /etc/os-release</code></li>
+    </ol>
+
+    <h3>Package dependencies not satisfied</h3>
+    <p>If you see dependency errors, ensure you have the latest package list:</p>
+    <pre><code>sudo apt update
+sudo apt install -f</code></pre>
 
     <h2>More Information</h2>
-    <p>Visit <a href="https://github.com/pythonscad/pythonscad">github.com/pythonscad/pythonscad</a> for documentation and source code.</p>
+    <ul>
+        <li><a href="https://github.com/pythonscad/pythonscad">PythonSCAD on GitHub</a></li>
+        <li><a href="https://pythonscad.org">PythonSCAD Website</a></li>
+    </ul>
 </body>
 </html>
-EOF
+HTMLEOF
+
+# Replace placeholder with actual URL
+sed -i "s|REPO_BASE_URL|$REPO_BASE_URL|g" index.html
 
 # Summary
 info ""
 info "Repository update complete!"
 info ""
 info "Repository structure:"
-tree -L 3 -I '*.deb' dists/ 2>/dev/null || find dists/ -type f | head -20
+find dists/ -type f | head -20
 info ""
-info "To use this repository, users should:"
-info "  1. wget -qO - https://YOUR_DOMAIN/pythonscad-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/pythonscad-archive-keyring.gpg"
-info "  2. echo 'deb [signed-by=/usr/share/keyrings/pythonscad-archive-keyring.gpg] https://YOUR_DOMAIN stable main' | sudo tee /etc/apt/sources.list.d/pythonscad.list"
-info "  3. sudo apt update && sudo apt install pythonscad"
+info "Package statistics:"
+for DISTRO in $CODENAMES; do
+    for arch in amd64 arm64; do
+        COUNT=$(ls pool/main/p/pythonscad/*_${DISTRO}_${arch}.deb 2>/dev/null | wc -l)
+        if [ "$COUNT" -gt 0 ]; then
+            info "  $DISTRO/$arch: $COUNT packages"
+        fi
+    done
+done
+info ""
+info "To use this repository, users should run:"
+info "  wget -qO - $REPO_BASE_URL/apt/pythonscad-archive-keyring.gpg | \\"
+info "    sudo gpg --dearmor -o /usr/share/keyrings/pythonscad-archive-keyring.gpg"
+info "  echo 'deb [signed-by=/usr/share/keyrings/pythonscad-archive-keyring.gpg] $REPO_BASE_URL/apt \$(lsb_release -sc) main' | \\"
+info "    sudo tee /etc/apt/sources.list.d/pythonscad.list"
+info "  sudo apt update && sudo apt install pythonscad"

--- a/supported-distributions.json
+++ b/supported-distributions.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment":
+    "Supported Linux distributions for PythonSCAD package builds. Used for both Debian/Ubuntu (deb) and Fedora/CentOS (rpm) builds.",
+  "version": "1.0",
+  "description": "Configuration for PythonSCAD distribution targets",
+  "distributions": [
+    {
+      "family": "ubuntu",
+      "name": "Ubuntu",
+      "version": "22.04",
+      "codename": "jammy",
+      "lts": true,
+      "eol_date": "2027-04",
+      "runner": "ubuntu-22.04",
+      "docker_image": null,
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "family": "ubuntu",
+      "name": "Ubuntu",
+      "version": "24.04",
+      "codename": "noble",
+      "lts": true,
+      "eol_date": "2029-04",
+      "runner": "ubuntu-24.04",
+      "docker_image": null,
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "family": "ubuntu",
+      "name": "Ubuntu",
+      "version": "24.10",
+      "codename": "oracular",
+      "lts": false,
+      "eol_date": "2025-07",
+      "runner": "ubuntu-24.04",
+      "docker_image": "ubuntu:oracular",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "family": "ubuntu",
+      "name": "Ubuntu",
+      "version": "25.10",
+      "codename": "questing",
+      "lts": false,
+      "eol_date": "2026-07",
+      "runner": "ubuntu-24.04",
+      "docker_image": "ubuntu:questing",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "family": "debian",
+      "name": "Debian",
+      "version": "11",
+      "codename": "bullseye",
+      "lts": true,
+      "eol_date": "2026-08",
+      "runner": null,
+      "docker_image": "debian:bullseye",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "family": "debian",
+      "name": "Debian",
+      "version": "12",
+      "codename": "bookworm",
+      "lts": true,
+      "eol_date": "2028-06",
+      "runner": null,
+      "docker_image": "debian:bookworm",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "family": "debian",
+      "name": "Debian",
+      "version": "13",
+      "codename": "trixie",
+      "lts": false,
+      "eol_date": "2025-06",
+      "runner": null,
+      "docker_image": "debian:trixie",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    }
+  ],
+  "notes": {
+    "eol_dates":
+      "Approximate end-of-life dates. Non-LTS versions should be removed from this file after EOL.",
+    "native_runners":
+      "Use native GitHub runner if available (runner field is not null). Otherwise use Docker image.",
+    "docker_images":
+      "Docker base images for distributions without native runners. Requires installation of build tools.",
+    "future_extension":
+      "This schema can be extended for RPM-based distributions by adding family: 'fedora', 'centos', etc. with package_manager: 'dnf'/'yum' fields."
+  }
+}


### PR DESCRIPTION
This PR implements multi-distribution support for the PythonSCAD APT repository.

## Changes

- **supported-distributions.json** (NEW): Centralized configuration for all 7 target distributions (Ubuntu 22.04 LTS, 24.04 LTS, 24.10, 25.10 and Debian 11, 12, 13). Includes metadata like EOL dates and runner info. Designed to support future RPM builds.

- **.github/workflows/build-debian-packages.yml**: 
  - Adds `prepare-matrix` job that reads supported-distributions.json and generates dynamic build matrix
  - Builds all 14 combinations (7 distributions × 2 architectures) in parallel
  - Uses native runners (ubuntu-22.04, ubuntu-24.04) where available, Docker containers otherwise
  - Uploads .deb files directly to GitHub Release with distro-suffixed names
  - Only uploads build logs as artifacts (7-day retention) to avoid storage quota issues

- **scripts/build-debian-package.sh**: Added Docker environment detection and fakeroot support

- **scripts/update-apt-repo.sh** (REWRITTEN):
  - Organizes packages by distribution codename (`dists/<codename>/...`)
  - Generates per-distribution Release files with separate GPG signatures
  - Validates packages against supported-distributions.json
  - Creates auto-detecting index.html with setup command using $(lsb_release -sc)

## Benefits

- ✅ Single source of truth in JSON file (both workflows use it)
- ✅ 14 parallel builds for all distro/arch combinations
- ✅ No artifact storage issues (.deb files in GitHub Releases)
- ✅ Auto-detecting setup command works on any distro
- ✅ Users get one command: `apt install pythonscad` after setup
- ✅ Per-distribution Release files and GPG signatures
- ✅ Future-proof JSON structure for RPM builds

## Installation (User Experience)

After this is deployed, users can simply run:

```bash
wget -qO - https://repo.pythonscad.org/apt/pythonscad-archive-keyring.gpg | \
  sudo gpg --dearmor -o /usr/share/keyrings/pythonscad-archive-keyring.gpg

echo "deb [signed-by=/usr/share/keyrings/pythonscad-archive-keyring.gpg] https://repo.pythonscad.org/apt $(lsb_release -sc) main" | \
  sudo tee /etc/apt/sources.list.d/pythonscad.list

sudo apt update
sudo apt install pythonscad
```

The $(lsb_release -sc) automatically detects their distribution and fetches the correct packages.