### PR TITLE
fix(windows): remove '-dirty' suffix from build package filenames

### DIFF
--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Configure git (disable line-ending conversion for accurate dirty check)
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.safecrlf false
+
       - name: Fetch tags for version detection
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- Fixes Windows builds incorrectly including "-dirty" suffix in filenames (e.g., `PythonSCAD-0.12.0-dirty-windows-x86-64.zip`)
- Configures git to disable line-ending conversion before version detection
- Makes Windows builds consistent with macOS and Linux naming

## Root Cause
On Windows runners, `git config core.autocrlf` was enabled, causing line-ending conversion that made `git describe --dirty` report false positives for uncommitted changes. This is a known issue with git on Windows where CRLF/LF differences aren't actual file changes.

## Solution
Added git configuration step before version detection:
```bash
git config --global core.autocrlf false
git config --global core.safecrlf false
```

This prevents git from treating line-ending normalization as modified files while still keeping the repository safe.

## Test Plan
- Windows build should now generate packages with clean version (no "-dirty" suffix)
- Compare with macOS and Linux builds to verify consistent naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)