### PR TITLE
fix(ci): correct shell syntax in APT repository migration

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -310,7 +310,7 @@ jobs:
             if [ -d /tmp/apt-repo-existing/pool/main ]; then
               # Old structure - migrate to new structure
               echo "Migrating from old pool structure to distribution-specific pools..."
-              for deb in /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb 2>/dev/null; do
+              for deb in /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb; do
                 [ -f "$deb" ] || continue
                 BASENAME=$(basename "$deb")
                 # Extract distro from filename


### PR DESCRIPTION
## Summary

Fixes a shell syntax error in the APT repository migration logic introduced in #321.

## Problem

The workflow failed with:
```
syntax error near unexpected token `2'
```

The issue was on this line:
```bash
for deb in /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb 2>/dev/null; do
```

In bash, you cannot use `2>/dev/null` directly after a glob pattern in a `for` loop. This is invalid syntax.

## Solution

Removed the `2>/dev/null` redirect:
```bash
for deb in /tmp/apt-repo-existing/pool/main/p/pythonscad/*.deb; do
```

The redirect was unnecessary because:
- The very next line has `[ -f "$deb" ] || continue` which already handles the case where the glob doesn't match any files
- If the glob doesn't match, it will expand to the literal string `*.deb`, which will fail the `-f` test and be skipped

## Testing

Tested locally with a script that simulates the migration:
```bash
# Created test packages in old pool structure
touch /tmp/apt-repo-existing/pool/main/p/pythonscad/pythonscad_0.8.17-1_ubuntu_noble_amd64.deb
touch /tmp/apt-repo-existing/pool/main/p/pythonscad/pythonscad_0.8.17-1_ubuntu_jammy_amd64.deb

# Ran migration logic
# Result: Successfully migrated to distribution-specific pools
/tmp/apt-repo/pool/noble/main/p/pythonscad/pythonscad_0.8.17-1_ubuntu_noble_amd64.deb
/tmp/apt-repo/pool/jammy/main/p/pythonscad/pythonscad_0.8.17-1_ubuntu_jammy_amd64.deb
```

## Related

- Fixes the CI failure in #321
- Should be merged before or with #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)