### PR TITLE
feat(ci): add automated website deployment workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,78 @@
+name: Deploy Website
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
+jobs:
+  deploy-website:
+    name: Build and deploy mkdocs website
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup (detached) tmate session if enabled
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 5
+        with:
+          detached: true
+          limit-access-to-actor: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Create virtual environment and install dependencies
+        run: |
+          cd web
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Build mkdocs site
+        run: |
+          cd web
+          source .venv/bin/activate
+          mkdocs build --strict
+
+      - name: Setup SSH key for SFTP
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.WEB_SFTP_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+          # Setup SSH known_hosts
+          PORT="${{ vars.WEB_SFTP_PORT || '22' }}"
+          if [ "$PORT" = "22" ]; then
+            ssh-keyscan -H ${{ vars.WEB_SFTP_HOST }} >> ~/.ssh/known_hosts
+          else
+            ssh-keyscan -p $PORT -H ${{ vars.WEB_SFTP_HOST }} >> ~/.ssh/known_hosts
+          fi
+
+      - name: Deploy to SFTP server
+        run: |
+          PORT="${{ vars.WEB_SFTP_PORT || '22' }}"
+
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key -p $PORT -o StrictHostKeyChecking=no" \
+            web/site/ \
+            ${{ vars.WEB_SFTP_USER }}@${{ vars.WEB_SFTP_HOST }}:${{ vars.WEB_SFTP_PATH }}/
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ src/core/parser.hxx
 src/core/parser.tab.h
 src/core/parser.cc
 pythonscad.egg-info/
+
+# MkDocs build output
+web/site/
+web/.venv/


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically build and deploy the mkdocs website
- Workflow triggers on release creation (same as Debian packages workflow)
- Uses rsync over SSH/SFTP to deploy to hosting provider

## Implementation Details

The workflow:
1. Creates a Python virtual environment
2. Installs mkdocs and dependencies from `web/requirements.txt`
3. Builds the static site with `mkdocs build --strict`
4. Deploys via rsync over SSH to configured SFTP server
5. Uses WEB_* prefixed GitHub secrets/variables for configuration

The following files were modified:
- Added `.github/workflows/deploy-website.yml` - The deployment workflow
- Updated `.gitignore` - Ignore `web/site/` and `web/.venv/` directories

## Required GitHub Secrets & Variables

Before this workflow can run, the following need to be configured in the repository:

**Secrets:**
- `WEB_SFTP_SSH_KEY` - Private SSH key for SFTP authentication

**Variables:**
- `WEB_SFTP_HOST` - SFTP server hostname
- `WEB_SFTP_USER` - SFTP username
- `WEB_SFTP_PATH` - Destination path on SFTP server
- `WEB_SFTP_PORT` - SFTP port (optional, defaults to 22)

## Test Plan

- [ ] Configure required secrets and variables
- [ ] Trigger workflow via manual dispatch to verify build succeeds
- [ ] Verify website deploys correctly to SFTP server
- [ ] Test automatic trigger on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)