### PR TITLE
fix(gui): skip stale-path session dialog for default Untitled files

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -182,7 +182,11 @@ bool jsonToVec3(const QJsonValue& value, double *x, double *y, double *z)
 bool isStandardUntitledFilename(const QString& filepath)
 {
   const QString fn = QFileInfo(filepath).fileName();
-  return fn == QStringLiteral("Untitled.py") || fn == QStringLiteral("Untitled.scad");
+#ifdef ENABLE_PYTHON
+  return fn == untitledBasenameForLanguage(LANG_PYTHON) || fn == untitledBasenameForLanguage(LANG_SCAD);
+#else
+  return fn == untitledBasenameForLanguage(LANG_SCAD);
+#endif
 }
 
 void initEmptyUntitledTab(EditorInterface *editor)

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -90,6 +90,12 @@ QString initialPathForSaveDialog(const QString& filepath, int language)
   return QDir(dir).filePath(untitledBasenameForLanguage(language));
 }
 
+/** Synthetic path prefix for session-restore window plumbing; not a filesystem path. */
+inline bool isSessionLaunchTokenPath(const QString& path)
+{
+  return path.startsWith(QStringLiteral(":session:"));
+}
+
 /** Save / Save As / Save a copy: one primary format (matches editor language) plus All files. */
 struct DesignSaveFilterSet {
   QString primaryLabel;
@@ -259,7 +265,7 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
 
   // Session restore passes a synthetic path like ":session:0:"; QFileInfo treats it as absolute
   // and non-existent, which must never be opened as a file or counted as a missing disk path.
-  if (filename.startsWith(QStringLiteral(":session:"))) {
+  if (isSessionLaunchTokenPath(filename)) {
     createTab(QString(), false);
   } else {
     createTab(filename);
@@ -768,7 +774,7 @@ void TabManager::onTabModified(EditorInterface *edt)
 
 void TabManager::openTabFile(const QString& filename)
 {
-  if (filename.startsWith(QStringLiteral(":session:"))) {
+  if (isSessionLaunchTokenPath(filename)) {
     return;
   }
   QFileInfo fileinfo(filename);
@@ -1146,7 +1152,7 @@ void TabManager::saveSession(const QString& path)
     auto *edt = static_cast<EditorInterface *>(tabWidget->widget(i));
     QJsonObject obj;
     QString sessionPath = edt->filepath;
-    if (sessionPath.startsWith(QStringLiteral(":session:"))) {
+    if (isSessionLaunchTokenPath(sessionPath)) {
       sessionPath.clear();
     }
     obj.insert(QStringLiteral("filepath"), sessionPath);
@@ -1234,7 +1240,7 @@ bool TabManager::saveGlobalSession(const QString& path, QString *error, bool sho
       auto *edt = static_cast<EditorInterface *>(tm->tabWidget->widget(i));
       QJsonObject obj;
       QString sessionPath = edt->filepath;
-      if (sessionPath.startsWith(QStringLiteral(":session:"))) {
+      if (isSessionLaunchTokenPath(sessionPath)) {
         sessionPath.clear();
       }
       obj.insert(QStringLiteral("filepath"), sessionPath);
@@ -1463,8 +1469,7 @@ bool TabManager::restoreSession(const QString& path, int windowIndex)
     // Never treat default untitled filenames as stale disk paths: the session may record a path
     // that was never created (e.g. missing file opened by name, or save-dialog default).
     const bool standardUntitled = isStandardUntitledFilename(filepath);
-    const bool countsAsMissing = !filepath.isEmpty() &&
-                                 !filepath.startsWith(QStringLiteral(":session:")) &&
+    const bool countsAsMissing = !filepath.isEmpty() && !isSessionLaunchTokenPath(filepath) &&
                                  fileInfo.isAbsolute() && !fileInfo.exists() && !standardUntitled;
     if (countsAsMissing) {
       if (firstMissingIndex < 0) {

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -164,6 +164,12 @@ bool jsonToVec3(const QJsonValue& value, double *x, double *y, double *z)
   return true;
 }
 
+bool isStandardUntitledFilename(const QString& filepath)
+{
+  const QString fn = QFileInfo(filepath).fileName();
+  return fn == QStringLiteral("Untitled.py") || fn == QStringLiteral("Untitled.scad");
+}
+
 void initEmptyUntitledTab(EditorInterface *editor)
 {
 #ifdef ENABLE_PYTHON
@@ -251,7 +257,13 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
   connect(parent->editActionZoomTextIn, &QAction::triggered, this, &TabManager::zoomIn);
   connect(parent->editActionZoomTextOut, &QAction::triggered, this, &TabManager::zoomOut);
 
-  createTab(filename);
+  // Session restore passes a synthetic path like ":session:0:"; QFileInfo treats it as absolute
+  // and non-existent, which must never be opened as a file or counted as a missing disk path.
+  if (filename.startsWith(QStringLiteral(":session:"))) {
+    createTab(QString(), false);
+  } else {
+    createTab(filename);
+  }
 
   // Disable the closing button for the first tabbar
   setTabsCloseButtonVisibility(0, false);
@@ -756,6 +768,9 @@ void TabManager::onTabModified(EditorInterface *edt)
 
 void TabManager::openTabFile(const QString& filename)
 {
+  if (filename.startsWith(QStringLiteral(":session:"))) {
+    return;
+  }
   QFileInfo fileinfo(filename);
   const QString absPath = fileinfo.absoluteFilePath();
   const QString suffix = Importer::effectiveSuffixForOpen(filename);
@@ -1130,7 +1145,11 @@ void TabManager::saveSession(const QString& path)
   for (int i = 0; i < tabWidget->count(); ++i) {
     auto *edt = static_cast<EditorInterface *>(tabWidget->widget(i));
     QJsonObject obj;
-    obj.insert(QStringLiteral("filepath"), edt->filepath);
+    QString sessionPath = edt->filepath;
+    if (sessionPath.startsWith(QStringLiteral(":session:"))) {
+      sessionPath.clear();
+    }
+    obj.insert(QStringLiteral("filepath"), sessionPath);
     obj.insert(QStringLiteral("content"), edt->toPlainText());
     obj.insert(QStringLiteral("contentModified"), edt->isContentModified());
     obj.insert(QStringLiteral("parameterModified"), edt->parameterWidget->isModified());
@@ -1146,9 +1165,9 @@ void TabManager::saveSession(const QString& path)
     if (!customizerState.isEmpty()) {
       obj.insert(QStringLiteral("customizerState"), QString::fromUtf8(customizerState));
     }
-    if (!edt->filepath.isEmpty()) {
+    if (!sessionPath.isEmpty()) {
       obj.insert(QStringLiteral("diskIdentity"),
-                 QString::fromStdString(MainWindow::autoReloadIdentityForPath(edt->filepath)));
+                 QString::fromStdString(MainWindow::autoReloadIdentityForPath(sessionPath)));
     }
     tabs.append(obj);
   }
@@ -1214,7 +1233,11 @@ bool TabManager::saveGlobalSession(const QString& path, QString *error, bool sho
     for (int i = 0; i < tm->tabWidget->count(); ++i) {
       auto *edt = static_cast<EditorInterface *>(tm->tabWidget->widget(i));
       QJsonObject obj;
-      obj.insert(QStringLiteral("filepath"), edt->filepath);
+      QString sessionPath = edt->filepath;
+      if (sessionPath.startsWith(QStringLiteral(":session:"))) {
+        sessionPath.clear();
+      }
+      obj.insert(QStringLiteral("filepath"), sessionPath);
       obj.insert(QStringLiteral("content"), edt->toPlainText());
       obj.insert(QStringLiteral("contentModified"), edt->isContentModified());
       obj.insert(QStringLiteral("parameterModified"), edt->parameterWidget->isModified());
@@ -1230,9 +1253,9 @@ bool TabManager::saveGlobalSession(const QString& path, QString *error, bool sho
       if (!customizerState.isEmpty()) {
         obj.insert(QStringLiteral("customizerState"), QString::fromUtf8(customizerState));
       }
-      if (!edt->filepath.isEmpty()) {
+      if (!sessionPath.isEmpty()) {
         obj.insert(QStringLiteral("diskIdentity"),
-                   QString::fromStdString(MainWindow::autoReloadIdentityForPath(edt->filepath)));
+                   QString::fromStdString(MainWindow::autoReloadIdentityForPath(sessionPath)));
       }
       tabs.append(obj);
     }
@@ -1422,7 +1445,7 @@ bool TabManager::restoreSession(const QString& path, int windowIndex)
 
   for (int i = 0; i < tabs.size(); ++i) {
     const QJsonObject obj = tabs[i].toObject();
-    const QString filepath = obj.value(QStringLiteral("filepath")).toString();
+    QString filepath = obj.value(QStringLiteral("filepath")).toString().trimmed();
     QString content = obj.value(QStringLiteral("content")).toString();
     const bool contentModified = obj.value(QStringLiteral("contentModified")).toBool();
     const bool parameterModified = obj.value(QStringLiteral("parameterModified")).toBool();
@@ -1437,7 +1460,13 @@ bool TabManager::restoreSession(const QString& path, int windowIndex)
     }
 
     const QFileInfo fileInfo(filepath);
-    if (!filepath.isEmpty() && fileInfo.isAbsolute() && !fileInfo.exists()) {
+    // Never treat default untitled filenames as stale disk paths: the session may record a path
+    // that was never created (e.g. missing file opened by name, or save-dialog default).
+    const bool standardUntitled = isStandardUntitledFilename(filepath);
+    const bool countsAsMissing = !filepath.isEmpty() &&
+                                 !filepath.startsWith(QStringLiteral(":session:")) &&
+                                 fileInfo.isAbsolute() && !fileInfo.exists() && !standardUntitled;
+    if (countsAsMissing) {
       if (firstMissingIndex < 0) {
         firstMissingIndex = i;
       }
@@ -1609,7 +1638,7 @@ bool TabManager::sessionHasOnlyEmptyTab(const QString& path)
   if (tabs.size() != 1) return false;
 
   const QJsonObject tab = tabs[0].toObject();
-  const QString filepath = tab.value(QStringLiteral("filepath")).toString();
+  const QString filepath = tab.value(QStringLiteral("filepath")).toString().trimmed();
   const bool contentModified = tab.value(QStringLiteral("contentModified")).toBool();
 
   // Trivial session: one window, one tab, nothing saved to a path, editor not dirty.

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -96,6 +96,15 @@ inline bool isSessionLaunchTokenPath(const QString& path)
   return path.startsWith(QStringLiteral(":session:"));
 }
 
+/** Path stored in session JSON (never persist internal launch tokens). */
+QString normalizedSessionFilepathForJson(const QString& filepath)
+{
+  if (isSessionLaunchTokenPath(filepath)) {
+    return {};
+  }
+  return filepath;
+}
+
 /** Save / Save As / Save a copy: one primary format (matches editor language) plus All files. */
 struct DesignSaveFilterSet {
   QString primaryLabel;
@@ -1151,10 +1160,7 @@ void TabManager::saveSession(const QString& path)
   for (int i = 0; i < tabWidget->count(); ++i) {
     auto *edt = static_cast<EditorInterface *>(tabWidget->widget(i));
     QJsonObject obj;
-    QString sessionPath = edt->filepath;
-    if (isSessionLaunchTokenPath(sessionPath)) {
-      sessionPath.clear();
-    }
+    const QString sessionPath = normalizedSessionFilepathForJson(edt->filepath);
     obj.insert(QStringLiteral("filepath"), sessionPath);
     obj.insert(QStringLiteral("content"), edt->toPlainText());
     obj.insert(QStringLiteral("contentModified"), edt->isContentModified());
@@ -1239,10 +1245,7 @@ bool TabManager::saveGlobalSession(const QString& path, QString *error, bool sho
     for (int i = 0; i < tm->tabWidget->count(); ++i) {
       auto *edt = static_cast<EditorInterface *>(tm->tabWidget->widget(i));
       QJsonObject obj;
-      QString sessionPath = edt->filepath;
-      if (isSessionLaunchTokenPath(sessionPath)) {
-        sessionPath.clear();
-      }
+      const QString sessionPath = normalizedSessionFilepathForJson(edt->filepath);
       obj.insert(QStringLiteral("filepath"), sessionPath);
       obj.insert(QStringLiteral("content"), edt->toPlainText());
       obj.insert(QStringLiteral("contentModified"), edt->isContentModified());


### PR DESCRIPTION
Fixes #545

## Changes
- Session restore: do not treat missing absolute paths whose filename is exactly `Untitled.py` or `Untitled.scad` as stale disk paths (session may only hold a placeholder path, not a saved file).
- Ignore internal `:session:` launch tokens in `openTabFile`, first-tab construction, missing-path counting, and when writing `filepath` / `diskIdentity` to session JSON.
- Trim `filepath` when restoring and in `sessionHasOnlyEmptyTab`.

## Follow-up refactors (Copilot review)
- `isSessionLaunchTokenPath()` in the anonymous namespace replaces repeated `:session:` prefix checks.
- `normalizedSessionFilepathForJson()` is shared by `saveSession` and `saveGlobalSession` for consistent `filepath` / `diskIdentity` persistence.
- `isStandardUntitledFilename()` compares against `untitledBasenameForLanguage()` to avoid duplicating default untitled basenames. (The helper was already in the anonymous namespace; no linkage change was required.)

## Note
The active session file is typically under `QStandardPaths::AppConfigLocation` (e.g. `~/.config/PythonSCAD/PythonSCAD/session.json`), not necessarily the parent `PythonSCAD/session.json`.

Made with [Cursor](https://cursor.com)
