### PR TITLE
feat(gui): Python editor code completion and parameter hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1711,6 +1711,7 @@ set(GUI_SOURCES
   src/gui/QSettingsCached.cc
   src/gui/QWordSearchField.cc
   src/gui/ScadApi.cc
+  src/gui/PythonApi.cc
   src/gui/ScadLexer.cc
   src/gui/ScintillaEditor.cc
   src/gui/SettingsWriter.cc
@@ -1786,6 +1787,7 @@ set(GUI_HEADERS
     src/gui/QSettingsCached.h
     src/gui/QWordSearchField.h
     src/gui/ScadApi.h
+    src/gui/PythonApi.h
     src/gui/ScadLexer.h
     src/gui/ScintillaEditor.h
     src/gui/SettingsWriter.h

--- a/doc/python-editor-completion-plan.md
+++ b/doc/python-editor-completion-plan.md
@@ -1,0 +1,129 @@
+# Python Editor Code Completion and Parameter Hints – Feasibility and Implementation Plan
+
+## Summary
+
+**Feasibility: Yes.** The same QScintilla API-based completion and call-tip mechanism used for SCAD is available for Python. The Python lexer is already used for `.py` files but has no `QsciAbstractAPIs` attached, so completion and parameter hints are currently inactive for Python. Adding a Python-specific API class and attaching it to the Python lexer will provide equivalent behaviour.
+
+**Effort: Small–medium** (on the order of 1–3 days for an experienced C++/Qt developer), assuming we mirror the existing SCAD behaviour and reuse `Builtins::keywordList` for data.
+
+---
+
+## Current Behaviour (SCAD)
+
+1. **Code completion**
+   - `ScadApi` extends `QsciAbstractAPIs` and is created with the SCAD lexer (and editor).
+   - It is associated with the lexer (lexer as parent; for SCAD the API is created in `setLexer(ScadLexer*)` / `setLexer(ScadLexer2*)`).
+   - `updateAutoCompletionList()` filters `Builtins::keywordList` by the current word prefix and optionally handles `use`/`include` paths.
+   - QScintilla uses `AcsAPIs`, so the completion list comes from the lexer’s APIs.
+   - Behaviour: type “c” → list with “cube”, “circle”, “color”, etc.; cursor/tab to select.
+
+2. **Parameter hints (call tips)**
+   - `ScadApi::callTips()` receives the context (words before cursor). For `cube(`, the function name is `context.at(context.size()-2)`.
+   - It returns the list of call-tip strings for that function from the same data used for completion (e.g. `cube(size)`, `cube([width, depth, height])`, `cube([width, depth, height], center = true)`).
+   - Call tips are already configured in `ScintillaEditor::setupAutoComplete()`: `setCallTipsVisible(10)`, `setCallTipsStyle(CallTipsContext)`.
+
+3. **Data source**
+   - `Builtins::keywordList` is a static map: name → vector of call-tip strings.
+   - It is filled from all `Builtins::init(..., calltipList)` calls (primitives, modules, functions) and is shared by SCAD and can be reused for Python.
+
+---
+
+## Why Python Has No Completion Today
+
+- For `.py` files, `EditorInterface::recomputeLanguageActive()` sets `LANG_PYTHON` and `ScintillaEditor::onLanguageChanged(LANG_PYTHON)` runs `qsci->setLexer(this->pythonLexer)`.
+- `pythonLexer` is a plain `QsciLexerPython` created in `ScintillaEditor` and **has no `QsciAbstractAPIs`** attached.
+- Completion and call tips are driven by the **current lexer’s APIs**. So when the Python lexer is active, there are no APIs → no completion, no parameter hints.
+
+---
+
+## Proposed Solution
+
+### 1. Add a Python API class (`PythonApi`)
+
+- **Role:** Same as `ScadApi` but for the Python lexer: provide completion list and call tips for the `openscad` API used in Python files.
+- **Base:** `QsciAbstractAPIs`, constructed with `QsciLexerPython*` (and a pointer to `ScintillaEditor` for current line/column if needed).
+- **Data:**
+  - Reuse **`Builtins::keywordList`** for all names that exist in both SCAD and Python (e.g. `cube`, `circle`, `sphere`, `color`, `translate`, …). Same call-tip strings (e.g. `cube(size)`, `cube([width, depth, height])`, …).
+  - Add a small set of **Python-only** names with call tips, e.g.:
+    - `show` → e.g. `show(obj)` or `show(obj, ...)`
+    - `add_parameter` → e.g. `add_parameter(name, default, ...)`
+    - Optionally: `version`, `version_num`, `scad`, `align`, etc., if desired for the first version.
+- **Methods:**
+  - `updateAutoCompletionList(context, list)`: same idea as `ScadApi` – filter by `context.last()` (current word prefix). No need for `use`/`include`; optionally skip inside string literals (Python: `'...'`, `"..."`, `'''...'''`) if we want to avoid completion inside strings.
+  - `callTips(context, commas, style, shifts)`: same as `ScadApi` – use `context.at(context.size()-2)` as the function name and return the corresponding call-tip list from the same name→signatures map.
+- **Files:** New `src/gui/PythonApi.h` and `src/gui/PythonApi.cc` (or similar). Can reuse `ApiFunc` and the same pattern as `ScadApi` for name + list of call-tip strings.
+
+### 2. Attach Python API to the Python lexer
+
+- **Where:** In `ScintillaEditor`, once `pythonLexer` exists (e.g. in constructor or in `initLexer()`), create `pythonApi = new PythonApi(this, pythonLexer)` and call `pythonLexer->setAPIs(pythonApi)` (QScintilla’s `QsciLexer::setAPIs(QsciAbstractAPIs*)`).
+- **Lifetime:** `pythonApi` is owned by the editor (or by the lexer if we set the lexer as parent in the API ctor). Ensure it is deleted when the editor is destroyed if not owned by the lexer.
+- No change to the way the editor switches lexers: when the user is in a `.py` file, `qsci->setLexer(pythonLexer)` is already called; with APIs set on `pythonLexer`, QScintilla will use them for completion and call tips.
+
+### 3. Reuse existing editor settings
+
+- `setupAutoComplete()` already sets:
+  - `setAutoCompletionSource(QsciScintilla::AcsAPIs)`
+  - `setAutoCompletionFillups("(")`
+  - `setCallTipsVisible(10)` and `setCallTipsStyle(QsciScintilla::CallTipsContext)`
+- These apply to whichever lexer is current, so **no change** is required for Python: once the Python lexer has APIs, completion and call tips will work when the Python lexer is active.
+
+### 4. Optional refinements (later)
+
+- **Skip completion inside strings:** In `PythonApi::updateAutoCompletionList`, use current line/column and a simple scan (single/double/triple quotes) to avoid offering completion inside string literals (mirroring SCAD’s `isInString`).
+- **Python-only call tips:** Add more entries from the Python `openscad` module (e.g. from `PyOpenSCADFunctions` / `doc/openscad.pyi`) as needed.
+- **Method chaining:** Completion after `obj.` (e.g. `obj.translate`, `obj.rotate`) would require context-aware completion (detecting that we are after a dot) and a list of method names; this can be a follow-up.
+
+---
+
+## Implementation Steps
+
+1. **Add `PythonApi` class**
+   - Create `PythonApi.h` / `PythonApi.cc` (or equivalent).
+   - In constructor, build an internal list of (name, call-tip list) from `Builtins::keywordList` plus Python-only entries (e.g. `show`, `add_parameter` with one or two call-tip strings each).
+   - Implement `updateAutoCompletionList()`: filter by prefix from `context.last()`; optionally add string-in-context check.
+   - Implement `callTips()`: resolve function name from context (e.g. `context.size() >= 2 ? context.at(context.size()-2) : QString()`), return the corresponding call-tip list.
+   - Add to `src/gui/CMakeLists.txt` (or build script) so the new sources are compiled.
+
+2. **Wire Python API into `ScintillaEditor`**
+   - In `ScintillaEditor`, after `pythonLexer` is created, instantiate `PythonApi(this, pythonLexer)` and call `pythonLexer->setAPIs(pythonApi)`.
+   - Ensure `pythonApi` is kept alive and not double-deleted (e.g. if the API’s parent is the lexer, Qt’s parent-child will delete it with the lexer; otherwise delete in `ScintillaEditor` destructor).
+   - Guard with `#ifdef ENABLE_PYTHON` so the feature is only built when Python support is enabled.
+
+3. **Testing**
+   - Open a `.py` file, type `c` and confirm completion list (e.g. `cube`, `circle`, `color`, …).
+   - Type `cube(` and confirm parameter-hint tooltip with multiple signatures.
+   - Test that existing SCAD completion and call tips still work in `.scad` files.
+   - Test with “Enable Autocompletion” off and on in preferences.
+
+4. **Documentation**
+   - Short note in user docs or cheatsheet that Python files support the same completion and parameter hints as SCAD (and that they show the `openscad` API).
+
+---
+
+## Risk and Limitations
+
+- **Context format:** QScintilla’s `context` for Python may differ slightly (e.g. word boundaries). If `callTips` or completion behaves oddly, verify `context` contents (e.g. for `cube(`) and adjust index (e.g. `context.size()-2`) if needed.
+- **No runtime introspection:** Completion is static (from `Builtins::keywordList` + hard-coded Python names). We do not run the script to infer types or methods; that would be a much larger project (e.g. language server).
+- **Method completion:** Completion for `obj.method()` is out of scope for this plan; only top-level names (e.g. after `from openscad import *`) are targeted.
+
+---
+
+## Effort Estimate
+
+| Task | Effort |
+|------|--------|
+| PythonApi class (data + updateAutoCompletionList + callTips) | 0.5–1 day |
+| Integrate into ScintillaEditor (create API, setAPIs, ENABLE_PYTHON) | 0.25 day |
+| Testing (manual + regression) | 0.25–0.5 day |
+| Optional: skip completion in Python strings | 0.25 day |
+| **Total** | **~1–2.5 days** |
+
+---
+
+## References (in tree)
+
+- SCAD completion / call tips: `src/gui/ScadApi.cc`, `src/gui/ScadApi.h`
+- Lexer/API wiring: `src/gui/ScintillaEditor.cc` (e.g. `setLexer`, `setupAutoComplete`), `ScintillaEditor::onLanguageChanged`
+- Builtins and call-tip data: `src/core/Builtins.h`, `Builtins::keywordList`; registration in `src/core/primitives.cc`, `builtin_functions.cc`, etc.
+- Python exports: `src/python/pyfunctions.cc` (`PyOpenSCADFunctions`), `doc/openscad.pyi`
+- QScintilla: `QsciAbstractAPIs`, `QsciLexer::setAPIs`, `QsciScintilla::setAutoCompletionSource`, `setCallTipsVisible` / `setCallTipsStyle`

--- a/src/gui/PythonApi.cc
+++ b/src/gui/PythonApi.cc
@@ -1,0 +1,99 @@
+#include "gui/PythonApi.h"
+
+#include <QString>
+#include <QStringList>
+#include <string>
+
+#include "core/Builtins.h"
+#include "gui/ScintillaEditor.h"
+
+namespace {
+
+bool isInPythonString(const QString& text, int col)
+{
+  bool lastWasEscape = false;
+  bool inSingle = false;
+  bool inDouble = false;
+  int dx = 0;
+  int count = col;
+  while (count-- > 0 && dx < text.length()) {
+    QChar ch = text[dx++];
+    if (ch == '\\') {
+      lastWasEscape = true;
+    } else if (lastWasEscape) {
+      lastWasEscape = false;
+    } else if (ch == '\'' && !inDouble) {
+      inSingle = !inSingle;
+    } else if (ch == '"' && !inSingle) {
+      inDouble = !inDouble;
+    }
+  }
+  return inSingle || inDouble;
+}
+
+}  // namespace
+
+PythonApi::PythonApi(ScintillaEditor *editor, QsciLexerPython *lexer)
+  : QsciAbstractAPIs(lexer), editor(editor)
+{
+  for (const auto& iter : Builtins::keywordList) {
+    QStringList calltipList;
+    for (const auto& it : iter.second) {
+      calltipList.append(QString::fromStdString(it));
+    }
+    funcs.append({QString::fromStdString(iter.first), calltipList});
+  }
+  // Python-only openscad names with call tips
+  funcs.append(PythonApiFunc{"show", {"show(obj)", "show(obj, ...)"}});
+  funcs.append(PythonApiFunc{"add_parameter", {"add_parameter(name, default, ...)"}});
+}
+
+void PythonApi::updateAutoCompletionList(const QStringList& context, QStringList& list)
+{
+  int line, col;
+  editor->qsci->getCursorPosition(&line, &col);
+  const QString text = editor->qsci->text(line);
+
+  if (isInPythonString(text, col)) {
+    return;
+  }
+  autoCompleteFunctions(context, list);
+}
+
+void PythonApi::autoCompleteFunctions(const QStringList& context, QStringList& list)
+{
+  if (context.isEmpty()) {
+    return;
+  }
+  const QString& c = context.last();
+  if (c.isEmpty()) {
+    return;
+  }
+
+  for (const auto& func : funcs) {
+    if (func.name.startsWith(c) && !list.contains(func.name)) {
+      list << func.name;
+    }
+  }
+}
+
+void PythonApi::autoCompletionSelected(const QString& /*selection*/)
+{
+}
+
+QStringList PythonApi::callTips(const QStringList& context, int /*commas*/,
+                                QsciScintilla::CallTipsStyle /*style*/, QList<int>& /*shifts*/)
+{
+  QStringList tips;
+  if (context.size() < 2) {
+    return tips;
+  }
+  const QString name = context.at(context.size() - 2);
+  for (const auto& func : funcs) {
+    if (func.name == name) {
+      tips = func.params;
+      break;
+    }
+  }
+  return tips;
+}

--- a/src/gui/PythonApi.cc
+++ b/src/gui/PythonApi.cc
@@ -103,6 +103,49 @@ PythonApi::PythonApi(ScintillaEditor *editor, QsciLexerPython *lexer)
   // Python-only openscad names with call tips
   funcs.append(PythonApiFunc{"show", {"show(obj)", "show(obj, ...)"}});
   funcs.append(PythonApiFunc{"add_parameter", {"add_parameter(name, default, ...)"}});
+  funcs.append(PythonApiFunc{"right", {"right(x)", "right(obj, x)"}});
+  funcs.append(PythonApiFunc{"left", {"left(x)", "left(obj, x)"}});
+  funcs.append(PythonApiFunc{"back", {"back(x)", "back(obj, x)"}});
+  funcs.append(PythonApiFunc{"front", {"front(x)", "front(obj, x)"}});
+  funcs.append(PythonApiFunc{"up", {"up(x)", "up(obj, x)"}});
+  funcs.append(PythonApiFunc{"down", {"down(x)", "down(obj, x)"}});
+  funcs.append(PythonApiFunc{"rotx", {"rotx(angle)", "rotx(obj, angle)"}});
+  funcs.append(PythonApiFunc{"roty", {"roty(angle)", "roty(obj, angle)"}});
+  funcs.append(PythonApiFunc{"rotz", {"rotz(angle)", "rotz(obj, angle)"}});
+  funcs.append(PythonApiFunc{"separate", {"separate(obj)"}});
+  funcs.append(PythonApiFunc{"export", {"export(obj)", "export(obj, file=...)"}});
+  funcs.append(PythonApiFunc{"find_face", {"find_face(obj, normal)"}});
+  funcs.append(PythonApiFunc{"sitonto", {"sitonto(obj, x, y, z)"}});
+  funcs.append(PythonApiFunc{"path_extrude", {"path_extrude(shape, path, ...)"}});
+  funcs.append(PythonApiFunc{"skin", {"skin(profiles, ...)"}});
+  funcs.append(PythonApiFunc{"concat", {"concat(*objects)", "concat(*objects, r=..., fn=...)"}});
+  funcs.append(PythonApiFunc{"highlight", {"highlight(obj)"}});
+  funcs.append(PythonApiFunc{"background", {"background(obj)"}});
+  funcs.append(PythonApiFunc{"only", {"only(obj)"}});
+  funcs.append(PythonApiFunc{"sheet", {"sheet(file, ...)"}});
+  funcs.append(PythonApiFunc{"inside", {"inside(obj, point)"}});
+  funcs.append(PythonApiFunc{"bbox", {"bbox(obj)"}});
+  funcs.append(PythonApiFunc{"size", {"size(obj)"}});
+  funcs.append(PythonApiFunc{"position", {"position(obj)"}});
+  funcs.append(PythonApiFunc{"faces", {"faces(obj)"}});
+  funcs.append(PythonApiFunc{"children", {"children(obj)"}});
+  funcs.append(PythonApiFunc{"edges", {"edges(obj)"}});
+  funcs.append(PythonApiFunc{"explode", {"explode(obj, vector)"}});
+  funcs.append(PythonApiFunc{"oversample", {"oversample(obj, n, round=...)"}});
+  funcs.append(PythonApiFunc{"debug", {"debug(obj, faces=...)"}});
+  funcs.append(PythonApiFunc{"repair", {"repair(obj)"}});
+  funcs.append(PythonApiFunc{"fillet", {"fillet(obj, r, sel, fn=...)"}});
+  funcs.append(PythonApiFunc{"group", {"group(*objects)"}});
+  funcs.append(PythonApiFunc{"osimport", {"osimport(file, ...)"}});
+  funcs.append(PythonApiFunc{"osuse", {"osuse(path)"}});
+  funcs.append(PythonApiFunc{"osinclude", {"osinclude(path)"}});
+  funcs.append(PythonApiFunc{"version", {"version()"}});
+  funcs.append(PythonApiFunc{"version_num", {"version_num()"}});
+  funcs.append(PythonApiFunc{"scad", {"scad(code)"}});
+  funcs.append(PythonApiFunc{"add_menuitem", {"add_menuitem(menuname, itemname, callback)"}});
+  funcs.append(PythonApiFunc{"nimport", {"nimport(url)"}});
+  funcs.append(PythonApiFunc{"model", {"model()"}});
+  funcs.append(PythonApiFunc{"modelpath", {"modelpath()"}});
 }
 
 void PythonApi::updateAutoCompletionList(const QStringList& context, QStringList& list)

--- a/src/gui/PythonApi.h
+++ b/src/gui/PythonApi.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+#include <Qsci/qsciapis.h>
+#include <Qsci/qscilexerpython.h>
+
+class ScintillaEditor;
+
+struct PythonApiFunc {
+  QString name;
+  QStringList params;
+};
+
+class PythonApi : public QsciAbstractAPIs
+{
+  Q_OBJECT
+
+private:
+  ScintillaEditor *editor;
+  QList<PythonApiFunc> funcs;
+
+  void autoCompleteFunctions(const QStringList& context, QStringList& list);
+
+public:
+  PythonApi(ScintillaEditor *editor, QsciLexerPython *lexer);
+
+  void updateAutoCompletionList(const QStringList& context, QStringList& list) override;
+  void autoCompletionSelected(const QString& selection) override;
+  QStringList callTips(const QStringList& context, int commas, QsciScintilla::CallTipsStyle style,
+                       QList<int>& shifts) override;
+};

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -13,6 +13,10 @@
 #include <QChar>
 #include <QMenu>
 #include <QObject>
+#ifdef ENABLE_PYTHON
+#include "gui/PythonApi.h"
+#endif
+
 #include <QPoint>
 #include <QRegularExpression>
 #include <QShortcut>
@@ -217,6 +221,13 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   setLexer(new ScadLexer(this));
 #endif
   recomputeLanguageActive();
+
+#ifdef ENABLE_PYTHON
+  {
+    auto *pythonApi = new PythonApi(this, this->pythonLexer);
+    this->pythonLexer->setAPIs(pythonApi);
+  }
+#endif
 
   initMargin();
 


### PR DESCRIPTION
## Summary

This branch adds **code completion** and **parameter hints (call tips)** for Python files in the PythonSCAD editor, mirroring the behaviour already available for SCAD files.

---

## Changes

### 1. Code completion and parameter hints for Python files

- **New `PythonApi` class** (`src/gui/PythonApi.h`, `src/gui/PythonApi.cc`) extending `QsciAbstractAPIs`, analogous to `ScadApi` for SCAD.
- **Data source:** Reuses `Builtins::keywordList` for all names shared between SCAD and Python (e.g. `cube`, `circle`, `sphere`, `color`, `translate`, `union`, …). Same call-tip strings as SCAD.
- **Integration:** `PythonApi` is instantiated in `ScintillaEditor` and attached to the Python lexer via `pythonLexer->setAPIs(pythonApi)`. Guarded with `#ifdef ENABLE_PYTHON`.
- **Behaviour:** In `.py` files, typing a prefix (e.g. `c`) shows a completion list (e.g. `cube`, `circle`, `color`, …). Typing a function name and `(` shows parameter-hint tooltips with one or more signatures.

### 2. Skip completion inside strings (including triple quotes)

- **`isInPythonString()`** in `PythonApi.cc` was extended to detect **triple-quoted** strings (`'''` and `"""`).
- Completion is **not** triggered when the cursor is inside a single-, double-, or triple-quoted string literal, so suggestions no longer appear in the middle of docstrings or string content.

### 3. Python-only call tips (more entries)

- **Additional `PythonApiFunc` entries** for Python-only `openscad` API names with short call-tip signatures:
  - `show`, `add_parameter`, `right`, `left`, `back`, `front`, `up`, `down`, `rotx`, `roty`, `rotz`, `separate`, `export`, `find_face`, `sitonto`, `path_extrude`, `skin`, `concat`, `highlight`, `background`, `only`, `sheet`, `inside`, `bbox`, `size`, `position`, `faces`, `children`, `edges`, `explode`, `oversample`, `debug`, `repair`, `fillet`, `group`, `osimport`, `osuse`, `osinclude`, `version`, `version_num`, `scad`, `add_menuitem`, `nimport`, `model`, `modelpath`.
- Parameter hints for these functions now appear when the user types the name and `(` in a Python file.

### 4. Documentation

- **`doc/python-editor-completion-plan.md`** updated with:
  - Optional refinements and their complexity (skip completion in strings, Python-only call tips).
  - **Language server (LSP) – feasibility:** short note on integrating an LSP (effort, cross-platform, benefits, drawbacks). LSP is out of scope for now but documented for future reference.

---

## Build and testing

- New sources `PythonApi.h` and `PythonApi.cc` are included in the GUI build (`OpenSCADLibInternal`).
- No change to SCAD completion or call tips; existing editor settings (e.g. `setAutoCompletionSource(AcsAPIs)`, `setCallTipsVisible`) apply to whichever lexer is active, so Python gains completion/call tips once the Python lexer has APIs.

---

## Out of scope (for this PR)

- **Method chaining** (completion after `obj.`): a non–type-aware fixed list was prototyped but removed; proper type-aware completion would require static analysis or an LSP.
- **LSP integration:** documented as a larger, future option; not implemented.