### PR TITLE
add all openscad rendervars

### DIFF
--- a/src/core/RenderVariables.h
+++ b/src/core/RenderVariables.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "glview/Camera.h"
 class BuiltinContext;
 template <typename T>

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -100,7 +100,7 @@ void SourceFile::registerUse(const std::string& path, const Location& loc)
         const auto& venv = venvBinDirFromSettings();
         const auto& binDir = venv.empty() ? PlatformUtils::applicationPath() : venv;
 
-        if (!pythonRuntimeInitialized) initPython(binDir, "", 0.0);
+        if (!pythonRuntimeInitialized) initPython(binDir, "", nullptr);
         std::string error = evaluatePython(cmd);
         if (error.size() > 0) LOG(message_group::Error, Location::NONE, "", error.c_str());
       } else LOG(message_group::Error, "File not trusted '%1$s'", path);

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -233,7 +233,6 @@ int curl_download(const std::string& url, const std::string& path)
 }
 #endif  // ifdef ENABLE_PYTHON
 
-
 // Global application state
 unsigned int GuiLocker::guiLocked = 0;
 
@@ -322,7 +321,7 @@ void MainWindow::addMenuItemCB(QString callback)
   if (content.size() == 0) return;
   const auto& venv = venvBinDirFromSettings();
   const auto& binDir = venv.empty() ? PlatformUtils::applicationPath() : venv;
-  initPython(binDir, "", 0.0);
+  initPython(binDir, "", nullptr);
   evaluatePython(content);
   evaluatePython(cbstr);
   finishPython();
@@ -397,7 +396,7 @@ void MainWindow::customSetup(void)
   connect(this->addmenu_mapper, SIGNAL(mapped(QString)), this, SLOT(addMenuItemCB(QString)));
   const auto& venv = venvBinDirFromSettings();
   const auto& binDir = venv.empty() ? PlatformUtils::applicationPath() : venv;
-  initPython(binDir, "", 0.0);
+  initPython(binDir, "", nullptr);
   evaluatePython(content);
   addmenuitem_this = this;
   evaluatePython("setup()");
