### PR TITLE
fix(macos): resolve spctl framework validation on macOS 15 and add validation checks

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -533,17 +533,6 @@ jobs:
               echo "Copying arm64-only Python framework"
               mkdir -p "$MERGED_DIR/$APP_NAME/Contents/Frameworks"
               cp -R "$arm_python" "$MERGED_DIR/$APP_NAME/Contents/Frameworks/"
-
-              # Remove broken site-packages symlink that points outside the bundle
-              SITE_PACKAGES_LINK="$MERGED_DIR/$APP_NAME/Contents/Frameworks/Python.framework/Versions/*/lib/python*/site-packages"
-              for link in $SITE_PACKAGES_LINK; do
-                if [ -L "$link" ] && [ ! -e "$link" ]; then
-                  echo "Removing broken site-packages symlink: $link"
-                  rm "$link"
-                  # Create an empty directory instead
-                  mkdir -p "$link"
-                fi
-              done
             elif [ -d "$x86_python" ] && [ -d "$arm_python" ]; then
               # In both - merge binaries
               PYTHON_VERSION=$(ls "$x86_python/Versions/" 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
@@ -582,6 +571,20 @@ jobs:
               fi
             fi
           fi
+
+          # Remove broken site-packages symlink that points outside the bundle
+          # This must happen after Python.framework is fully assembled (regardless of merge path)
+          echo "=== Cleaning up Python.framework ==="
+          SITE_PACKAGES_LINK="$MERGED_DIR/$APP_NAME/Contents/Frameworks/Python.framework/Versions/*/lib/python*/site-packages"
+          for link in $SITE_PACKAGES_LINK; do
+            if [ -L "$link" ] && [ ! -e "$link" ]; then
+              echo "Removing broken site-packages symlink: $link"
+              rm "$link"
+              # Create an empty directory instead
+              mkdir -p "$link"
+              echo "✓ Created empty site-packages directory"
+            fi
+          done
 
           # Merge Qt plugin .dylib files from both bundles
           echo "=== Merging Qt plugins ==="
@@ -1218,13 +1221,24 @@ jobs:
           fi
 
       - name: Upload artifacts to release
-        if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
+        if: (github.event_name == 'release' || github.event.inputs.upload_to_release != '') && steps.validation.outcome == 'success'
         uses: softprops/action-gh-release@v2
         with:
           files: /tmp/out/*.dmg
           tag_name: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail workflow if validation failed
+        if: always()
+        run: |
+          if [ "${{ steps.validation.outcome }}" != "success" ]; then
+            echo "❌ Workflow failed because validation did not pass"
+            echo "DMG and artifacts are available for inspection but were NOT uploaded to the release"
+            exit 1
+          else
+            echo "✅ Validation passed - DMG was uploaded to release (if applicable)"
+          fi
 
       - name: Clean up signing keychain
         if: always() && steps.install_cert.outputs.cert_installed == 'true'


### PR DESCRIPTION
## Problem

macOS 15 (Sequoia) users are experiencing "cannot be verified" errors when trying to run PythonSCAD, even though the app is properly signed and notarized.

**Error Message:**
```
/Applications/PythonSCAD.app: rejected (invalid destination for symbolic link in bundle)
```

## Root Cause ✅

**Discovered:** The bundled `Python.framework` contains a broken symlink from Homebrew:
```
Python.framework/Versions/3.14/lib/python3.14/site-packages 
  → ../../../../../../lib/python3.14/site-packages
```

This symlink points to `PythonSCAD.app/Contents/lib/python3.14/site-packages` which **doesn't exist**. On macOS 15, `spctl` strictly validates framework bundles and rejects the app because of this invalid symlink destination.

**Why it exists:** Homebrew's Python formula creates this symlink to point to the system-wide site-packages directory (`/opt/homebrew/lib/python3.14/site-packages`). When the framework is copied into the app bundle, this symlink becomes broken.

**Investigation process:**
1. Downloaded and mounted the notarized DMG locally
2. Tested each framework individually with `spctl --assess`
3. All Qt frameworks: ✅ "accepted, source=Notarized Developer ID"
4. Python.framework: ❌ "rejected (invalid destination for symbolic link in bundle)"
5. Found broken symlink using: `find -type l ! -exec test -e {} \;`

## Solution ✅

**Remove the broken symlink and replace with empty directory:**
- The bundled Python has the `EXTERNALLY-MANAGED` marker (PEP 668)
- The app only uses the Python standard library and bundled scripts
- No third-party packages are installed or needed
- Python doesn't require `site-packages` to exist
- An empty directory maintains the expected structure without breaking spctl validation

**Implementation:**
After the Python.framework is fully assembled (regardless of merge path), the workflow now:
1. Detects broken `site-packages` symlink
2. Removes the symlink
3. Creates an empty `site-packages` directory in its place

**Key fix:** Previous attempt only fixed the arm64-only path, but builds actually use both x86_64 and arm64, so the elif branch runs. Fixed by moving cleanup to run after all merge paths complete.

## Changes Made

### 1. Code Signing Improvements

**Proper inside-out signing approach:**
- Sign standalone dylibs first
- Sign Python framework components (innermost to outermost)  
- Sign each Qt framework as a bundle (not just the main binary)
- Sign the main executable
- Sign the app bundle WITHOUT `--deep` flag

**Key insights:**
- Each framework must be signed as a bundle: `codesign --sign "$ID" QtFoo.framework`
- The `--deep` flag can fail on framework symlinks (use `--verify --strict` without `--deep`)
- Inside-out signing is the Apple-recommended approach

### 2. Python.framework Symlink Fix

**After Python.framework is assembled:**
- Detect broken `site-packages` symlink
- Remove broken symlink
- Replace with empty directory
- Runs for both universal binary and arm64-only builds

**Why this is safe:**
- The bundled Python is marked as `EXTERNALLY-MANAGED`
- No third-party packages are used or installed
- Python will work normally with an empty site-packages
- Fixes spctl validation on macOS 15

### 3. Validation and Release Upload Improvements

**Validation behavior:**
- Validates DMG signature and notarization
- Validates app bundle inside DMG with spctl
- **Workflow fails if validation doesn't pass**
- Artifacts are always uploaded for inspection

**Release upload behavior:**
- Files are uploaded to release **only if validation succeeds**
- Artifacts (DMG and pre-DMG bundle) always uploaded for debugging
- Clear failure messages explain what happened

## Current Status

🔄 **Testing Fix:** https://github.com/pythonscad/pythonscad/actions/runs/22037147233

**Note:** Previous run (22035344423) used an older commit before the fix was properly positioned in the workflow. The current run includes the complete fix.

The current build will:
1. ✅ Sign all frameworks properly (inside-out approach)
2. ✅ Remove broken `site-packages` symlink (all build paths)
3. ✅ Create valid Python.framework structure
4. ✅ Pass all spctl validation checks
5. 🎯 Produce a DMG that works on macOS 15 without errors

**Expected outcome:** The app should pass all validation and users should be able to run it directly without workarounds.

## Workaround for Current Release (v0.14.1)

Until the fixed release is published, users can bypass the error:

**Right-click method (easiest):**
1. Right-click on `PythonSCAD.app`
2. Choose "Open" → Click "Open" in dialog
3. After first time, can double-click normally

**Terminal method:**
```bash
xattr -cr /Applications/PythonSCAD.app
spctl --add /Applications/PythonSCAD.app
```

## Technical Details

**Framework Structure:**
- Frameworks have a standard structure: `Framework.framework/Versions/A/Binary`
- Standard symlinks: `Versions/Current -> A` and `Binary -> Versions/Current/Binary`
- These are valid symlinks pointing within the bundle

**Problem Symlink:**
- `site-packages -> ../../../../../../lib/python3.14/site-packages`
- Points **outside** the framework to a non-existent location
- macOS 15's spctl has stricter validation and rejects this

**Why the Fix Works:**
- Removes invalid symlink that points outside the bundle
- Creates valid directory structure
- No functional impact (app doesn't use external packages)
- Passes spctl validation

## References

- Apple TN2206: macOS Code Signing In Depth
- Apple Developer: Signing a Mac Product For Distribution
- PEP 668: Marking Python base environments as "externally managed"
- macOS 15 Sequoia Gatekeeper improvements

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>