### PR TITLE
fix(gui): align save-as path, filters, and untitled names with editor language

### DIFF
--- a/src/genlang/genlang.h
+++ b/src/genlang/genlang.h
@@ -1,14 +1,14 @@
 /* This is a colletion of function to share among all new languages */
 #pragma once
 
+#include "genlang/language.h"
+
 #include <memory>
 #include "core/node.h"
 #include "core/function.h"
 #include "core/ScopeContext.h"
 #include "core/UserModule.h"
 #include "core/CsgOpNode.h"
-
-enum { LANG_NONE = -1, LANG_SCAD = 0, LANG_PYTHON = 1, LANG_JS = 2, LANG_LUA = 3 };
 
 #define DECLARE_INSTANCE()                                                                              \
   std::string instance_name;                                                                            \

--- a/src/genlang/genlang.h
+++ b/src/genlang/genlang.h
@@ -1,4 +1,5 @@
 /* This is a colletion of function to share among all new languages */
+#pragma once
 
 #include <memory>
 #include "core/node.h"

--- a/src/genlang/genlang.h
+++ b/src/genlang/genlang.h
@@ -1,4 +1,4 @@
-/* This is a colletion of function to share among all new languages */
+/* This is a collection of functions to share among all new languages */
 #pragma once
 
 #include "genlang/language.h"

--- a/src/genlang/language.h
+++ b/src/genlang/language.h
@@ -1,0 +1,3 @@
+#pragma once
+
+enum { LANG_NONE = -1, LANG_SCAD = 0, LANG_PYTHON = 1, LANG_JS = 2, LANG_LUA = 3 };

--- a/src/gui/Editor.cc
+++ b/src/gui/Editor.cc
@@ -4,7 +4,6 @@
 
 #include "gui/Preferences.h"
 #include "gui/QSettingsCached.h"
-#include "genlang/genlang.h"
 
 void EditorInterface::recomputeLanguageActive()
 {

--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "core/IndicatorData.h"
+#include "genlang/genlang.h"
 #include "gui/parameter/ParameterWidget.h"
 
 enum class EditorSelectionIndicatorStatus { SELECTED, IMPACTED };
@@ -114,6 +115,6 @@ public:
   std::string autoReloadId;
   std::vector<IndicatorData> indicatorData;
   ParameterWidget *parameterWidget;
-  int language;
+  int language = LANG_SCAD;
   bool languageManuallySet = false;
 };

--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "core/IndicatorData.h"
-#include "genlang/genlang.h"
+#include "genlang/language.h"
 #include "gui/parameter/ParameterWidget.h"
 
 enum class EditorSelectionIndicatorStatus { SELECTED, IMPACTED };

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2472,7 +2472,14 @@ void MainWindow::sendToExternalTool(ExternalToolInterface& externalToolService)
 {
   const QFileInfo activeFile(activeEditor->filepath);
   QString activeFileName = activeFile.fileName();
-  if (activeFileName.isEmpty()) activeFileName = "Untitled.scad";
+  if (activeFileName.isEmpty()) {
+#ifdef ENABLE_PYTHON
+    activeFileName = (activeEditor->language == LANG_PYTHON) ? QStringLiteral("Untitled.py")
+                                                             : QStringLiteral("Untitled.scad");
+#else
+    activeFileName = QStringLiteral("Untitled.scad");
+#endif
+  }
   // TODO: Replace suffix to match exported file format?
 
   activeFileName = activeFileName +
@@ -3982,8 +3989,15 @@ QString MainWindow::getCurrentFileName() const
   if (activeEditor == nullptr) return {};
 
   const QFileInfo fileInfo(activeEditor->filepath);
-  QString fname = _("Untitled.scad");
-  if (!fileInfo.fileName().isEmpty()) fname = fileInfo.fileName();
+  if (!fileInfo.fileName().isEmpty()) {
+    return fileInfo.fileName().replace("&", "&&");
+  }
+#ifdef ENABLE_PYTHON
+  QString fname = (activeEditor->language == LANG_PYTHON) ? QStringLiteral("Untitled.py")
+                                                          : QStringLiteral("Untitled.scad");
+#else
+  QString fname = QStringLiteral("Untitled.scad");
+#endif
   return fname.replace("&", "&&");
 }
 

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -90,69 +90,60 @@ QString initialPathForSaveDialog(const QString& filepath, int language)
   return QDir(dir).filePath(untitledBasenameForLanguage(language));
 }
 
