### PR TITLE
fix: use Fusion style with explicit palettes for reliable cross-platform theming

### DIFF
--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -22,7 +22,7 @@
 #include <cassert>
 #include <exception>
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && defined(ENABLE_DBUS)
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusVariant>
@@ -35,9 +35,6 @@ OpenSCADApp::OpenSCADApp(int& argc, char **argv) : QApplication(argc, argv)
 #ifdef Q_OS_MACOS
   this->installEventFilter(new SCADEventFilter(this));
 #endif
-
-  // Remember platform default style so we can restore it for light/native theme
-  platformStyleName = style()->objectName();
 
   // Note: It may be tempting to add more initialization code here, but keep in mind that this is run as
   // part of QApplication initialization, so it's usually better to that in the main gui() function after
@@ -112,7 +109,7 @@ void OpenSCADApp::setRenderBackend3D(RenderBackend3D backend)
 
 static bool isSystemDarkTheme()
 {
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && defined(ENABLE_DBUS)
   // On Linux, neither Qt's colorScheme() API (Qt 6.5+) nor the palette
   // heuristic are reliable: GNOME's Qt platform plugin can read the
   // gtk-theme name (e.g. "Adwaita-dark") instead of the actual dark-style

--- a/src/gui/OpenSCADApp.h
+++ b/src/gui/OpenSCADApp.h
@@ -38,7 +38,6 @@ public:
 
 private:
   QProgressDialog *fontCacheDialog{nullptr};
-  QString platformStyleName;
   QPalette themePalette;
 };
 


### PR DESCRIPTION
## Summary

- Fixes invisible menu text when using Light Mode on Windows (#482)
- Fixes light theme showing dark backgrounds on startup when the system theme is dark (Linux GNOME/Wayland)
- Fixes "Auto (follow system)" theme incorrectly starting in dark mode on a light desktop (Linux)
- Uses Fusion style with explicit hardcoded palettes for all theme modes for consistent cross-platform behavior

## Root cause

Multiple interrelated issues in `setGuiTheme()` / `setApplicationFont()`:

1. **Windows menu text invisible in Light Mode:** `setApplicationFont()` applies a global `*` stylesheet to set fonts. On Windows, the native style relies on palette-based rendering for menus, and the stylesheet disrupted this, making menu text invisible (white on white). The fix is to re-apply the explicit theme palette after each `setStyleSheet()` call, since `setStyleSheet()` triggers platform-theme plugins to re-apply the system palette.

2. **Linux light theme dark on startup:** The light mode code path relied on `QStyle::standardPalette()` to obtain light colors. However, platform theme plugins (e.g. QGnomePlatform on GNOME/Wayland) inject system dark colors into **every** Qt style — including Fusion — making `standardPalette()` return dark colors on a dark system.

3. **Linux "Auto" mode wrong on startup:** `isSystemDarkTheme()` used Qt's `colorScheme()` API and a palette-based heuristic, both of which are unreliable on Linux. GNOME's Qt platform plugin reads the gtk-theme name (e.g. "Adwaita-dark") instead of the actual dark-style preference.

## Fix

- Use **Fusion style for all theme modes** (light, dark, auto). Native platform styles offer little benefit when we override the palette anyway, and they are the source of the platform-theme injection problems.
- Define **explicit hardcoded palettes** for both light and dark themes, so platform theme plugins cannot override them.
- **Re-apply the theme palette after `setStyleSheet()`** in `setApplicationFont()`, because the global stylesheet triggers platform-theme plugins to re-apply the system palette.
- On Linux (when built with D-Bus support), use the **XDG Desktop Portal** to detect the system color scheme — this is the authoritative source used by Nautilus and other GNOME/KDE apps. Falls back to Qt's `colorScheme()` API on Windows/macOS where it works correctly.
- **Remove unused `platformStyleName`** member (no longer needed since we always use Fusion).
- **Guard D-Bus includes/calls with `ENABLE_DBUS`** so the code compiles on Linux builds where QtDBus is not available.

## Test plan

- [x] Verify on Linux (GNOME/Wayland, dark system theme) that "light" preference persists correctly across restarts
- [x] Verify switching between light/dark/auto works at runtime on Linux
- [x] Verify "auto" follows the system theme correctly on Linux (tested GNOME Dark Style toggle)
- [x] Verify on Windows 11 that menus are readable in Light Mode
- [x] Verify on Windows 11 that font changes are properly applied
- [x] Verify on Windows 11 that "auto" works from application start
- [x] Verify on macOS that theme switching works correctly
- [x] Verify custom font settings (family and size) still apply globally
- [x] Run existing test suite (`ctest`) to check for regressions

Closes #482