@@ -2017,7 +2016,14 @@ std::shared_ptr<SourceFile> MainWindow::parseDocument(EditorInterface *editor)
   } else if (editor->language == LANG_PYTHON) {
     const auto& venv = venvBinDirFromSettings();
     const auto& binDir = venv.empty() ? PlatformUtils::applicationPath() : venv;
-    initPython(venv, fnameba.constData(), this->animateWidget->getAnimTval());
+
+    const RenderVariables r = {
+      .preview = this->isPreview,
+      .time = this->animateWidget->getAnimTval(),
+      .camera = qglview->cam,
+    };
+
+    initPython(venv, fnameba.constData(), &r);
     this->activeEditor->resetHighlighting();
     this->activeEditor->parameterWidget->setEnabled(false);
     do {
@@ -4144,7 +4150,6 @@ void MainWindow::setupConsole()
   this->console->setConsoleFont(
     GlobalPreferences::inst()->getValue("advanced/consoleFontFamily").toString(),
     GlobalPreferences::inst()->getValue("advanced/consoleFontSize").toUInt());
-
 
   const QString version =
     QString("<b>PythonSCAD %1</b>").arg(QString::fromStdString(std::string(openscad_versionnumber)));

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -607,7 +607,7 @@ int cmdline(const CommandLine& cmd)
   std::string text_py = text;
   if (python_active) {
     if (cmd.animate.frames == 0) {
-      initPython("", cmd.filename, 0.0);
+      initPython("", cmd.filename, nullptr);
       auto error = evaluatePython(commandline_commands);
       error += evaluatePython(text_py);
       finishPython();
@@ -664,7 +664,7 @@ int cmdline(const CommandLine& cmd)
       render_variables.time = frame * (1.0 / cmd.animate.frames);
 #ifdef ENABLE_PYTHON
       if (python_active) {
-        initPython(PlatformUtils::applicationPath(), cmd.filename, render_variables.time);
+        initPython(PlatformUtils::applicationPath(), cmd.filename, &render_variables);
         auto error = evaluatePython(text_py);
         if (error.size() > 0) LOG(error.c_str());
         finishPython();

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -434,7 +434,7 @@ Outline2d python_getprofile(void *v_cbfunc, int fn, double arg)
 {
   PyObject *cbfunc = reinterpret_cast<PyObject *>(v_cbfunc);
   Outline2d result;
-  if (pythonInitDict == nullptr) initPython(PlatformUtils::applicationPath(), "", 0.0);
+  if (pythonInitDict == nullptr) initPython(PlatformUtils::applicationPath(), "", nullptr);
   PyObject *args = PyTuple_Pack(1, PyFloat_FromDouble(arg));
   PyObject *polygon = PyObject_CallObject(cbfunc, args);
   Py_XDECREF(args);
@@ -713,7 +713,7 @@ void openscad_object_callback(PyObject *obj)
   }
 }
 #endif
-void initPython(const std::string& binDir, const std::string& scriptpath, double time)
+void initPython(const std::string& binDir, const std::string& scriptpath, const RenderVariables *r)
 {
   static bool alreadyTried = false;
   if (alreadyTried) return;
@@ -863,7 +863,25 @@ void initPython(const std::string& binDir, const std::string& scriptpath, double
     }
   }
   std::ostringstream stream;
-  stream << "t=" << time << "\nphi=" << 2 * G_PI * time << "\n" << commandline_commands << "\n";
+  if (r != nullptr) {
+    stream << "preview=" << (r->preview ? "True" : "False") << "\n";
+
+    stream << "t=" << r->time << "\n";
+    stream << "phi=" << 2 * G_PI * r->time << "\n";
+
+    const auto vpr = r->camera.getVpr();
+    stream << "vpr=[" << vpr.x() << "," << vpr.y() << "," << vpr.z() << "]\n";
+
+    const auto vpt = r->camera.getVpt();
+    stream << "vpt=[" << vpt.x() << "," << vpt.y() << "," << vpt.z() << "]\n";
+
+    const auto vpd = r->camera.zoomValue();
+    stream << "vpd=" << vpd << "\n";
+
+    const auto vpf = r->camera.fovValue();
+    stream << "vpf=" << vpf << "\n";
+  }
+  stream << commandline_commands << "\n";
   PyRun_String(stream.str().c_str(), Py_file_input, pythonInitDict.get(), pythonInitDict.get());
   customizer_parameters_finished = customizer_parameters;
   customizer_parameters.clear();
@@ -1353,7 +1371,7 @@ int Py_RunMain_ipython(void)
 
 void ipython(void)
 {
-  initPython(PlatformUtils::applicationPath(), "", 0.0);
+  initPython(PlatformUtils::applicationPath(), "", nullptr);
   Py_RunMain_ipython();
   return;
 }

--- a/src/python/python_public.h
+++ b/src/python/python_public.h
@@ -7,6 +7,7 @@
 #include "core/function.h"
 #include "geometry/Polygon2d.h"
 #include <core/Selection.h>
+#include <core/RenderVariables.h>
 
 extern bool python_active;
 extern bool python_trusted;
@@ -16,7 +17,7 @@ extern AssignmentList customizer_parameters_finished;
 void python_export_obj_att(std::ostream& output);
 std::string python_version(void);
 
-void initPython(const std::string& binDir, const std::string& scriptpath, double time);
+void initPython(const std::string& binDir, const std::string& scriptpath, const RenderVariables *r);
 std::string evaluatePython(const std::string& code, bool dry_run = false);
 void finishPython();
 void python_lock(void);


### PR DESCRIPTION
All render vars from openscad are available in pythonscad, too.
This involves preview, t, vpt, vpr, vpd, vpf.