+/** Save / Save As / Save a copy: one primary format (matches editor language) plus All files. */
+struct DesignSaveFilterSet {
+  QString primaryLabel;
+  QString allFilesLabel;
+  QString defaultSuffixQt;
+
+  QString combined() const
+  {
+    return QStringList{primaryLabel, allFilesLabel}.join(QStringLiteral(";;"));
+  }
+};
+
+DesignSaveFilterSet makeDesignSaveFilters(int editorLanguage)
+{
+  DesignSaveFilterSet f;
 #ifdef ENABLE_PYTHON
-struct DesignSaveFiltersPy
-{
-  QString python;
-  QString scad;
-  QString allDesigns;
-  QString allFiles;
-  QString combined() const
-  {
-    return QStringList{python, scad, allDesigns, allFiles}.join(QStringLiteral(";;"));
-  }
-};
-
-DesignSaveFiltersPy makeDesignSaveFilters()
-{
-  return DesignSaveFiltersPy{
-    QString(_("Python script (*.py)")),
-    QString(_("OpenSCAD script (*.scad)")),
-    QString(_("All design files (*.py *.scad)")),
-    QString(_("All files (*)")),
-  };
-}
-
-void appendDesignExtensionIfNeeded(QString& filename, const QString& selectedFilter,
-                                   const DesignSaveFiltersPy& f, int editorLanguage)
-{
-  if (!QFileInfo(filename).suffix().isEmpty()) return;
-  if (selectedFilter == f.python) {
-    filename.append(QStringLiteral(".py"));
-  } else if (selectedFilter == f.scad) {
-    filename.append(QStringLiteral(".scad"));
-  } else if (selectedFilter == f.allDesigns || selectedFilter == f.allFiles) {
-    filename.append((editorLanguage == LANG_PYTHON) ? QStringLiteral(".py") : QStringLiteral(".scad"));
+  if (editorLanguage == LANG_PYTHON) {
+    f.primaryLabel = QString(_("Python script (*.py)"));
+    f.defaultSuffixQt = QStringLiteral("py");
   } else {
-    filename.append((editorLanguage == LANG_PYTHON) ? QStringLiteral(".py") : QStringLiteral(".scad"));
+    f.primaryLabel = QString(_("OpenSCAD script (*.scad)"));
+    f.defaultSuffixQt = QStringLiteral("scad");
   }
-}
 #else
-struct DesignSaveFiltersScadOnly
-{
-  QString scad;
-  QString allFiles;
-  QString combined() const
-  {
-    return QStringList{scad, allFiles}.join(QStringLiteral(";;"));
-  }
-};
-
-DesignSaveFiltersScadOnly makeDesignSaveFilters()
-{
-  return DesignSaveFiltersScadOnly{
-    QString(_("OpenSCAD script (*.scad)")),
-    QString(_("All files (*)")),
-  };
+  (void)editorLanguage;
+  f.primaryLabel = QString(_("OpenSCAD script (*.scad)"));
+  f.defaultSuffixQt = QStringLiteral("scad");
+#endif
+  f.allFilesLabel = QString(_("All files (*)"));
+  return f;
 }
 
-void appendDesignExtensionIfNeeded(QString& filename, const QString& /*selectedFilter*/,
-                                   const DesignSaveFiltersScadOnly& /*f*/, int /*editorLanguage*/)
+void appendDesignSaveExtensionIfNeeded(QString& filename, const DesignSaveFilterSet& filters)
 {
   if (!QFileInfo(filename).suffix().isEmpty()) return;
-  filename.append(QStringLiteral(".scad"));
+  filename.append(filters.defaultSuffixQt == QStringLiteral("py") ? QStringLiteral(".py")
+                                                                  : QStringLiteral(".scad"));
 }
-#endif
+
+void configureDesignSaveFileDialog(QFileDialog& dialog, const DesignSaveFilterSet& filters)
+{
+  dialog.setNameFilters(filters.combined().split(QStringLiteral(";;")));
+  dialog.selectNameFilter(filters.primaryLabel);
+  dialog.setDefaultSuffix(filters.defaultSuffixQt);
+}
+
+bool warnOverwriteIfNeeded(QWidget *dialogParent, const QString& filename)
+{
+  const QFileInfo info(filename);
+  if (!info.exists()) return true;
+  const auto text = QString(_("%1 already exists.\nDo you want to replace it?")).arg(info.fileName());
+  return QMessageBox::warning(dialogParent, dialogParent->windowTitle(), text,
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes;
+}
 
 QJsonArray vec3ToJson(const Eigen::Vector3d& vec)
 {
@@ -1712,13 +1703,8 @@ bool TabManager::saveAs(EditorInterface *edt)
   assert(edt != nullptr);
 
   const QString initialPath = initialPathForSaveDialog(edt->filepath, edt->language);
-  const auto filters = makeDesignSaveFilters();
-  QString selectedFilter;
-#ifdef ENABLE_PYTHON
-  selectedFilter = (edt->language == LANG_PYTHON) ? filters.python : filters.scad;
-#else
-  selectedFilter = filters.scad;
-#endif
+  const auto filters = makeDesignSaveFilters(edt->language);
+  QString selectedFilter = filters.primaryLabel;
   auto filename = QFileDialog::getSaveFileName(parent, _("Save File"), initialPath, filters.combined(),
                                                &selectedFilter);
   if (filename.isEmpty()) {
@@ -1728,18 +1714,12 @@ bool TabManager::saveAs(EditorInterface *edt)
   auto guard = parent->scopedSetCurrentOutput();
 
   if (QFileInfo(filename).suffix().isEmpty()) {
-    appendDesignExtensionIfNeeded(filename, selectedFilter, filters, edt->language);
+    appendDesignSaveExtensionIfNeeded(filename, filters);
 
     // Manual overwrite check since Qt doesn't do it, when using the
     // defaultSuffix property
-    const QFileInfo info(filename);
-    if (info.exists()) {
-      const auto text =
-        QString(_("%1 already exists.\nDo you want to replace it?")).arg(info.fileName());
-      if (QMessageBox::warning(parent, parent->windowTitle(), text, QMessageBox::Yes | QMessageBox::No,
-                               QMessageBox::No) != QMessageBox::Yes) {
-        return false;
-      }
+    if (!warnOverwriteIfNeeded(parent, filename)) {
+      return false;
     }
   }
 
@@ -1773,16 +1753,16 @@ bool TabManager::saveACopy(EditorInterface *edt)
   const QString path = edt->filepath;
 
 #ifdef ENABLE_PYTHON
-  const bool usePySuffix = path.endsWith(QStringLiteral(".py")) || edt->language == LANG_PYTHON;
+  const QString copyExt =
+    (edt->language == LANG_PYTHON) ? QStringLiteral(".py") : QStringLiteral(".scad");
 #else
-  const bool usePySuffix = false;
+  const QString copyExt = QStringLiteral(".scad");
 #endif
-  const QString suffix = usePySuffix ? QStringLiteral(".py") : QStringLiteral(".scad");
 
   QString suggestedBasename = untitledBasenameForLanguage(edt->language);
   if (!path.isEmpty()) {
     const QFileInfo info(path);
-    suggestedBasename = info.baseName() + QStringLiteral("_copy") + suffix;
+    suggestedBasename = info.baseName() + QStringLiteral("_copy") + copyExt;
   }
 
   QSettingsCached settings;
@@ -1798,20 +1778,12 @@ bool TabManager::saveACopy(EditorInterface *edt)
     startDir = info.absolutePath();
   }
 
-  const auto filters = makeDesignSaveFilters();
-  QString selectedFilter;
-#ifdef ENABLE_PYTHON
-  selectedFilter = usePySuffix ? filters.python : filters.scad;
-#else
-  selectedFilter = filters.scad;
-#endif
+  const auto filters = makeDesignSaveFilters(edt->language);
 
   QFileDialog saveCopyDialog;
   saveCopyDialog.setAcceptMode(QFileDialog::AcceptSave);
   saveCopyDialog.setWindowTitle(_("Save A Copy"));
-  saveCopyDialog.setNameFilters(filters.combined().split(QStringLiteral(";;")));
-  saveCopyDialog.selectNameFilter(selectedFilter);
-  saveCopyDialog.setDefaultSuffix(usePySuffix ? QStringLiteral("py") : QStringLiteral("scad"));
+  configureDesignSaveFileDialog(saveCopyDialog, filters);
   saveCopyDialog.setViewMode(QFileDialog::List);
   saveCopyDialog.setDirectory(startDir);
   saveCopyDialog.selectFile(suggestedBasename);
@@ -1827,9 +1799,8 @@ bool TabManager::saveACopy(EditorInterface *edt)
 
   if (savefile.isEmpty()) return false;
 
-  selectedFilter = saveCopyDialog.selectedNameFilter();
   if (QFileInfo(savefile).suffix().isEmpty()) {
-    appendDesignExtensionIfNeeded(savefile, selectedFilter, filters, edt->language);
+    appendDesignSaveExtensionIfNeeded(savefile, filters);
   }
 
   QSaveFile file(savefile);

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -1716,8 +1716,8 @@ bool TabManager::saveAs(EditorInterface *edt)
   if (QFileInfo(filename).suffix().isEmpty()) {
     appendDesignSaveExtensionIfNeeded(filename, filters);
 
-    // Manual overwrite check since Qt doesn't do it, when using the
-    // defaultSuffix property
+    // We append the suffix after getSaveFileName returns, so the path Qt validated may
+    // differ from the final path; prompt if that final file already exists.
     if (!warnOverwriteIfNeeded(parent, filename)) {
       return false;
     }

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -19,6 +19,7 @@
 #include <QByteArray>
 #include <QClipboard>
 #include <QDesktopServices>
+#include <QDialog>
 #include <QDir>
 #include <QFile>
 #include <QFileDialog>
@@ -50,6 +51,7 @@
 #include "gui/MainWindow.h"
 #include "gui/OpenSCADApp.h"
 #include "gui/Preferences.h"
+#include "gui/QSettingsCached.h"
 #include "gui/ScintillaEditor.h"
 #include "gui/UnsavedChangesDialog.h"
 #include "utils/printutils.h"
@@ -61,6 +63,96 @@ namespace {
 uint64_t sessionDirtyGenerationValue = 0;
 bool sessionSaveWarningShown = false;
 bool skipSessionSaveOnQuit = false;
+
+QString untitledBasenameForLanguage(int language)
+{
+#ifdef ENABLE_PYTHON
+  return (language == LANG_PYTHON) ? QStringLiteral("Untitled.py") : QStringLiteral("Untitled.scad");
+#else
+  (void)language;
+  return QStringLiteral("Untitled.scad");
+#endif
+}
+
+QString initialPathForSaveDialog(const QString& filepath, int language)
+{
+  if (!filepath.isEmpty()) {
+    return filepath;
+  }
+  QSettingsCached settings;
+  QString dir = settings.value(QStringLiteral("lastOpenDirName")).toString();
+  if (dir.isEmpty()) {
+    dir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+  }
+  if (dir.isEmpty()) {
+    dir = QDir::homePath();
+  }
+  return QDir(dir).filePath(untitledBasenameForLanguage(language));
+}
+
+#ifdef ENABLE_PYTHON
+struct DesignSaveFiltersPy
+{
+  QString python;
+  QString scad;
+  QString allDesigns;
+  QString allFiles;
+  QString combined() const
+  {
+    return QStringList{python, scad, allDesigns, allFiles}.join(QStringLiteral(";;"));
+  }
+};
+
+DesignSaveFiltersPy makeDesignSaveFilters()
+{
+  return DesignSaveFiltersPy{
+    QString(_("Python script (*.py)")),
+    QString(_("OpenSCAD script (*.scad)")),
+    QString(_("All design files (*.py *.scad)")),
+    QString(_("All files (*)")),
+  };
+}
+
+void appendDesignExtensionIfNeeded(QString& filename, const QString& selectedFilter,
+                                   const DesignSaveFiltersPy& f, int editorLanguage)
+{
+  if (!QFileInfo(filename).suffix().isEmpty()) return;
+  if (selectedFilter == f.python) {
+    filename.append(QStringLiteral(".py"));
+  } else if (selectedFilter == f.scad) {
+    filename.append(QStringLiteral(".scad"));
+  } else if (selectedFilter == f.allDesigns || selectedFilter == f.allFiles) {
+    filename.append((editorLanguage == LANG_PYTHON) ? QStringLiteral(".py") : QStringLiteral(".scad"));
+  } else {
+    filename.append((editorLanguage == LANG_PYTHON) ? QStringLiteral(".py") : QStringLiteral(".scad"));
+  }
+}
+#else
+struct DesignSaveFiltersScadOnly
+{
+  QString scad;
+  QString allFiles;
+  QString combined() const
+  {
+    return QStringList{scad, allFiles}.join(QStringLiteral(";;"));
+  }
+};
+
+DesignSaveFiltersScadOnly makeDesignSaveFilters()
+{
+  return DesignSaveFiltersScadOnly{
+    QString(_("OpenSCAD script (*.scad)")),
+    QString(_("All files (*)")),
+  };
+}
+
+void appendDesignExtensionIfNeeded(QString& filename, const QString& /*selectedFilter*/,
+                                   const DesignSaveFiltersScadOnly& /*f*/, int /*editorLanguage*/)
+{
+  if (!QFileInfo(filename).suffix().isEmpty()) return;
+  filename.append(QStringLiteral(".scad"));
+}
+#endif
 
 QJsonArray vec3ToJson(const Eigen::Vector3d& vec)
 {
@@ -212,7 +304,8 @@ void TabManager::tabSwitched(int x)
     QString editorcmd = "gvim --remote-send '<esc>:sb " + QString::fromStdString(filename) +
                         "<cr>' || (gvim '" + QString::fromStdString(filename) + "' &)";
     //   LOG("1. Opening file '%1$s'",editorcmd.toUtf8().constData());
-    (void)system(editorcmd.toUtf8().constData());
+    const int gvimRc = system(editorcmd.toUtf8().constData());
+    (void)gvimRc;
     // **MCH*
   }
 
@@ -295,7 +388,8 @@ void TabManager::open(const QString& filename)
       "gvim --remote-tab-silent '" + filename.toUtf8() + "' || gvim '" + filename.toUtf8() + "' &";
     editorcmd += filename.toUtf8();
     //    LOG("2. Opening file '%1$s'",editorcmd.toUtf8().constData());
-    (void)system(editorcmd.toUtf8().constData());
+    const int gvimRc = system(editorcmd.toUtf8().constData());
+    (void)gvimRc;
   }
   for (auto edt : editorList) {
     if (filename == edt->filepath) {
@@ -1605,6 +1699,8 @@ bool TabManager::save(EditorInterface *edt, const QString& path)
     edt->parameterWidget->setModified(false);
     parent->updateRecentFiles(path);
     edt->filepath = path;
+    QSettingsCached settings;
+    settings.setValue(QStringLiteral("lastOpenDirName"), QFileInfo(path).absolutePath());
   } else {
     saveError(file, _("Error saving design"), path);
   }
@@ -1615,17 +1711,16 @@ bool TabManager::saveAs(EditorInterface *edt)
 {
   assert(edt != nullptr);
 
-  const auto defaultName = (edt->language == LANG_PYTHON) ? _("Untitled.py") : _("Untitled.scad");
-  const auto dir = edt->filepath.isEmpty() ? defaultName : edt->filepath;
-#ifdef ENABLE_PYTHON
+  const QString initialPath = initialPathForSaveDialog(edt->filepath, edt->language);
+  const auto filters = makeDesignSaveFilters();
   QString selectedFilter;
-  QString pythonFilter = _("PythonSCAD Designs (*.py)");
-  auto filename = QFileDialog::getSaveFileName(parent, _("Save File"), dir,
-                                               QString("%1").arg(pythonFilter), &selectedFilter);
+#ifdef ENABLE_PYTHON
+  selectedFilter = (edt->language == LANG_PYTHON) ? filters.python : filters.scad;
 #else
-  auto filename =
-    QFileDialog::getSaveFileName(parent, _("Save File"), dir, _("OpenSCAD Designs (*.scad)"));
+  selectedFilter = filters.scad;
 #endif
+  auto filename = QFileDialog::getSaveFileName(parent, _("Save File"), initialPath, filters.combined(),
+                                               &selectedFilter);
   if (filename.isEmpty()) {
     return false;
   }
@@ -1633,17 +1728,7 @@ bool TabManager::saveAs(EditorInterface *edt)
   auto guard = parent->scopedSetCurrentOutput();
 
   if (QFileInfo(filename).suffix().isEmpty()) {
-#ifdef ENABLE_PYTHON
-    // Check if the user selected the Python filter
-    if (selectedFilter == pythonFilter) {
-      filename.append(".py");
-    } else {
-      // For other cases, use .scad as the default extension
-      filename.append(".scad");
-    }
-#else
-    filename.append(".scad");
-#endif
+    appendDesignExtensionIfNeeded(filename, selectedFilter, filters, edt->language);
 
     // Manual overwrite check since Qt doesn't do it, when using the
     // defaultSuffix property
@@ -1687,28 +1772,49 @@ bool TabManager::saveACopy(EditorInterface *edt)
 
   const QString path = edt->filepath;
 
-  QString suffix = ".scad";
-  QDir dir(_("Untitled.scad"));
-  if (path.endsWith(".py")) {
-    suffix = ".py";
-    dir = QDir(_("Untitled.py"));
+#ifdef ENABLE_PYTHON
+  const bool usePySuffix = path.endsWith(QStringLiteral(".py")) || edt->language == LANG_PYTHON;
+#else
+  const bool usePySuffix = false;
+#endif
+  const QString suffix = usePySuffix ? QStringLiteral(".py") : QStringLiteral(".scad");
+
+  QString suggestedBasename = untitledBasenameForLanguage(edt->language);
+  if (!path.isEmpty()) {
+    const QFileInfo info(path);
+    suggestedBasename = info.baseName() + QStringLiteral("_copy") + suffix;
   }
 
-  if (!path.isEmpty()) {
-    QFileInfo info(path);
-    QString filecopy(info.absolutePath() % "/" % info.baseName() % "_copy" % suffix);
-    dir.setPath(filecopy);
+  QSettingsCached settings;
+  QString startDir = settings.value(QStringLiteral("lastOpenDirName")).toString();
+  if (startDir.isEmpty()) {
+    startDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
   }
+  if (startDir.isEmpty()) {
+    startDir = QDir::homePath();
+  }
+  if (!path.isEmpty()) {
+    const QFileInfo info(path);
+    startDir = info.absolutePath();
+  }
+
+  const auto filters = makeDesignSaveFilters();
+  QString selectedFilter;
+#ifdef ENABLE_PYTHON
+  selectedFilter = usePySuffix ? filters.python : filters.scad;
+#else
+  selectedFilter = filters.scad;
+#endif
 
   QFileDialog saveCopyDialog;
-  saveCopyDialog.setAcceptMode(QFileDialog::AcceptSave);  // Set the dialog to "Save" mode.
-  saveCopyDialog.setWindowTitle("Save A Copy");
-
-  saveCopyDialog.setNameFilter("PythonSCAD Designs (*.py, *.scad)");
-
-  saveCopyDialog.setDefaultSuffix("scad");
+  saveCopyDialog.setAcceptMode(QFileDialog::AcceptSave);
+  saveCopyDialog.setWindowTitle(_("Save A Copy"));
+  saveCopyDialog.setNameFilters(filters.combined().split(QStringLiteral(";;")));
+  saveCopyDialog.selectNameFilter(selectedFilter);
+  saveCopyDialog.setDefaultSuffix(usePySuffix ? QStringLiteral("py") : QStringLiteral("scad"));
   saveCopyDialog.setViewMode(QFileDialog::List);
-  saveCopyDialog.setDirectory(dir);
+  saveCopyDialog.setDirectory(startDir);
+  saveCopyDialog.selectFile(suggestedBasename);
 
   if (saveCopyDialog.exec() != QDialog::Accepted) return false;
 
@@ -1720,6 +1826,11 @@ bool TabManager::saveACopy(EditorInterface *edt)
   QString savefile = selectedFiles.first();
 
   if (savefile.isEmpty()) return false;
+
+  selectedFilter = saveCopyDialog.selectedNameFilter();
+  if (QFileInfo(savefile).suffix().isEmpty()) {
+    appendDesignExtensionIfNeeded(savefile, selectedFilter, filters, edt->language);
+  }
 
   QSaveFile file(savefile);
   if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -125,8 +125,8 @@ DesignSaveFilterSet makeDesignSaveFilters(int editorLanguage)
 void appendDesignSaveExtensionIfNeeded(QString& filename, const DesignSaveFilterSet& filters)
 {
   if (!QFileInfo(filename).suffix().isEmpty()) return;
-  filename.append(filters.defaultSuffixQt == QStringLiteral("py") ? QStringLiteral(".py")
-                                                                  : QStringLiteral(".scad"));
+  filename.append(QLatin1Char('.'));
+  filename.append(filters.defaultSuffixQt);
 }
 
 void configureDesignSaveFileDialog(QFileDialog& dialog, const DesignSaveFilterSet& filters)

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -31,7 +31,7 @@ public:
 
   // returns the name and tooltip of the tab for the given provided editor
   // if there is a path associated with an editor this is the filepath
-  // otherwise Untitled.scad
+  // otherwise Untitled.py or Untitled.scad according to editor language
   std::tuple<QString, QString> getEditorTabName(EditorInterface *edt);
 
   // returns the name and tooltip of the tab for the given provided editor with


### PR DESCRIPTION
## Summary

Fixes [#534](https://github.com/pythonscad/pythonscad/issues/534): Save / Save As now suggests **`Untitled.py` vs `Untitled.scad` in line with the editor language**, using a **full directory + basename** for `QFileDialog` (via `lastOpenDirName`, then Documents/home), so native portals behave reliably instead of a bare `Untitled.py` path.

## Changes

- **Save / Save As / Save a copy**
  - Initial path: `lastOpenDirName` (same setting as Open File) + `Untitled.{py,scad}`, or existing file path when already saved.
  - **Filters:** only the format that matches the **editor language** (Python script `*.py` or OpenSCAD script `*.scad`), plus **All files (`*`)** so users can deliberately choose another extension.
  - Shared helpers in `TabManager.cc` (`makeDesignSaveFilters`, `configureDesignSaveFileDialog`, `appendDesignSaveExtensionIfNeeded`, `warnOverwriteIfNeeded`) keep Save, Save As, and Save a copy in sync.
  - If the filename has **no** suffix, append **`.py` / `.scad`** according to that editor language (same as the primary filter’s `defaultSuffix`).
- **After a successful save**, update **`lastOpenDirName`** to the saved file’s directory (aligned with Open).
- **Save a copy:** same filter model as Save As, sensible **start directory** and **suggested basename** (`Untitled…` or `basename_copy…` using editor language).
- **Consistency**
  - `MainWindow::getCurrentFileName()` uses the same untitled naming as tabs when there is no path.
  - External-tool temp basename for an unsaved buffer uses **Python vs SCAD** untitled name.
  - `EditorInterface::language` default **`LANG_SCAD`**; **`#pragma once`** on `genlang.h` so including it from `Editor.h` is safe.
- **`genlang/language.h`:** `LANG_*` constants live in a small header so `Editor.h` does not pull the full genlang/core graph.
- **Gvim `system()` calls**: satisfy **`warn_unused_result`** in `TabManager.cc` (same translation unit as the save work).
- **Comment** at top of `genlang.h`: spelling / wording cleanup.

## How to test

1. New file (Python template) → **Save** / **Save As** → suggested name should be **`Untitled.py`** under a real folder (e.g. last open dir or Documents); type list should be **Python + All files** only.
2. Switch editor to SCAD (if available) → **Save As** → suggested **`Untitled.scad`** and **OpenSCAD + All files** only.
3. With **All files**, type a name **with** a custom extension → file keeps that extension; **without** extension → **`.py` or `.scad`** from editor language.
4. **Save a copy** → same filter behavior as Save As.

---

Closes #534
