### PR TITLE
fix: filter git describe to match only PythonSCAD version tags

### DIFF
--- a/cmake/Modules/openscad_version.cmake
+++ b/cmake/Modules/openscad_version.cmake
@@ -5,7 +5,7 @@ if ("${OPENSCAD_VERSION}" STREQUAL "")
   find_package(Git QUIET)
   if (GIT_FOUND)
     execute_process(
-      COMMAND "${GIT_EXECUTABLE}" describe --tags --always --dirty
+      COMMAND "${GIT_EXECUTABLE}" describe --tags --match "v[0-9]*.[0-9]*.[0-9]*" --always --dirty
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       OUTPUT_VARIABLE GIT_VERSION
       OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
The version detection was picking up upstream-sync/* tags (used for tracking OpenSCAD upstream synchronization), causing version parsing to fail with errors like:
"Version string 'upstream-sync/openscad-2026-02-04-903-g342f50943' doesn't match expected format"

Add --match "v[0-9]*.[0-9]*.[0-9]*" to git describe to only match PythonSCAD semantic versioning tags (e.g., v0.12.3).