### PR TITLE
fix(gui): prevent dialog flickering on Qt5 caused by resize oscillation

### DIFF
--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -11,7 +11,9 @@
 #include "geometry/cgal/CGALCache.h"
 #endif
 #include <QApplication>
+#include <QDialog>
 #include <QEvent>
+#include <QMessageBox>
 #include <QObject>
 #include <QProgressDialog>
 #include <QString>
@@ -46,53 +48,39 @@ OpenSCADApp::~OpenSCADApp()
   delete this->fontCacheDialog;
 }
 
-#include <QDialog>
-#include <QMessageBox>
-
 bool OpenSCADApp::notify(QObject *object, QEvent *event)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-  // Qt5 + Fusion style: QMessageBox::resizeEvent() calls updateSize() which
-  // calls resize() when sizeHint() differs from the current size.  With
-  // word-wrapped text the hint depends on the current width, so sizeHint()
-  // can alternate between two values causing visible flicker.  Break the
-  // cycle by suppressing the re-entrant resize event.
-  if (event->type() == QEvent::Resize) {
-    if (auto *dialog = qobject_cast<QDialog *>(object)) {
-      static QDialog *resizingDialog = nullptr;
-      if (resizingDialog == dialog) {
-        return true;
-      }
-      resizingDialog = dialog;
-      QString msg;
-      try {
-        bool result = QApplication::notify(object, event);
-        resizingDialog = nullptr;
-        return result;
-      } catch (const std::exception& e) {
-        resizingDialog = nullptr;
-        msg = e.what();
-      } catch (...) {
-        resizingDialog = nullptr;
-        msg = _("Unknown error");
-      }
-      QMessageBox::critical(
-        nullptr, QString(_("Critical Error")),
-        QString(_("A critical error was caught. The application may have become unstable:\n%1"))
-          .arg(QString(msg)));
-      return false;
-    }
-  }
-#endif
-
   QString msg;
   try {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // Qt5 + Fusion style: QMessageBox::resizeEvent() calls updateSize() which
+    // calls resize() when sizeHint() differs from the current size.  With
+    // word-wrapped text the hint depends on the current width, so sizeHint()
+    // can alternate between two values causing visible flicker.  Break the
+    // cycle by suppressing the re-entrant resize event.
+    if (event->type() == QEvent::Resize) {
+      if (auto *dialog = qobject_cast<QDialog *>(object)) {
+        static QDialog *resizingDialog = nullptr;
+        if (resizingDialog == dialog) {
+          return true;
+        }
+        resizingDialog = dialog;
+        struct Guard {
+          QDialog **p;
+          ~Guard() { *p = nullptr; }
+        };
+        Guard guard{&resizingDialog};
+        return QApplication::notify(object, event);
+      }
+    }
+#endif
     return QApplication::notify(object, event);
   } catch (const std::exception& e) {
     msg = e.what();
   } catch (...) {
     msg = _("Unknown error");
   }
+  // This happens when an uncaught exception is thrown in a Qt event handler
   QMessageBox::critical(
     nullptr, QString(_("Critical Error")),
     QString(_("A critical error was caught. The application may have become unstable:\n%1"))


### PR DESCRIPTION
## Summary

- Fix modal dialog flickering (QMessageBox, ShareDesignDialog, UnsavedChangesDialog) on Qt5 builds
- Root cause: `QMessageBox::resizeEvent()` calls `updateSize()` which computes `sizeHint()` and calls `resize()` when it differs. With Fusion style and word-wrapped text, `sizeHint()` alternates between two values depending on the current width, creating a re-entrant resize loop (layout oscillation)
- Fix: detect and suppress re-entrant resize events on `QDialog` instances in `OpenSCADApp::notify()`, breaking the oscillation cycle
- Scoped to Qt5 only (`#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)`) — Qt6 does not exhibit this behavior

Closes #498

## Test plan

- [x] Build with Qt5 and verify no flickering on:
  - [x] Tab close save dialog (modify a tab, close it)
  - [x] Window close save dialog (modify a tab, close the window)
  - [x] Share Design dialog (Design > Share design)
- [x] Build with Qt6 and verify dialogs still work correctly (the fix is compiled out)
- [x] Verify dialogs can still be manually resized by dragging

Made with [Cursor](https://cursor.com)