### PR TITLE
fix: open New Window with Untitled.py tab instead of Untitled.scad

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -58,7 +58,7 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
   connect(parent->editActionZoomTextIn, &QAction::triggered, this, &TabManager::zoomIn);
   connect(parent->editActionZoomTextOut, &QAction::triggered, this, &TabManager::zoomOut);
 
-  createTab(filename);
+  createTab(filename.isEmpty() ? QString("Untitled.py") : filename);
 
   // Disable the closing button for the first tabbar
   setTabsCloseButtonVisibility(0, false);
@@ -797,10 +797,11 @@ bool TabManager::saveAs(EditorInterface *edt)
 #ifdef ENABLE_PYTHON
   QString selectedFilter;
   QString pythonFilter = _("PythonSCAD Designs (*.py)");
-  auto filename = QFileDialog::getSaveFileName(parent, _("Save File"), dir, QString("%1").arg(pythonFilter),
-                                               &selectedFilter);
+  auto filename = QFileDialog::getSaveFileName(parent, _("Save File"), dir,
+                                               QString("%1").arg(pythonFilter), &selectedFilter);
 #else
-  auto filename = QFileDialog::getSaveFileName(parent, _("Save File"), dir, _("OpenSCAD Designs (*.scad)"));
+  auto filename =
+    QFileDialog::getSaveFileName(parent, _("Save File"), dir, _("OpenSCAD Designs (*.scad)"));
 #endif
   if (filename.isEmpty()) {
     return false;


### PR DESCRIPTION
## Summary

- Fixes #472. When using **File > New Window**, the new window opened with an "Untitled.scad" tab instead of "Untitled.py".
- The `TabManager` constructor now passes `"Untitled.py"` to `createTab` when no filename is provided, matching the behavior of the welcome dialog and the **File > New** action.

## Test plan

- [x] Open PythonSCAD and use **File > New Window** — verify the new window has an "Untitled.py" tab
- [x] Open PythonSCAD and click "New" in the welcome dialog — verify it still opens "Untitled.py"
- [x] Open PythonSCAD with a file argument — verify it opens that file correctly

Made with [Cursor](https://cursor.com)