### PR TITLE
fix(windows): bundle MSYS2 Python runtime for MXE cross-compiled builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2031,7 +2031,23 @@ if(NOT APPLE OR APPLE_UNIX)
   endif()
   if(WIN32)
     if(ENABLE_PYTHON)
-	    install(DIRECTORY "${PYTHON_EMBED_DEVPATH}/" DESTINATION "." )
+	    if(MXECROSS)
+	      # For MXE cross-compilation, install Python runtime from MSYS2 package
+	      # This ensures ABI compatibility since the executable was linked against MSYS2 Python
+
+	      # Install all DLLs from ucrt64/bin/ (includes libpython3.13.dll and dependencies)
+	      install(DIRECTORY "${PYTHON_MINGW_DEVPATH}/${PYTHON_MINGW_REPODIR}/bin/"
+	              DESTINATION "."
+	              FILES_MATCHING PATTERN "*.dll")
+
+	      # Install Python standard library and extension modules
+	      # Python will search for lib/python3.x/ relative to the DLL location
+	      install(DIRECTORY "${PYTHON_MINGW_DEVPATH}/${PYTHON_MINGW_REPODIR}/lib/"
+	              DESTINATION "lib")
+	    else()
+	      # For native MSYS2 Windows builds, use python.org embed package
+	      install(DIRECTORY "${PYTHON_EMBED_DEVPATH}/" DESTINATION "." )
+	    endif()
     endif()
     if(USE_MIMALLOC AND MI_LINK_SHARED)
       if(CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
## Problem

Windows release builds were failing with the error:
```
The code execution cannot proceed because libpython3.13.dll was not found.
Reinstalling the program may fix this problem.
```

## Root Cause

ABI incompatibility between build-time and runtime Python packages:
- **Build/Link time**: Executable linked against MSYS2 MinGW Python (`libpython3.13.dll`)
- **Runtime**: Package only included python.org MSVC Python (`python313.dll`)
- These use different ABIs (GNU/MinGW vs MSVC) and are **not interchangeable**

## Solution

Modified CMakeLists.txt to install the complete MSYS2 Python runtime for MXE cross-compiled Windows builds:
- Installs all DLLs from MSYS2 package (includes `libpython3.13.dll` and dependencies)
- Installs Python standard library from MSYS2 to maintain ABI compatibility
- Native MSYS2 Windows builds remain unchanged (still use python.org embed package)

## Changes
- For MXE builds: Install MSYS2 Python runtime from `ucrt64/bin/` and `ucrt64/lib/`
- For native MSYS2 builds: No changes (preserves existing behavior)

## Testing
- ✅ Windows MXE cross-compilation build completes successfully
- ✅ Package now includes `libpython3.13.dll` (was missing before)
- ✅ Python standard library properly installed in `lib/python3.13/`
- ✅ Executable links to correct DLL

## Trade-offs
- Package size increases from 229 MB → 416 MB (+187 MB)
- Reason: MSYS2 includes full `.py` source files vs compressed `.pyc` bytecode in embed package
- Benefit: ABI compatibility and full Python functionality

Fixes #328