### PR TITLE
fix(ci): use prerelease instead of draft for release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   wait-and-publish:
     runs-on: ubuntu-latest
-    # Only run for draft releases
-    if: github.event_name == 'workflow_dispatch' || github.event.release.draft == true
+    # Only run for prerelease releases
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
     steps:
       - name: Wait for build workflows and publish
         uses: actions/github-script@v7
@@ -59,16 +59,16 @@ jobs:
                   return;
                 }
               } else {
-                // Find latest draft release
+                // Find latest prerelease
                 const { data: releases } = await github.rest.repos.listReleases({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   per_page: 10,
                 });
 
-                release = releases.find(r => r.draft);
+                release = releases.find(r => r.prerelease);
                 if (!release) {
-                  core.setFailed('No draft release found');
+                  core.setFailed('No prerelease found');
                   return;
                 }
                 releaseTag = release.tag_name;
@@ -173,18 +173,19 @@ jobs:
                   repo: context.repo.repo,
                   release_id: release.id,
                   draft: false,
+                  prerelease: false,
                 });
 
                 console.log(`\n✅ Release ${releaseTag} published successfully!`);
                 console.log(`🔗 ${release.html_url}`);
                 return;
               } else {
-                // Some builds failed - update release notes and keep as draft
-                console.log('\n⚠️  Some builds failed. Keeping release as draft.');
+                // Some builds failed - update release notes and keep as prerelease
+                console.log('\n⚠️  Some builds failed. Keeping release as prerelease.');
 
                 // Build status report
                 let statusReport = '\n\n---\n\n## 🏗️ Build Status\n\n';
-                statusReport += '⚠️ **Some builds failed.** This release remains as a draft.\n\n';
+                statusReport += '⚠️ **Some builds failed.** This release remains as a prerelease.\n\n';
 
                 for (const [name, info] of Object.entries(statusByWorkflow)) {
                   const icon = info.conclusion === 'success' ? '✅' :
@@ -209,7 +210,7 @@ jobs:
                 });
 
                 // Fail the workflow so it's visible in Actions
-                core.setFailed(`Some build workflows failed. Release kept as draft.`);
+                core.setFailed(`Some build workflows failed. Release kept as prerelease.`);
                 return;
               }
             }

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,7 +5,7 @@
       "package-name": "pythonscad",
       "include-component-in-tag": false,
       "version-file": "VERSION.txt",
-      "draft": true,
+      "prerelease": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Problem

The original PR #348 had a critical flaw: **draft releases don't trigger the `release: [created]` GitHub event**, which prevented build workflows from running.

## Root Cause

When Release Please creates a draft release:
- ❌ `release: [created]` event is NOT fired
- ❌ Build workflows don't trigger
- ❌ No assets get uploaded
- ❌ Downloads page stays empty

This is a GitHub security feature - only published releases trigger workflows.

## Solution

Use **prerelease** instead of **draft**:

| Feature | Draft | Prerelease |
|---------|-------|------------|
| Triggers `release: [created]` | ❌ No | ✅ Yes |
| Visible to users | ❌ No | ⚠️ Marked as "Pre-release" |
| Shows on releases page | ❌ No | ✅ Yes (with warning) |
| In "Latest" release | ❌ No | ❌ No |

### Changes Made

1. **`.release-please-config.json`**
   - Changed `"draft": true` → `"prerelease": true`

2. **`.github/workflows/publish-release.yml`**
   - Check for `prerelease` flag instead of `draft`
   - When all builds succeed, clear BOTH flags: `draft: false, prerelease: false`
   - Updated error messages

## How It Works Now

```
1. Release Please creates PRERELEASE
   ↓ (triggers release:created event)
2. All 5 build workflows run in parallel
   ↓ (upload assets to the prerelease)
3. Publish workflow monitors build status
   ↓
4. When all succeed:
   → Set prerelease: false (makes it a full release)
   → Set draft: false (ensures it's published)
   → Release now shows as "Latest" ✅

5. When any fail:
   → Keep prerelease: true
   → Add status report to release notes
```

## Testing

To verify this works:
- [ ] Merge this PR
- [ ] Merge a feature PR to trigger release-please
- [ ] Verify prerelease is created
- [ ] Verify build workflows trigger automatically
- [ ] Verify publish workflow runs and clears prerelease flag

## Replaces

This PR replaces #348, which had the draft implementation that doesn't work.
