### PR TITLE
fix: include filename in warnings for files included via osuse() (#387)

### DIFF
--- a/tests/data/pythonscad-echo/pythonscad-issue387.py
+++ b/tests/data/pythonscad-echo/pythonscad-issue387.py
@@ -1,0 +1,3 @@
+"""Test for pythonscad issue #387: Filename is not included in warnings happening in included files"""
+from openscad import *
+osuse("../scad/issues/pythonscad-issue387-included.scad").test()

--- a/tests/data/scad/issues/pythonscad-issue387-included.scad
+++ b/tests/data/scad/issues/pythonscad-issue387-included.scad
@@ -1,0 +1,2 @@
+// This file tests issue #387: Filename is not included in warnings for included files
+function test() = $bar;

--- a/tests/regression/pythonscadecho/pythonscad-issue387-expected.echo
+++ b/tests/regression/pythonscadecho/pythonscad-issue387-expected.echo
@@ -1,0 +1,1 @@
+WARNING: Ignoring unknown variable "$bar" in file pythonscad-issue387-included.scad, line 2


### PR DESCRIPTION
Fixes #387

## Problem
When using Python's `osuse()` to include SCAD files, warnings generated in the included files were missing the filename (showing 'in file , line X' instead of 'in file filename.scad, line X').

## Root Causes
1. **In python_osuse_include()**: The `parse()` call was using generic 'python' string as the source file instead of the actual Python script path. This prevented proper file resolution during include processing.

2. **In PyDataObject_call_function()**: When evaluating functions from included files, the code re-parsed the file using 'python' as both the filename and document path for the EvaluationSession. This caused `toRelativeString()` to receive an invalid docPath, making `fs_uncomplete()` return an empty string when converting absolute paths to relative paths.

## Solution
- Updated `python_osuse_include()` to pass the Python script path to `parse()` and `EvaluationSession` instead of 'python'
- Updated `PyDataObject_call_function()` to use the included file's parent path for `parse()` and `EvaluationSession` instead of 'python'

This ensures Location objects have proper context for displaying relative filenames in warning and error messages.

## Testing
Added regression test: pythonscad-issue387