### PR TITLE
fix(ci): mark published release as latest in GitHub

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -174,6 +174,7 @@ jobs:
                   release_id: release.id,
                   draft: false,
                   prerelease: false,
+                  make_latest: 'true',
                 });
 
                 console.log(`\n✅ Release ${releaseTag} published successfully!`);


### PR DESCRIPTION
## Summary
- Adds `make_latest: 'true'` to the release update API call in the publish-release workflow
- Ensures published releases are properly marked as the latest version on the GitHub releases page

## Why
The workflow was publishing releases but not setting them as "latest", requiring manual intervention in the GitHub UI. This fix automates that step.

## Test plan
- Verify next release is automatically marked as latest when all builds complete
- Check that prerelease flag is correctly set to false on published releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)