### PR TITLE
fix(gui): guard against null modinst and path in right-click context menu

### DIFF
--- a/src/core/AST.h
+++ b/src/core/AST.h
@@ -22,7 +22,11 @@ public:
   }
 
   [[nodiscard]] std::string fileName() const { return path ? path->generic_string() : ""; }
-  [[nodiscard]] const fs::path& filePath() const { return *path; }
+  [[nodiscard]] const fs::path& filePath() const
+  {
+    static const fs::path empty_path;
+    return path ? *path : empty_path;
+  }
   [[nodiscard]] int firstLine() const { return first_line; }
   [[nodiscard]] int firstColumn() const { return first_col; }
   [[nodiscard]] int lastLine() const { return last_line; }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -231,7 +231,6 @@ int curl_download(const std::string& url, const std::string& path)
 }
 #endif  // ifdef ENABLE_PYTHON
 
-
 // Global application state
 unsigned int GuiLocker::guiLocked = 0;
 
@@ -2456,7 +2455,13 @@ void MainWindow::rightClick(QPoint position)
       if (step->name() == "root") {
         continue;
       }
+      if (!step->modinst) {
+        continue;
+      }
       auto location = step->modinst->location();
+      if (location.isNone()) {
+        continue;
+      }
       ss.str("");
 
       // Remove the "module" prefix if any as it induce confusion between the module declaration and
@@ -4149,7 +4154,6 @@ void MainWindow::setupConsole()
   this->console->setConsoleFont(
     GlobalPreferences::inst()->getValue("advanced/consoleFontFamily").toString(),
     GlobalPreferences::inst()->getValue("advanced/consoleFontSize").toUInt());
-
 
   const QString version =
     QString("<b>PythonSCAD %1</b>").arg(QString::fromStdString(std::string(openscad_versionnumber)));


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV crash when right-clicking the 3D view on certain objects.

**Backtrace:**
`MainWindow::rightClick()` → `get_library_for_path(location.filePath())` → `path_contains_file()` → `std::filesystem::path::has_filename()` — crash due to null/corrupt path.

**Root cause:**
The right-click context menu iterates CSG tree nodes to build a backtrace. Some nodes have a null `modinst` pointer or a `Location::NONE` location. Accessing `location.filePath()` on these crashes because `Location::filePath()` dereferences a `shared_ptr<fs::path>` without a null check (unlike `fileName()` which already has one).

**Fixes:**
1. **`MainWindow::rightClick()`**: Skip nodes with null `modinst` or `Location::NONE` in the backtrace loop.
2. **`Location::filePath()` in `AST.h`**: Add null guard matching the existing one in `fileName()` — return a static empty path instead of dereferencing a null `shared_ptr`.