### PR TITLE
fix(ci): use distribution-specific pools in APT repository

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -304,10 +304,27 @@ jobs:
             ${{ secrets.REPO_SFTP_USER }}@${{ secrets.REPO_SFTP_HOST }}:${{ secrets.REPO_SFTP_BASE_PATH }}/apt/ \
             /tmp/apt-repo-existing/ || echo "No existing repository found (first run)"
 
-          # Copy existing packages to new repo location
+          # Copy existing packages to new repo location (distribution-specific pools)
           if [ -d /tmp/apt-repo-existing/pool ]; then
-            mkdir -p /tmp/apt-repo/pool/main/p/pythonscad
-            cp /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb /tmp/apt-repo/pool/main/p/pythonscad/ 2>/dev/null || true
+            # Check if existing repo uses old structure (pool/main) or new structure (pool/DISTRO)
+            if [ -d /tmp/apt-repo-existing/pool/main ]; then
+              # Old structure - migrate to new structure
+              echo "Migrating from old pool structure to distribution-specific pools..."
+              for deb in /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb 2>/dev/null; do
+                [ -f "$deb" ] || continue
+                BASENAME=$(basename "$deb")
+                # Extract distro from filename
+                if [[ $BASENAME =~ pythonscad_[^_]+_[^_]+_([^_]+)_[^_]+\.deb ]]; then
+                  DISTRO="${BASH_REMATCH[1]}"
+                  mkdir -p "/tmp/apt-repo/pool/$DISTRO/main/p/pythonscad"
+                  cp "$deb" "/tmp/apt-repo/pool/$DISTRO/main/p/pythonscad/"
+                fi
+              done
+            else
+              # New structure - just copy
+              echo "Copying existing distribution-specific pools..."
+              cp -r /tmp/apt-repo-existing/pool/* /tmp/apt-repo/pool/ 2>/dev/null || true
+            fi
           fi
 
       - name: Build APT repository structure


### PR DESCRIPTION
## Summary

Fixes APT repository dependency issues by organizing packages into distribution-specific pools instead of using a single shared pool.

## Problem

The APT repository was using a single shared pool (`pool/main/p/pythonscad/`) for all distributions. When generating the Packages index for each distribution, `dpkg-scanpackages` would scan this entire shared pool, including packages from ALL distributions in each distribution's Packages file.

This caused apt to potentially select packages built for the wrong distribution (e.g., Ubuntu 22.04 packages when installing on Ubuntu 25.10), resulting in unsatisfied dependency errors:

```
Depends: libboost-program-options1.74.0 (>= 1.74.0) but it is not installable
Depends: libboost-regex1.74.0-icu67 but it is not installable  
Depends: libglew2.1 (>= 1.12.0) but it is not installable
Depends: libpython3.9 (>= 3.9.1) but it is not installable
```

## Solution

This PR implements **Option 2: Separate Pools Per Distribution** from the analysis:

- **Modified `update-apt-repo.sh`**: Packages are now organized into distribution-specific pools:
  - `pool/jammy/main/p/pythonscad/`
  - `pool/noble/main/p/pythonscad/`
  - `pool/questing/main/p/pythonscad/`
  - etc.

- **Updated `dpkg-scanpackages` calls**: Now scans only the specific distribution's pool when generating Packages indices

- **Added migration logic**: The workflow now automatically migrates existing shared pool to distribution-specific structure

- **Updated HTML index**: Repository landing page now links to distribution-specific pools

## Testing

After this fix:
- Users on Ubuntu 25.10 will only see packages built for Ubuntu 25.10
- Users on Ubuntu 22.04 will only see packages built for Ubuntu 22.04
- Each distribution gets packages with correct dependencies for that specific version

## Checklist

- [x] Changes maintain backwards compatibility (migration logic included)
- [x] Commit message follows Conventional Commits format
- [x] Pre-commit hooks passed
- [x] Documentation updated (HTML index page)

## Related Issue

Fixes the issue reported by @nomike where `apt install pythonscad` on Ubuntu 25.10 was trying to install packages built for Ubuntu 22.04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)