### PR TITLE
fix(ci): update libbrotlidec references to use bundled libbrotlicommon

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -113,6 +113,14 @@ jobs:
               # Fix install_name to use @executable_path
               install_name_tool -id "@executable_path/../Frameworks/libbrotlicommon.1.dylib" \
                 "$APP_BUNDLE/Contents/Frameworks/libbrotlicommon.1.dylib"
+
+              # Fix references in libbrotlidec to use the bundled version
+              if [ -f "$APP_BUNDLE/Contents/Frameworks/libbrotlidec.1.dylib" ]; then
+                echo "Updating libbrotlidec references to use bundled libbrotlicommon"
+                install_name_tool -change "/usr/local/opt/brotli/lib/libbrotlicommon.1.dylib" \
+                  "@executable_path/../Frameworks/libbrotlicommon.1.dylib" \
+                  "$APP_BUNDLE/Contents/Frameworks/libbrotlidec.1.dylib"
+              fi
             fi
           fi
 
@@ -232,6 +240,14 @@ jobs:
               # Fix install_name to use @executable_path
               install_name_tool -id "@executable_path/../Frameworks/libbrotlicommon.1.dylib" \
                 "$APP_BUNDLE/Contents/Frameworks/libbrotlicommon.1.dylib"
+
+              # Fix references in libbrotlidec to use the bundled version
+              if [ -f "$APP_BUNDLE/Contents/Frameworks/libbrotlidec.1.dylib" ]; then
+                echo "Updating libbrotlidec references to use bundled libbrotlicommon"
+                install_name_tool -change "/opt/homebrew/opt/brotli/lib/libbrotlicommon.1.dylib" \
+                  "@executable_path/../Frameworks/libbrotlicommon.1.dylib" \
+                  "$APP_BUNDLE/Contents/Frameworks/libbrotlidec.1.dylib"
+              fi
             fi
           fi
 
@@ -581,6 +597,18 @@ jobs:
               echo "Fixing libbrotlicommon.1.dylib install_name ID"
               install_name_tool -id "@executable_path/../Frameworks/libbrotlicommon.1.dylib" "$FRAMEWORKS_DIR/libbrotlicommon.1.dylib"
             fi
+          fi
+
+          # Fix references in libbrotlidec to use the bundled libbrotlicommon
+          if [ -f "$FRAMEWORKS_DIR/libbrotlidec.1.dylib" ]; then
+            echo "Updating libbrotlidec references to use bundled libbrotlicommon"
+            # Try to change both possible paths (x86_64 and arm64)
+            install_name_tool -change "/usr/local/opt/brotli/lib/libbrotlicommon.1.dylib" \
+              "@executable_path/../Frameworks/libbrotlicommon.1.dylib" \
+              "$FRAMEWORKS_DIR/libbrotlidec.1.dylib" 2>/dev/null || true
+            install_name_tool -change "/opt/homebrew/opt/brotli/lib/libbrotlicommon.1.dylib" \
+              "@executable_path/../Frameworks/libbrotlicommon.1.dylib" \
+              "$FRAMEWORKS_DIR/libbrotlidec.1.dylib" 2>/dev/null || true
           fi
 
           echo "app_bundle=$MERGED_DIR/$APP_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Fixes the macOS release build failure at the sanity check step.

## Problem
The macOS build was failing with:
```
Not found: /usr/local/opt/brotli/lib/libbrotlicommon.1.dylib
Error: External dependency /opt/homebrew/opt/brotli/lib/libbrotlicommon.1.dylib
```

While the workflow was copying `libbrotlicommon.1.dylib` into the app bundle and fixing its install name ID, it wasn't updating the dependency references **from** `libbrotlidec.1.dylib` **to** `libbrotlicommon.1.dylib`. This caused `libbrotlidec` to still look for the library at external Homebrew paths instead of using the bundled version.

## Solution
Uses `install_name_tool -change` to update the references in `libbrotlidec.1.dylib` after bundling `libbrotlicommon.1.dylib` in three places:
- x86_64 build step (uses `/usr/local/opt/brotli/lib/` path)
- arm64 build step (uses `/opt/homebrew/opt/brotli/lib/` path)
- Universal binary merge step (updates both possible paths)

## Testing
The fix ensures that the sanity check script (`scripts/macosx-sanity-check.py`) will pass by confirming all library dependencies use bundled paths with `@executable_path`.

Fixes https://github.com/pythonscad/pythonscad/actions/runs/20886814237/job/60014752066

🤖 Generated with [Claude Code](https://claude.com/claude-code)