### PR TITLE
fix(scripts): allow bash variable expansion in update-apt-repo.sh

### DIFF
--- a/scripts/update-apt-repo.sh
+++ b/scripts/update-apt-repo.sh
@@ -72,7 +72,7 @@ info "Repository directory: $(pwd)"
 info "Packages directory: $PACKAGES_DIR"
 
 # Extract distribution codenames from supported-distributions.json
-CODENAMES=$(python3 << 'PYSCRIPT'
+CODENAMES=$(python3 << PYSCRIPT
 import json
 with open("$SCRIPT_DIR/supported-distributions.json") as f:
     config = json.load(f)


### PR DESCRIPTION
## Summary
Fixes the APT repository assembly step that was failing with `FileNotFoundError` when trying to read `supported-distributions.json`.

## Problem
The heredoc in `update-apt-repo.sh` used single quotes (`<< 'PYSCRIPT'`) which prevented bash variable expansion. This caused `$SCRIPT_DIR` to be treated as a literal string instead of being replaced with the actual directory path.

## Solution
Removed the quotes from the heredoc delimiter (`<< PYSCRIPT` instead of `<< 'PYSCRIPT'`), allowing bash to expand `$SCRIPT_DIR` to the correct path before Python executes.

## Changes
- `scripts/update-apt-repo.sh`: Modified line 75 to allow variable expansion in heredoc

## Testing
The fix allows the APT repository assembly step to successfully locate and read the `supported-distributions.json` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)