### PR TITLE
chore: make publish-release workflow wait for the new native Windows build

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
               'Build Debian packages',
               'Build and upload macOS build',
               'Build RPM packages',
-              'Build and upload Windows build (MXE Cross-Compile)',
+              'Build Windows Native Package',
             ];
 
             const MAX_WAIT_MS = 90 * 60 * 1000; // 90 minutes


### PR DESCRIPTION
Now that we replaced the old cross compiled MXE builds for Windows with the new natively compiled MSYS2 builds, the publish-release workflow needs to be updated to wait for the new build pipeline to finish instead of looking for the old one.