### PR TITLE
fix: update application icon on Windows to use the PythonSCAD logo

### DIFF
--- a/resources/pythonscad_win32-nightly.rc.in
+++ b/resources/pythonscad_win32-nightly.rc.in
@@ -42,7 +42,7 @@ VS_VERSION_INFO VERSIONINFO
 /* End of Version info */
 
 /* Application icon ID 1 so Explorer and taskbar use PythonSCAD icon */
-1 ICON DISCARDABLE "@CMAKE_SOURCE_DIR@/resources/icons/icon-nightly.ico"
+1 ICON DISCARDABLE "@CMAKE_SOURCE_DIR@/resources/icons/pythonscad.ico"
 
 IDI_ICON1   ICON    DISCARDABLE "@CMAKE_SOURCE_DIR@/resources/icons/icon-nightly.ico"
 IDI_ICON2   ICON    DISCARDABLE "@CMAKE_SOURCE_DIR@/resources/icons/icon-nightly.ico"


### PR DESCRIPTION
The application was using the OpenSCAD nightly icon so far.
This PR switches that to use the PythonSCAD logo