### PR TITLE
fix(ci): validate SFTP secrets and quote host in ssh-keyscan

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -338,10 +338,14 @@ jobs:
 
       - name: Setup SSH key for SFTP
         run: |
+          if [ -z "${{ secrets.REPO_SFTP_HOST }}" ] || [ -z "${{ secrets.REPO_SFTP_SSH_KEY }}" ]; then
+            echo "::error::Required secrets REPO_SFTP_HOST and REPO_SFTP_SSH_KEY must be set in repository settings."
+            exit 1
+          fi
           mkdir -p ~/.ssh
           echo "${{ secrets.REPO_SFTP_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ secrets.REPO_SFTP_HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${{ secrets.REPO_SFTP_HOST }}" >> ~/.ssh/known_hosts
 
       - name: Download existing repository from SFTP
         run: |

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -480,10 +480,14 @@ jobs:
 
       - name: Setup SSH key for SFTP
         run: |
+          if [ -z "${{ secrets.REPO_SFTP_HOST }}" ] || [ -z "${{ secrets.REPO_SFTP_SSH_KEY }}" ]; then
+            echo "::error::Required secrets REPO_SFTP_HOST and REPO_SFTP_SSH_KEY must be set in repository settings."
+            exit 1
+          fi
           mkdir -p ~/.ssh
           echo "${{ secrets.REPO_SFTP_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ secrets.REPO_SFTP_HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${{ secrets.REPO_SFTP_HOST }}" >> ~/.ssh/known_hosts
 
       - name: Download existing repository from SFTP
         run: |


### PR DESCRIPTION
Adds explicit validation for `REPO_SFTP_HOST` and `REPO_SFTP_SSH_KEY` before running ssh-keyscan in the Debian and RPM publish jobs. If either secret is missing, the step fails with a clear error instead of an opaque ssh-keyscan exit code 1. Also quotes the host argument in ssh-keyscan.

Addresses the failure in [Publish APT repository to SFTP](https://github.com/pythonscad/pythonscad/actions/runs/21986001491) (Setup SSH key for SFTP step).

Made with [Cursor](https://cursor.com)