### PR TITLE
feat: prepare project for PyPI publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,65 @@
+# Builds a source distribution (sdist) and publishes it to PyPI.
+# Triggered when a GitHub Release is fully published (not prerelease).
+#
+# Prerequisites (one-time setup):
+#   1. Create the "pythonscad" project on PyPI (https://pypi.org)
+#   2. Configure "trusted publishing" for this repository under:
+#      PyPI project settings -> Publishing -> Add a new publisher
+#      - Owner: pythonscad
+#      - Repository: pythonscad
+#      - Workflow name: publish-to-pypi.yml
+#      - Environment name: pypi
+name: Publish to PyPI
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Fetch tags for version detection
+        run: |
+          git fetch --unshallow --tags || git fetch --tags
+          git describe --tags --always --dirty
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build frontend
+        run: pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: build-sdist
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
+include VERSION.txt
+include COPYING
+include pyproject.toml
 include ./src/*.h
 include ./src/platform/*.h
 include ./src/python/*.h
@@ -5,11 +8,13 @@ include ./src/io/*.h
 include ./src/libsvg/*.h
 include ./src/core/*.h
 include ./src/core/*.hxx
+include ./src/core/*.y
+include ./src/core/*.l
 include ./src/core/customizer/*.h
 include ./src/utils/*.h
 include ./src/glview/*.h
+include ./src/genlang/*.h
 recursive-include ./src/ext/ *.h *.hpp
 recursive-include ./src/geometry/ *.h
 recursive-include ./src/gui/ *.h
-recursive-include ./submodules/ *.h
-
+recursive-include ./submodules/ *.h *.hpp *.cpp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pythonscad"
+dynamic = ["version"]
+description = "Python interface to OpenSCAD — script-based 3D modeling with Python as a native language"
+readme = "README.md"
+license = "GPL-2.0-or-later"
+requires-python = ">=3.10"
+authors = [
+    { name = "Guenther Sohler", email = "guenther.sohler@gmail.com" },
+]
+keywords = ["3d", "modeling", "cad", "openscad", "3d-printing", "csg", "python"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Manufacturing",
+    "Intended Audience :: Science/Research",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia :: Graphics :: 3D Modeling",
+    "Topic :: Scientific/Engineering",
+]
+
+[project.urls]
+Homepage = "https://pythonscad.org"
+Documentation = "https://pythonscad.org/tutorial/site/index.html"
+Repository = "https://github.com/pythonscad/pythonscad"
+Issues = "https://github.com/pythonscad/pythonscad/issues"
+Changelog = "https://github.com/pythonscad/pythonscad/blob/master/CHANGELOG.md"

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,223 @@ import subprocess
 import os
 import shutil
 
+
+def get_version():
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "VERSION.txt")) as f:
+        return f.read().strip()
+
+
+def pkg_config_flags(packages, flag):
+    """Query pkg-config for the given flag (e.g. '--cflags-only-I', '--libs-only-l')."""
+    try:
+        out = subprocess.check_output(
+            ["pkg-config", flag] + packages,
+            text=True, stderr=subprocess.DEVNULL,
+        )
+        return out.strip().split()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+
+def pkg_config_exists(package):
+    """Return True if pkg-config can find the given package."""
+    try:
+        subprocess.check_call(
+            ["pkg-config", "--exists", package],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def pkg_config_version(package):
+    """Return the version string for a pkg-config package, or None."""
+    try:
+        out = subprocess.check_output(
+            ["pkg-config", "--modversion", package],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+        return out.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def get_pkg_config_include_dirs():
+    """Return include directories discovered via pkg-config."""
+    pkgs = ["eigen3", "harfbuzz", "libxml-2.0", "freetype2", "glib-2.0", "cairo"]
+    raw = pkg_config_flags(pkgs, "--cflags-only-I")
+    dirs = [flag[2:] for flag in raw if flag.startswith("-I")]
+
+    # Fallback paths used when pkg-config is unavailable or incomplete
+    fallbacks = [
+        "/usr/include/eigen3",
+        "/usr/include/harfbuzz",
+        "/usr/include/libxml2",
+        "/usr/include/freetype2",
+        "/usr/include/glib-2.0",
+        "/usr/include/cairo",
+        "/usr/lib64/glib-2.0/include",
+        "/usr/lib/x86_64-linux-gnu/glib-2.0/include",
+    ]
+    for fb in fallbacks:
+        if fb not in dirs and os.path.isdir(fb):
+            dirs.append(fb)
+
+    return dirs
+
+
+def get_pkg_config_libraries():
+    """Return library names discovered via pkg-config."""
+    pkgs = ["freetype2", "libxml-2.0", "fontconfig", "glib-2.0", "harfbuzz"]
+    raw = pkg_config_flags(pkgs, "--libs-only-l")
+    libs = [flag[2:] for flag in raw if flag.startswith("-l")]
+
+    required = ["freetype", "xml2", "fontconfig", "double-conversion", "gmp",
+                "harfbuzz", "mpfr", "glib-2.0"]
+    for lib in required:
+        if lib not in libs:
+            libs.append(lib)
+
+    return libs
+
+
+def detect_lib3mf():
+    """Detect lib3mf and return (sources, include_dirs, libraries, defines) or dummy fallback."""
+    # lib3mf v2 uses pkg-config name "lib3mf", v1 uses "lib3MF"
+    for pkg_name in ("lib3mf", "lib3MF"):
+        ver = pkg_config_version(pkg_name)
+        if ver is None:
+            continue
+
+        inc_raw = pkg_config_flags([pkg_name], "--cflags-only-I")
+        inc_dirs = [f[2:] for f in inc_raw if f.startswith("-I")]
+        lib_raw = pkg_config_flags([pkg_name], "--libs-only-l")
+        libraries = [f[2:] for f in lib_raw if f.startswith("-l")]
+
+        major = int(ver.split(".")[0])
+        if major >= 2:
+            sources = ["src/io/export_3mf_v2.cc", "src/io/import_3mf_v2.cc"]
+            print(f"lib3mf: found v{ver} (v2 API)")
+        else:
+            sources = ["src/io/export_3mf_v1.cc", "src/io/import_3mf_v1.cc"]
+            print(f"lib3mf: found v{ver} (v1 API)")
+
+        defines = [("ENABLE_LIB3MF", "1")]
+        return sources, inc_dirs, libraries, defines
+
+    print("lib3mf: not found, using dummy stubs")
+    sources = ["src/io/export_3mf_dummy.cc", "src/io/import_3mf_dummy.cc"]
+    return sources, [], [], []
+
+
+def detect_libfive():
+    """Detect libfive submodule and return (sources, include_dirs, defines) or empty fallback."""
+    libfive_include = os.path.join("submodules", "libfive", "libfive", "include")
+    libfive_src = os.path.join("submodules", "libfive", "libfive", "src")
+
+    if not os.path.isdir(libfive_src):
+        print("libfive: submodule not found, skipping")
+        return [], [], []
+
+    src_prefix = libfive_src + os.sep
+    sources = [
+        src_prefix + "eval/base.cpp",
+        src_prefix + "eval/deck.cpp",
+        src_prefix + "eval/eval_interval.cpp",
+        src_prefix + "eval/eval_jacobian.cpp",
+        src_prefix + "eval/eval_array.cpp",
+        src_prefix + "eval/eval_deriv_array.cpp",
+        src_prefix + "eval/eval_feature.cpp",
+        src_prefix + "eval/tape.cpp",
+        src_prefix + "eval/feature.cpp",
+        src_prefix + "render/discrete/heightmap.cpp",
+        src_prefix + "render/discrete/voxels.cpp",
+        src_prefix + "render/brep/contours.cpp",
+        src_prefix + "render/brep/edge_tables.cpp",
+        src_prefix + "render/brep/manifold_tables.cpp",
+        src_prefix + "render/brep/mesh.cpp",
+        src_prefix + "render/brep/neighbor_tables.cpp",
+        src_prefix + "render/brep/progress.cpp",
+        src_prefix + "render/brep/dc/marching.cpp",
+        src_prefix + "render/brep/dc/dc_contourer.cpp",
+        src_prefix + "render/brep/dc/dc_mesher.cpp",
+        src_prefix + "render/brep/dc/dc_neighbors2.cpp",
+        src_prefix + "render/brep/dc/dc_neighbors3.cpp",
+        src_prefix + "render/brep/dc/dc_worker_pool2.cpp",
+        src_prefix + "render/brep/dc/dc_worker_pool3.cpp",
+        src_prefix + "render/brep/dc/dc_tree2.cpp",
+        src_prefix + "render/brep/dc/dc_tree3.cpp",
+        src_prefix + "render/brep/dc/dc_xtree2.cpp",
+        src_prefix + "render/brep/dc/dc_xtree3.cpp",
+        src_prefix + "render/brep/dc/dc_object_pool2.cpp",
+        src_prefix + "render/brep/dc/dc_object_pool3.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_debug.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_worker_pool2.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_worker_pool3.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_neighbors2.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_neighbors3.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_tree2.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_tree3.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_xtree2.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_xtree3.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_object_pool2.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_object_pool3.cpp",
+        src_prefix + "render/brep/hybrid/hybrid_mesher.cpp",
+        src_prefix + "render/brep/simplex/simplex_debug.cpp",
+        src_prefix + "render/brep/simplex/simplex_neighbors2.cpp",
+        src_prefix + "render/brep/simplex/simplex_neighbors3.cpp",
+        src_prefix + "render/brep/simplex/simplex_worker_pool2.cpp",
+        src_prefix + "render/brep/simplex/simplex_worker_pool3.cpp",
+        src_prefix + "render/brep/simplex/simplex_tree2.cpp",
+        src_prefix + "render/brep/simplex/simplex_tree3.cpp",
+        src_prefix + "render/brep/simplex/simplex_xtree2.cpp",
+        src_prefix + "render/brep/simplex/simplex_xtree3.cpp",
+        src_prefix + "render/brep/simplex/simplex_object_pool2.cpp",
+        src_prefix + "render/brep/simplex/simplex_object_pool3.cpp",
+        src_prefix + "render/brep/simplex/simplex_mesher.cpp",
+        src_prefix + "render/brep/vol/vol_neighbors.cpp",
+        src_prefix + "render/brep/vol/vol_object_pool.cpp",
+        src_prefix + "render/brep/vol/vol_tree.cpp",
+        src_prefix + "render/brep/vol/vol_worker_pool.cpp",
+        src_prefix + "solve/solver.cpp",
+        src_prefix + "tree/opcode.cpp",
+        src_prefix + "tree/archive.cpp",
+        src_prefix + "tree/data.cpp",
+        src_prefix + "tree/deserializer.cpp",
+        src_prefix + "tree/serializer.cpp",
+        src_prefix + "tree/tree.cpp",
+        src_prefix + "tree/operations.cpp",
+        src_prefix + "oracle/oracle_clause.cpp",
+        src_prefix + "oracle/transformed_oracle.cpp",
+        src_prefix + "oracle/transformed_oracle_clause.cpp",
+        src_prefix + "libfive.cpp",
+    ]
+
+    stdlib_dir = os.path.join("submodules", "libfive", "libfive", "stdlib")
+    if os.path.isdir(stdlib_dir):
+        sources.append(os.path.join(stdlib_dir, "stdlib.cpp"))
+        sources.append(os.path.join(stdlib_dir, "stdlib_impl.cpp"))
+
+    sources.append("src/python/FrepNode.cc")
+
+    include_dirs = [libfive_include]
+    defines = [
+        ("ENABLE_LIBFIVE", "1"),
+        ("GIT_TAG", '"N/A"'),
+        ("GIT_REV", '"N/A"'),
+        ("GIT_BRANCH", '"N/A"'),
+    ]
+
+    print(f"libfive: enabled ({len(sources)} source files)")
+    return sources, include_dirs, defines
+
+
 class BuildExtWithLexYacc(build_ext):
     """Custom build_ext command to run lex/yacc before building extension modules."""
 
     def run(self):
-
         yacc_src = "src/core/parser.y"
         lex_src = "src/core/lexer.l"
 
@@ -24,19 +236,19 @@ class BuildExtWithLexYacc(build_ext):
             return src_time > target_time
 
         if needs_rebuild(yacc_src, [yacc_out, yacc_hdr]):
-            print(f"→ Generiere Yacc: {yacc_src}")
+            print(f"Generating Yacc: {yacc_src}")
             subprocess.run(["bison", "-d", "-p", "parser", yacc_src], check=True)
             os.rename("parser.tab.c", yacc_out)
             shutil.copyfile("parser.tab.h", "src/core/parser.hxx")
             os.rename("parser.tab.h", yacc_hdr)
         else:
-            print(f"✓ {yacc_src} is recent")
+            print(f"{yacc_src} is up to date")
 
         if needs_rebuild(lex_src, [lex_out]):
-            print(f"→ Generiere Lex: {lex_src}")
-            subprocess.run(["lex",  "-o", lex_out,  lex_src], check=True)
+            print(f"Generating Lex: {lex_src}")
+            subprocess.run(["lex", "-o", lex_out, lex_src], check=True)
         else:
-            print(f"✓ {lex_src} is recent")
+            print(f"{lex_src} is up to date")
 
         super().run()
 
@@ -185,7 +397,6 @@ def main():
               "src/io/export_svg.cc",
               "src/io/export_gcode.cc",
               "src/io/export_foldable.cc",
-              "src/io/export_3mf_dummy.cc",
               "src/io/export_ps.cc",
               "src/io/export_wrl.cc",
               "src/io/export_amf.cc",
@@ -198,7 +409,6 @@ def main():
               "src/io/import_json.cc",
               "src/io/import_obj.cc",
               "src/io/import_step.cc",
-              "src/io/import_3mf_dummy.cc",
               "src/io/import_amf.cc",
               "src/io/import_nef.cc",
               "src/io/import_svg.cc",
@@ -275,67 +485,55 @@ def main():
               ]
     lodepng = [ "src/ext/lodepng/lodepng.cpp" ]
 
-    pythonscad_ext = Extension("openscad"
-        , sources = root + python + geometry + ext + io + libsvg + core +  manifold +
-        clipper + utils + platform  + glview + lex_yacc + lodepng
-        ,include_dirs = [
-                  ".",
-                  "src",
-                  "src/core",
-                  "src/ext",
-                  "src/geometry",
-                  "src/io",
-                  "src/utils",
-                  "src/platform",
-                  "src/ext/libtess2/Include",
-                  "submodules/Clipper2/CPP/Clipper2Lib/include",
-                  "submodules/manifold/include",
-                  "/usr/include/eigen3",
-                  "/usr/include/harfbuzz",
-                  "/usr/include/libxml2",
-                  "/usr/include/freetype2",
-                  "/usr/include/glib-2.0",
-                  "/usr/include/cairo",
-                  "/usr/lib64/glib-2.0/include",
-                  "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
-                ],libraries=[
-                  "freetype",
-                  "xml2",
-                  "fontconfig",
-                  "double-conversion",
-                  "gmp",
-                  "harfbuzz",
-                  "mpfr"
-                ],define_macros=[
-                  ("ENABLE_PYTHON","1"),
-                  ("ENABLE_CGAL","1"),
-                  ("ENABLE_MANIFOLD","1"),
-                  ("EXPERIMENTAL","1"),
-                  ("OPENSCAD_NOGUI","1"),
-                  ("PYTHON_EXECUTABLE_NAME","\"pythonscad\""),
-                  ("MANIFOLD_PAR","-1"),
-                  ("OPENSCAD_YEAR","2025"),
-                  ("OPENSCAD_MONTH","2"),
-                  ("STACKSIZE","524288")
-                ],undef_macros=[
-                ], extra_link_args=[
-                        "-l", "glib-2.0"
-                ],  extra_compile_args=[
-                ])
+    # Detect optional dependencies
+    lib3mf_sources, lib3mf_incdirs, lib3mf_libs, lib3mf_defines = detect_lib3mf()
+    libfive_sources, libfive_incdirs, libfive_defines = detect_libfive()
 
-    setup(name="pythonscad",
-          version="2025.10.31",
-          description="Python interface to openscad",
-          url="https://pythonscad.org",
-          author="Guenther Sohler",
-          author_email="guenther.sohler@gmail.com",
-          license="MIT",
-          classifiers=[
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.11" ],
-          cmdclass={"build_ext": BuildExtWithLexYacc},
-          ext_modules=[ pythonscad_ext ]
-          )
+    project_include_dirs = [
+        ".",
+        "src",
+        "src/core",
+        "src/ext",
+        "src/geometry",
+        "src/io",
+        "src/utils",
+        "src/platform",
+        "src/ext/libtess2/Include",
+        "submodules/Clipper2/CPP/Clipper2Lib/include",
+        "submodules/manifold/include",
+    ] + get_pkg_config_include_dirs() + lib3mf_incdirs + libfive_incdirs
+
+    all_sources = (root + python + geometry + ext + io + lib3mf_sources +
+                   libsvg + core + manifold + clipper + utils + platform +
+                   glview + lex_yacc + lodepng + libfive_sources)
+
+    all_defines = [
+        ("ENABLE_PYTHON", "1"),
+        ("ENABLE_CGAL", "1"),
+        ("ENABLE_MANIFOLD", "1"),
+        ("EXPERIMENTAL", "1"),
+        ("OPENSCAD_NOGUI", "1"),
+        ("PYTHON_EXECUTABLE_NAME", '"pythonscad"'),
+        ("MANIFOLD_PAR", "-1"),
+        ("OPENSCAD_YEAR", "2025"),
+        ("OPENSCAD_MONTH", "2"),
+        ("STACKSIZE", "524288"),
+    ] + lib3mf_defines + libfive_defines
+
+    pythonscad_ext = Extension(
+        "openscad",
+        sources=all_sources,
+        include_dirs=project_include_dirs,
+        libraries=get_pkg_config_libraries() + lib3mf_libs,
+        define_macros=all_defines,
+    )
+
+    setup(
+        version=get_version(),
+        cmdclass={"build_ext": BuildExtWithLexYacc},
+        ext_modules=[pythonscad_ext],
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/web/docs/installation.md
+++ b/web/docs/installation.md
@@ -6,25 +6,35 @@ This page explains how to install PythonSCAD on common platforms.
 
 ## Linux (Debian / Ubuntu / APT)
 
-PythonSCAD packages are published to an APT repository. See <https://repos.pythonscad.org/apt/> for detailed instructions on how to use it.
+PythonSCAD packages are published to an APT repository.
+See <https://repos.pythonscad.org/apt/> for detailed instructions.
 
-Alternatively you can download the latest Debian package from our [downlaods page](downloads.md).
+Alternatively you can download the latest Debian package
+from our [downloads page](downloads.md).
 
 ## Linux (Fedora / CentOS / RHEL / YUM / DNF)
 
-PythonSCAD packages are published to a YUM repository. See <https://repos.pythonscad.org/yum/> for detailed instructions on how to use it.
+PythonSCAD packages are published to a YUM repository.
+See <https://repos.pythonscad.org/yum/> for detailed instructions.
 
-Alternatively you can download the latest RPM package from our [downlaods page](downloads.md).
+Alternatively you can download the latest RPM package
+from our [downloads page](downloads.md).
 
 ## GNU Guix
 
-We try to keep PythonSCAD up to date in GNU Guix by periodically submitting updated package defintions. You can just run `guix install pythonscad` to install it or use one of the other methods (e.g. guix home).
+We try to keep PythonSCAD up to date in GNU Guix by periodically
+submitting updated package definitions. You can run
+`guix install pythonscad` to install it or use one of the other
+methods (e.g. guix home).
 
 ## AppImage (Linux)
 
-AppImages should be distribution agnostic and should run on most Linux distributions.
+AppImages should be distribution agnostic and should run on most
+Linux distributions.
 
-Download the AppImage from the [downlaods page](downloads.md). To use it system-wide you can make it executable and move it into a directory on your `PATH` (for example `/usr/local/bin`):
+Download the AppImage from the [downloads page](downloads.md).
+To use it system-wide you can make it executable and move it into
+a directory on your `PATH` (for example `/usr/local/bin`):
 
 ```shell
 chmod +x PythonSCAD-<version>.AppImage
@@ -37,60 +47,102 @@ sudo mv PythonSCAD-<version>.AppImage /usr/local/bin/pythonscad
 
 We provide both a ZIP distribution and an installer for Windows.
 
-- ZIP: extract the zip somewhere convenient and run the contained `pythonscad.exe`.
+- ZIP: extract the zip somewhere convenient and run the contained
+  `pythonscad.exe`.
 - Installer: run the installer to install PythonSCAD on your system.
 
 Note about digital signing:
 
-Currently the installer and binaries are not digitally signed with a Microsoft Authenticode certificate. This means Windows SmartScreen or antivirus software may show warnings or block execution. Typical steps to run unsigned software on Windows:
+Currently the installer and binaries are not digitally signed with
+a Microsoft Authenticode certificate. This means Windows SmartScreen
+or antivirus software may show warnings or block execution. Typical
+steps to run unsigned software on Windows:
 
-- If Windows shows a SmartScreen warning, click **More info** then **Run anyway**.
-- If Windows blocks the file, right-click the downloaded file, choose **Properties**, and check **Unblock** (if present), then click **OK** and retry.
-- You may need to run the installer as Administrator for system-wide installation.
+- If Windows shows a SmartScreen warning, click **More info** then
+  **Run anyway**.
+- If Windows blocks the file, right-click the downloaded file,
+  choose **Properties**, and check **Unblock** (if present), then
+  click **OK** and retry.
+- You may need to run the installer as Administrator for
+  system-wide installation.
 
 ---
 
 ## macOS
 
-The macOS application bundle provided is not yet signed with an Apple Developer ID. Gatekeeper may prevent the app from opening on first launch. Typical ways to open an unsigned app:
+The macOS application bundle provided is not yet signed with an
+Apple Developer ID. Gatekeeper may prevent the app from opening on
+first launch. Typical ways to open an unsigned app:
 
-1. Right-click (or control-click) the app in Finder and choose **Open**. In the dialog that appears, click **Open** again to allow launching the app this time.
-2. If that does not work, you can remove the quarantine attribute from the app in Terminal (use with caution):
+1. Right-click (or control-click) the app in Finder and choose
+   **Open**. In the dialog that appears, click **Open** again to
+   allow launching the app this time.
+2. If that does not work, you can remove the quarantine attribute
+   from the app in Terminal (use with caution):
 
 ```shell
 sudo xattr -rd com.apple.quarantine /Applications/PythonSCAD.app
 ```
 
-Using the GUI **Open** option is usually the safest way to grant permission for a single unsigned app.
+Using the GUI **Open** option is usually the safest way to grant
+permission for a single unsigned app.
 
 ## Installing via Python (pip / pipx)
 
-PythonSCAD can also be used as a Python package, but note that the project is not published on PyPI yet. That means `pip install pythonscad` will not work from PyPI. Workarounds:
+PythonSCAD is available on [PyPI](https://pypi.org/project/pythonscad/).
+Installing via pip compiles the C++ extension from source, so you
+will need the build dependencies listed below.
 
-- Install from a local checkout or a wheel file:
+### Build dependencies
+
+A C++17 compiler, `pkg-config`, `bison`, `flex`, and the following
+libraries must be installed before running `pip install`:
+
+- Eigen3, CGAL, GMP, MPFR
+- Freetype2, Fontconfig, HarfBuzz
+- libxml2, glib2, Cairo
+- double-conversion
+
+On Debian/Ubuntu you can install them with:
 
 ```shell
-# from the current repository root
+sudo ./scripts/get-dependencies.py --yes --profile pythonscad-qt5
+```
+
+### Install from PyPI
+
+```shell
+pip install pythonscad
+```
+
+### Alternative: install from source
+
+- Install from a local checkout:
+
+```shell
 pip install .
 
 # or install in editable/development mode
 pip install -e .
 ```
 
-- Install directly from the Git repository (if you want a user-local install):
+- Install directly from the Git repository:
 
 ```shell
 pip install git+https://github.com/pythonscad/pythonscad.git
 ```
 
-- `pipx` can be used to install the CLI in an isolated environment (use the same git/local path above):
+- `pipx` can be used to install the CLI in an isolated environment:
 
 ```shell
-pipx install --spec=git+https://github.com/pythonscad/pythonscad.git pythonscad
+pipx install pythonscad
 ```
 
-Remember these installs are local to the Python environment used by `pip`/`pipx` and do not create system packages.
+Remember these installs are local to the Python environment used
+by `pip`/`pipx` and do not create system packages.
 
 ---
 
-If you encounter problems installing or running the applications, please [create an issue][(](https://github.com/pythonscad/pythonscad/issues/new/choose)) on our GitHub page.
+If you encounter problems installing or running the applications,
+please [create an issue](https://github.com/pythonscad/pythonscad/issues/new/choose)
+on our GitHub page.


### PR DESCRIPTION
## Summary

- Add pyproject.toml with PEP 621 metadata, dynamic version from VERSION.txt, GPL-2.0-or-later license
- Rework setup.py: pkg-config for portable library detection, auto-detect lib3mf (v1/v2) and libfive at build time
- Add publish-to-pypi.yml workflow for trusted OIDC publishing on release
- Update MANIFEST.in for complete sdist (VERSION.txt, COPYING, parser grammars, submodule cpp)
- Rewrite installation.md pip section with PyPI instructions and fix pre-existing lint issues

## One-time setup before first publish

1. Register pythonscad on PyPI (or use pending publisher)
2. Configure trusted publishing: Owner pythonscad, Repo pythonscad, Workflow publish-to-pypi.yml, Environment pypi
3. Create GitHub environment pypi with deployment branch restriction to master

## Test plan

- [x] pip install -e . succeeds in fresh venv (~43 min compile)
- [x] Smoke test passes
- [x] lib3mf v1 and libfive auto-detected and compiled in
- [x] Version reads 0.16.0 from VERSION.txt
- [x] CI pip-build-and-test workflow passes

Made with [Cursor](https://cursor.com)