### PR TITLE
fix(ci): write matrix output to GITHUB_OUTPUT file

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -38,7 +38,7 @@ jobs:
           # Extract matrix for Debian/Ubuntu only, expand to distro x arch combinations
           python3 << 'EOF'
           import json
-          import sys
+          import os
 
           with open('supported-distributions.json') as f:
               config = json.load(f)
@@ -66,9 +66,9 @@ jobs:
               'include': matrix_include
           }
 
-          # Output as JSON for GitHub Actions
-          import sys
-          print(f"matrix={json.dumps(matrix)}", file=sys.stdout)
+          # Output as JSON for GitHub Actions by writing to $GITHUB_OUTPUT
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
+              output_file.write(f"matrix={json.dumps(matrix)}\n")
           EOF
 
   build-debian:


### PR DESCRIPTION
Fixes the issue where the prepare-matrix job output wasn't being captured.

## Problem
The `prepare-matrix` job was printing output to stdout instead of writing to the `` file, causing the `build-debian` job to receive empty input for `fromJson()`.

## Solution
Updated the Python script to write the matrix JSON to the `` file using the correct GitHub Actions output mechanism.

## Error Fixed
```
Error when evaluating 'strategy' for job 'build-debian'. 
Error from function 'fromJson': empty input
```

This fix is required for #297 (multi-distro APT support) to work correctly.