### PR TITLE
fix(build): add PORTABLE_BINARY=ON to Windows and macOS release builds

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -72,6 +72,7 @@ jobs:
             -DENABLE_PYTHON=ON \
             -DENABLE_TBB=OFF \
             -DENABLE_LIBFIVE=ON \
+            -DPORTABLE_BINARY=ON \
             -DENABLE_GAMEPAD=OFF \
             -DUSE_BUILTIN_CLIPPER2=OFF \
             -DUSE_BUILTIN_MANIFOLD=ON
@@ -204,6 +205,7 @@ jobs:
             -DENABLE_PYTHON=ON \
             -DENABLE_TBB=OFF \
             -DENABLE_LIBFIVE=ON \
+            -DPORTABLE_BINARY=ON \
             -DENABLE_GAMEPAD=OFF \
             -DUSE_BUILTIN_CLIPPER2=OFF \
             -DUSE_BUILTIN_MANIFOLD=ON

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -107,6 +107,7 @@ jobs:
             -DUSE_QT6=ON \
             -DENABLE_PYTHON=ON \
             -DENABLE_LIBFIVE=ON \
+            -DPORTABLE_BINARY=ON \
             -DENABLE_TESTS=OFF \
             -DPACKAGE_ARCH=windows-x86-64 \
             $EXTRA_CMAKE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,6 +663,7 @@ if(ENABLE_PYTHON)
       # available on all target machines.
       if(PORTABLE_BINARY)
         set(MARCH_SUPPORTED OFF CACHE BOOL "Disable -march=native for portable builds" FORCE)
+        set(ENABLE_DEBUG OFF CACHE BOOL "Disable debug symbols for portable builds" FORCE)
       endif()
       # Note: add_subdirectory(libfive) is deferred to after Python3 is found,
       # so we can define PYTHON_SITE_PACKAGES_DIR using modern sysconfig


### PR DESCRIPTION
## Summary

- Add `-DPORTABLE_BINARY=ON` to Windows native and macOS release build workflows
- When `PORTABLE_BINARY` is enabled, also disable libfive debug symbols (`ENABLE_DEBUG=OFF`)

## Root Cause

The v0.17.0 Windows release crashes with `0xc0000142` on CPUs without AVX-512 support (AMD Ryzen, older Intel). This happens because:

1. libfive's CMakeLists.txt adds `-march=native` when building with GCC/Clang
2. GitHub Actions `windows-latest` runners have Intel CPUs with AVX-512
3. The resulting `libfive.dll` contains `gemm_kern_avx512` and other AVX-512 instructions
4. On machines without AVX-512, the DLL initialization routine crashes immediately

The `PORTABLE_BINARY` CMake option (already used for AppImage builds) disables `-march=native` to produce portable binaries. It was missing from the Windows and macOS release workflows.

Additionally, libfive defaults to `ENABLE_DEBUG=ON` which embeds ~420MB of debug symbols in `libfive.dll` (total: 445MB for a ~25MB library). The fix also strips these for portable builds.

## Verification

Tested by loading DLLs from v0.16.0 and v0.17.0 distributions:
- v0.16.0 `libfive.dll`: loads successfully, **zero** AVX-512 symbols
- v0.17.0 `libfive.dll`: fails with `WinError 1114` (DLL init failed), **two** `avx512` symbols found

Fixes #497

## Test plan

- [ ] Trigger a Windows native build with this PR's changes
- [ ] Verify `libfive.dll` has no AVX-512 symbols (`dumpbin /EXPORTS` should show no `avx512`)
- [ ] Verify `libfive.dll` size is ~25MB (no debug sections)
- [ ] Test the built package on a machine without AVX-512 (e.g. AMD Ryzen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)