### PR TITLE
chore(gui): hide share design menu while server unavailable

### DIFF
--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -331,8 +331,10 @@
     <addaction name="designActionMeasureDist"/>
     <addaction name="designActionMeasureAngle"/>
     <addaction name="designActionFindHandle"/>
+    <!-- Share design server (pythonscad.org) is unavailable; restore when fixed.
     <addaction name="designShareDesign"/>
     <addaction name="designLoadShareDesign"/>
+    -->
     <addaction name="separator"/>
     <addaction name="designCheckValidity"/>
     <addaction name="designActionDisplayAST"/>


### PR DESCRIPTION
## Summary
The share-design feature depends on `pythonscad.org` endpoints that are currently broken on the server side. This change hides **Share Design** and **Load shared Design** from the **Design** menu so users are not offered a broken flow.

## Details
- Commented out the two `<addaction>` lines in `MainWindow.ui` (with a short note for future restoration).
- Left the `<action>` definitions and all `MainWindow.cc` / dialog code unchanged so the feature can be re-enabled by uncommenting when the server is fixed.

## Restore later
Remove the XML comment wrapper around the two menu `addaction` entries in `src/gui/MainWindow.ui`.

Made with [Cursor](https://cursor.com)