### PR TITLE
fix(gui): session restore and CLI prompt for missing design files

### DIFF
--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -112,6 +112,8 @@ public:
   bool contentsRendered;  // Set if the source code has changes since the last render (F6)
   int findState;
   QString filepath;
+  /// True after loading from an existing file on disk or a successful save to this path.
+  bool diskBacked = false;
   std::string autoReloadId;
   std::vector<IndicatorData> indicatorData;
   ParameterWidget *parameterWidget;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -41,6 +41,7 @@
 #include <QClipboard>
 #include <QDesktopServices>
 #include <QDialog>
+#include <QDir>
 #include <QDockWidget>
 #include <QDropEvent>
 #include <QElapsedTimer>
@@ -2100,6 +2101,7 @@ std::string MainWindow::autoReloadIdentityForPath(const QString& filepath)
 bool MainWindow::fileChangedOnDisk()
 {
   if (activeEditor->filepath.isEmpty()) return false;
+  if (!activeEditor->diskBacked) return false;
   const std::string newid = autoReloadIdentityForPath(activeEditor->filepath);
   // If file isn't there, just return and use current editor text
   if (newid.empty()) return false;
@@ -4572,9 +4574,22 @@ void MainWindow::setupErrorLog()
  */
 void MainWindow::setupEditor(const QStringList& filenames)
 {
-  tabManager = new TabManager(this, filenames.isEmpty() ? QString() : filenames[0]);
+  QString ctorFirst;
+  if (!filenames.isEmpty()) {
+    const QString& f0 = filenames[0];
+    if (!f0.startsWith(QStringLiteral(":session:")) && TabManager::isMissingDesignDocumentPath(f0)) {
+      deferredCliMissingFile = QFileInfo(f0).absoluteFilePath();
+    } else {
+      ctorFirst = f0;
+    }
+  }
+
+  tabManager = new TabManager(this, ctorFirst);
   activeEditor = tabManager->editor;
   editorDockContents->layout()->addWidget(tabManager->getTabContent());
+  if (!deferredCliMissingFile.isEmpty()) {
+    tabManager->getTabContent()->hide();
+  }
 
   connect(this->fileActionNew, &QAction::triggered, tabManager, &TabManager::actionNew);
   connect(this->fileActionClose, &QAction::triggered, tabManager, &TabManager::closeCurrentTab);
@@ -5022,8 +5037,47 @@ void MainWindow::restoreWindowState()
 
 }
 
+void MainWindow::handleDeferredCliMissingFile()
+{
+  const QString path = deferredCliMissingFile;
+  deferredCliMissingFile.clear();
+
+  QMessageBox box(this);
+  box.setIcon(QMessageBox::Question);
+  box.setWindowTitle(_("Application"));
+  box.setText(QString(_("The file \"%1\" does not exist.\n\nDo you want to create it?"))
+                .arg(QDir::toNativeSeparators(path)));
+  box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+  box.setDefaultButton(QMessageBox::Yes);
+  if (box.exec() != QMessageBox::Yes) {
+    tabManager->getTabContent()->show();
+    activeEditor->setFocus();
+    return;
+  }
+
+  if (!tabManager->save(activeEditor, path)) {
+    tabManager->getTabContent()->show();
+    activeEditor->setFocus();
+    return;
+  }
+
+  activeEditor->resetLanguageDetection();
+  onLanguageActiveChanged(activeEditor->language);
+  tabManager->updateTabIcon(activeEditor);
+  const auto [fname, fpath] = tabManager->getEditorTabNameWithModifier(activeEditor);
+  tabManager->setEditorTabName(fname, fpath, activeEditor);
+  tabManager->getTabContent()->show();
+  onTabManagerEditorChanged(activeEditor);
+  onTabManagerEditorContentReloaded(activeEditor);
+  activeEditor->setFocus();
+}
+
 void MainWindow::openRemainingFiles(const QStringList& filenames)
 {
+  if (!deferredCliMissingFile.isEmpty()) {
+    handleDeferredCliMissingFile();
+  }
+
   for (int i = 1; i < filenames.size(); ++i) tabManager->createTab(filenames[i]);
   if (filenames.size() == 1 && filenames[0].startsWith(QStringLiteral(":session:"))) {
     int windowIndex = 0;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -5048,6 +5048,8 @@ void MainWindow::handleDeferredCliMissingFile()
     return;
   }
 
+  tabManager->prepareEditorBufferForNewDesignFile(activeEditor, path);
+
   if (!tabManager->save(activeEditor, path)) {
     tabManager->getTabContent()->show();
     activeEditor->setFocus();

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -5042,14 +5042,7 @@ void MainWindow::handleDeferredCliMissingFile()
   const QString path = deferredCliMissingFile;
   deferredCliMissingFile.clear();
 
-  QMessageBox box(this);
-  box.setIcon(QMessageBox::Question);
-  box.setWindowTitle(_("Application"));
-  box.setText(QString(_("The file \"%1\" does not exist.\n\nDo you want to create it?"))
-                .arg(QDir::toNativeSeparators(path)));
-  box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-  box.setDefaultButton(QMessageBox::Yes);
-  if (box.exec() != QMessageBox::Yes) {
+  if (!TabManager::confirmCreateMissingDesignFile(this, path)) {
     tabManager->getTabContent()->show();
     activeEditor->setFocus();
     return;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -163,6 +163,9 @@ private:
   void setupMenusAndActions();
   void restoreWindowState();
   void openRemainingFiles(const QStringList& filenames);
+  /// First CLI path was a missing design file; tab UI deferred until user answers create prompt.
+  QString deferredCliMissingFile;
+  void handleDeferredCliMissingFile();
 
 protected:
   void closeEvent(QCloseEvent *event) override;

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -255,17 +255,6 @@ bool writeSessionFile(const QJsonObject& root, const QString& path, QString *err
   return true;
 }
 
-bool confirmCreateMissingDesignFile(QWidget *parent, const QString& absPath)
-{
-  QMessageBox box(parent);
-  box.setIcon(QMessageBox::Question);
-  box.setWindowTitle(_("Application"));
-  box.setText(QString(_("The file \"%1\" does not exist.\n\nDo you want to create it?"))
-                .arg(QDir::toNativeSeparators(absPath)));
-  box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-  box.setDefaultButton(QMessageBox::Yes);
-  return box.exec() == QMessageBox::Yes;
-}
 }  // namespace
 
 bool TabManager::isMissingDesignDocumentPath(const QString& path)
@@ -282,6 +271,18 @@ bool TabManager::isMissingDesignDocumentPath(const QString& path)
     return false;
   }
   return !fi.exists() || !fi.isFile();
+}
+
+bool TabManager::confirmCreateMissingDesignFile(QWidget *parent, const QString& absPath)
+{
+  QMessageBox box(parent);
+  box.setIcon(QMessageBox::Question);
+  box.setWindowTitle(_("Application"));
+  box.setText(QString(_("The file \"%1\" does not exist.\n\nDo you want to create it?"))
+                .arg(QDir::toNativeSeparators(absPath)));
+  box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+  box.setDefaultButton(QMessageBox::Yes);
+  return box.exec() == QMessageBox::Yes;
 }
 
 TabManager::TabManager(MainWindow *o, const QString& filename)
@@ -863,7 +864,7 @@ void TabManager::openTabFile(const QString& filename)
 
   const bool missingOnDisk = !fileinfo.exists() || !fileinfo.isFile();
   if (missingOnDisk) {
-    if (!confirmCreateMissingDesignFile(parent, absPath)) {
+    if (!TabManager::confirmCreateMissingDesignFile(parent, absPath)) {
       editor->diskBacked = false;
       return;
     }

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -1551,7 +1551,13 @@ bool TabManager::restoreSession(const QString& path, int windowIndex)
       tabDiskBacked = obj.value(QStringLiteral("diskBacked")).toBool();
     } else {
       const bool onDiskNow = fileInfo.exists() && fileInfo.isFile();
+      const QString savedDiskId = obj.value(QStringLiteral("diskIdentity")).toString();
+      const bool hadDiskSnapshot = !savedDiskId.isEmpty();
       if (onDiskNow) {
+        tabDiskBacked = true;
+      } else if (hadDiskSnapshot) {
+        // v4 session: file existed when saved (mtime+size recorded) — treat as disk-backed even if
+        // contentModified was true (unsaved edits) or the file was deleted before restore.
         tabDiskBacked = true;
       } else {
         // Pre-v5 session: infer disk backing for stale-file warning (see diskBacked in Editor).

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -285,6 +285,34 @@ bool TabManager::confirmCreateMissingDesignFile(QWidget *parent, const QString& 
   return box.exec() == QMessageBox::Yes;
 }
 
+void TabManager::prepareEditorBufferForNewDesignFile(EditorInterface *edt, const QString& absPath)
+{
+  const QString suffix = Importer::effectiveSuffixForOpen(absPath);
+#ifdef ENABLE_PYTHON
+  if (suffix == QStringLiteral("py")) {
+    std::string templ = "from openscad import *\n";
+    std::string libs = Settings::SettingsPython::pythonNetworkImportList.value();
+    std::stringstream ss(libs);
+    std::string word;
+    while (std::getline(ss, word, '\n')) {
+      if (word.size() == 0) continue;
+      templ += "nimport(\"" + word + "\")\n";
+    }
+    edt->setPlainText(QString::fromStdString(templ));
+    edt->setLanguageManually(LANG_PYTHON);
+    const QByteArray pathUtf8 = QFileInfo(absPath).absoluteFilePath().toUtf8();
+    parent->clearPythonUntrustStateForPath(
+      std::string(pathUtf8.constData(), static_cast<size_t>(pathUtf8.size())));
+  } else
+#endif
+  {
+    edt->setPlainText("");
+    edt->setLanguageManually(LANG_SCAD);
+  }
+  edt->setContentModified(false);
+  edt->parameterWidget->setModified(false);
+}
+
 TabManager::TabManager(MainWindow *o, const QString& filename)
 {
   parent = o;
@@ -868,28 +896,29 @@ void TabManager::openTabFile(const QString& filename)
       editor->diskBacked = false;
       return;
     }
-  }
-
+    prepareEditorBufferForNewDesignFile(editor, absPath);
+  } else {
 #ifdef ENABLE_PYTHON
-  if (suffix == QStringLiteral("py")) {
-    std::string templ = "from openscad import *\n";
-    std::string libs = Settings::SettingsPython::pythonNetworkImportList.value();
-    std::stringstream ss(libs);
-    std::string word;
-    while (std::getline(ss, word, '\n')) {
-      if (word.size() == 0) continue;
-      templ += "nimport(\"" + word + "\")\n";
-    }
-    editor->setPlainText(QString::fromStdString(templ));
-  } else
+    if (suffix == QStringLiteral("py")) {
+      std::string templ = "from openscad import *\n";
+      std::string libs = Settings::SettingsPython::pythonNetworkImportList.value();
+      std::stringstream ss(libs);
+      std::string word;
+      while (std::getline(ss, word, '\n')) {
+        if (word.size() == 0) continue;
+        templ += "nimport(\"" + word + "\")\n";
+      }
+      editor->setPlainText(QString::fromStdString(templ));
+    } else
 #endif
-  {
-    editor->setPlainText("");
+    {
+      editor->setPlainText("");
+    }
   }
 
   editor->filepath = absPath;
 #ifdef ENABLE_PYTHON
-  if (suffix == QStringLiteral("py")) {
+  if (suffix == QStringLiteral("py") && !missingOnDisk) {
     const QByteArray pathUtf8 = editor->filepath.toUtf8();
     parent->clearPythonUntrustStateForPath(
       std::string(pathUtf8.constData(), static_cast<size_t>(pathUtf8.size())));

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -189,6 +189,13 @@ bool isStandardUntitledFilename(const QString& filepath)
 #endif
 }
 
+void warnDesignPathIsDirectory(QWidget *dialogParent, const QString& absPath)
+{
+  QMessageBox::warning(dialogParent, _("Application"),
+                       QString(_("Cannot open design file \"%1\": path is a directory."))
+                         .arg(QDir::toNativeSeparators(absPath)));
+}
+
 void initEmptyUntitledTab(EditorInterface *editor)
 {
 #ifdef ENABLE_PYTHON
@@ -270,6 +277,11 @@ bool TabManager::isMissingDesignDocumentPath(const QString& path)
   if (!Importer::knownFileExtensions[suffix].isEmpty()) {
     return false;
   }
+  // Permissive: only rule out a plain directory at the path; other non-files (e.g. some symlinks)
+  // fall through to existing open/save behavior.
+  if (fi.exists() && fi.isDir()) {
+    return false;
+  }
   return !fi.exists() || !fi.isFile();
 }
 
@@ -301,7 +313,7 @@ void TabManager::prepareEditorBufferForNewDesignFile(EditorInterface *edt, const
     edt->setPlainText(QString::fromStdString(templ));
     edt->setLanguageManually(LANG_PYTHON);
     const QByteArray pathUtf8 = QFileInfo(absPath).absoluteFilePath().toUtf8();
-    parent->clearPythonUntrustStateForPath(
+    this->parent->clearPythonUntrustStateForPath(
       std::string(pathUtf8.constData(), static_cast<size_t>(pathUtf8.size())));
   } else
 #endif
@@ -887,6 +899,12 @@ void TabManager::openTabFile(const QString& filename)
     setEditorTabName(fname, fpath, editor);
     parent->setWindowTitle(fname);
     emit editorContentReloaded(editor);
+    return;
+  }
+
+  if (fileinfo.exists() && fileinfo.isDir()) {
+    warnDesignPathIsDirectory(parent, absPath);
+    editor->diskBacked = false;
     return;
   }
 

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -254,7 +254,35 @@ bool writeSessionFile(const QJsonObject& root, const QString& path, QString *err
   }
   return true;
 }
+
+bool confirmCreateMissingDesignFile(QWidget *parent, const QString& absPath)
+{
+  QMessageBox box(parent);
+  box.setIcon(QMessageBox::Question);
+  box.setWindowTitle(_("Application"));
+  box.setText(QString(_("The file \"%1\" does not exist.\n\nDo you want to create it?"))
+                .arg(QDir::toNativeSeparators(absPath)));
+  box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+  box.setDefaultButton(QMessageBox::Yes);
+  return box.exec() == QMessageBox::Yes;
+}
 }  // namespace
+
+bool TabManager::isMissingDesignDocumentPath(const QString& path)
+{
+  if (path.isEmpty() || isSessionLaunchTokenPath(path)) {
+    return false;
+  }
+  const QFileInfo fi(path);
+  const QString suffix = Importer::effectiveSuffixForOpen(path);
+  if (!Importer::knownFileExtensions.contains(suffix)) {
+    return false;
+  }
+  if (!Importer::knownFileExtensions[suffix].isEmpty()) {
+    return false;
+  }
+  return !fi.exists() || !fi.isFile();
+}
 
 TabManager::TabManager(MainWindow *o, const QString& filename)
 {
@@ -506,6 +534,7 @@ void TabManager::createTab(const QString& filename, bool initializeEmptyEditor)
   // Fill the editor with the content of the file
   if (filename.isEmpty()) {
     editor->filepath = "";
+    editor->diskBacked = false;
     if (initializeEmptyEditor) {
       initEmptyUntitledTab(editor);
       refreshDocument();
@@ -795,10 +824,12 @@ void TabManager::openTabFile(const QString& filename)
   const QString suffix = Importer::effectiveSuffixForOpen(filename);
   if (!Importer::knownFileExtensions.contains(suffix)) {
     editor->setPlainText("");
+    editor->diskBacked = false;
     if (!fileinfo.exists() || !fileinfo.isFile()) {
       return;
     }
     editor->filepath = absPath;
+    editor->diskBacked = true;
     editor->resetLanguageDetection();
     editor->parameterWidget->resetForNewDocument();
     editor->parameterWidget->readFile(absPath);
@@ -813,6 +844,31 @@ void TabManager::openTabFile(const QString& filename)
     emit editorContentReloaded(editor);
     return;
   }
+
+  const auto cmd = Importer::knownFileExtensions[suffix];
+  if (!cmd.isEmpty()) {
+    editor->filepath.clear();
+    editor->diskBacked = false;
+    editor->language = LANG_PYTHON;
+    editor->languageManuallySet = true;
+    editor->setPlainText(cmd.arg(filename));
+    refreshDocument();
+
+    auto [fname, fpath] = getEditorTabNameWithModifier(editor);
+    setEditorTabName(fname, fpath, editor);
+    parent->setWindowTitle(fname);
+    emit editorContentReloaded(editor);
+    return;
+  }
+
+  const bool missingOnDisk = !fileinfo.exists() || !fileinfo.isFile();
+  if (missingOnDisk) {
+    if (!confirmCreateMissingDesignFile(parent, absPath)) {
+      editor->diskBacked = false;
+      return;
+    }
+  }
+
 #ifdef ENABLE_PYTHON
   if (suffix == QStringLiteral("py")) {
     std::string templ = "from openscad import *\n";
@@ -826,27 +882,35 @@ void TabManager::openTabFile(const QString& filename)
     editor->setPlainText(QString::fromStdString(templ));
   } else
 #endif
+  {
     editor->setPlainText("");
-
-  const auto cmd = Importer::knownFileExtensions[suffix];
-  if (cmd.isEmpty()) {
-    editor->filepath = fileinfo.absoluteFilePath();
-#ifdef ENABLE_PYTHON
-    if (suffix == QStringLiteral("py")) {
-      const QByteArray pathUtf8 = editor->filepath.toUtf8();
-      parent->clearPythonUntrustStateForPath(
-        std::string(pathUtf8.constData(), static_cast<size_t>(pathUtf8.size())));
-    }
-#endif
-    editor->parameterWidget->resetForNewDocument();
-    editor->parameterWidget->readFile(fileinfo.absoluteFilePath());
-    parent->updateRecentFiles(filename);
-  } else {
-    editor->filepath.clear();
-    editor->language = LANG_PYTHON;
-    editor->languageManuallySet = true;
-    editor->setPlainText(cmd.arg(filename));
   }
+
+  editor->filepath = absPath;
+#ifdef ENABLE_PYTHON
+  if (suffix == QStringLiteral("py")) {
+    const QByteArray pathUtf8 = editor->filepath.toUtf8();
+    parent->clearPythonUntrustStateForPath(
+      std::string(pathUtf8.constData(), static_cast<size_t>(pathUtf8.size())));
+  }
+#endif
+  editor->parameterWidget->resetForNewDocument();
+  if (!missingOnDisk) {
+    editor->parameterWidget->readFile(absPath);
+  }
+
+  if (missingOnDisk) {
+    if (!save(editor, absPath)) {
+      editor->filepath.clear();
+      editor->diskBacked = false;
+      return;
+    }
+    editor->parameterWidget->readFile(absPath);
+  } else {
+    editor->diskBacked = true;
+    parent->updateRecentFiles(filename);
+  }
+
   refreshDocument();
 
   auto [fname, fpath] = getEditorTabNameWithModifier(editor);
@@ -934,6 +998,7 @@ bool TabManager::refreshDocument()
         setContentRenderState();  // since last render
         editor->recomputeLanguageActive();
       }
+      editor->diskBacked = true;
       file_opened = true;
     }
   }
@@ -1116,11 +1181,13 @@ bool TabManager::shouldSkipSessionSave()
 
 void TabManager::setTabSessionData(EditorInterface *edt, const QString& filepath, const QString& content,
                                    bool contentModified, bool parameterModified,
-                                   const QByteArray& customizerState, std::optional<int> sessionLanguage)
+                                   const QByteArray& customizerState, std::optional<int> sessionLanguage,
+                                   bool diskBackedValue)
 {
   const QSignalBlocker blockEditor(edt);
   const QSignalBlocker blockParameters(edt->parameterWidget);
   edt->filepath = filepath;
+  edt->diskBacked = diskBackedValue;
   edt->setPlainText(content);
   edt->setContentModified(contentModified);
   edt->parameterWidget->setModified(parameterModified);
@@ -1169,6 +1236,7 @@ void TabManager::saveSession(const QString& path)
     obj.insert(QStringLiteral("content"), edt->toPlainText());
     obj.insert(QStringLiteral("contentModified"), edt->isContentModified());
     obj.insert(QStringLiteral("parameterModified"), edt->parameterWidget->isModified());
+    obj.insert(QStringLiteral("diskBacked"), edt->diskBacked);
     obj.insert(QStringLiteral("language"), edt->language);
     int cursorLine = 0;
     int cursorColumn = 0;
@@ -1254,6 +1322,7 @@ bool TabManager::saveGlobalSession(const QString& path, QString *error, bool sho
       obj.insert(QStringLiteral("content"), edt->toPlainText());
       obj.insert(QStringLiteral("contentModified"), edt->isContentModified());
       obj.insert(QStringLiteral("parameterModified"), edt->parameterWidget->isModified());
+      obj.insert(QStringLiteral("diskBacked"), edt->diskBacked);
       obj.insert(QStringLiteral("language"), edt->language);
       int cursorLine = 0;
       int cursorColumn = 0;
@@ -1337,6 +1406,10 @@ bool TabManager::migrateSession(QJsonObject& root, int fromVersion)
     }
     case 3: {
       // v3 -> v4: optional per-tab diskIdentity (mtime+size at session save).
+      break;
+    }
+    case 4: {
+      // v4 -> v5: optional per-tab diskBacked (loaded from disk or saved at least once).
       break;
     }
     default:
@@ -1473,11 +1546,23 @@ bool TabManager::restoreSession(const QString& path, int windowIndex)
     }
 
     const QFileInfo fileInfo(filepath);
-    // Never treat default untitled filenames as stale disk paths: the session may record a path
-    // that was never created (e.g. missing file opened by name, or save-dialog default).
-    const bool standardUntitled = isStandardUntitledFilename(filepath);
+    bool tabDiskBacked = false;
+    if (obj.contains(QStringLiteral("diskBacked"))) {
+      tabDiskBacked = obj.value(QStringLiteral("diskBacked")).toBool();
+    } else {
+      const bool onDiskNow = fileInfo.exists() && fileInfo.isFile();
+      if (onDiskNow) {
+        tabDiskBacked = true;
+      } else {
+        // Pre-v5 session: infer disk backing for stale-file warning (see diskBacked in Editor).
+        tabDiskBacked = !filepath.isEmpty() && !isSessionLaunchTokenPath(filepath) &&
+                        fileInfo.isAbsolute() && !isStandardUntitledFilename(filepath) &&
+                        !contentModified;
+      }
+    }
+
     const bool countsAsMissing = !filepath.isEmpty() && !isSessionLaunchTokenPath(filepath) &&
-                                 fileInfo.isAbsolute() && !fileInfo.exists() && !standardUntitled;
+                                 fileInfo.isAbsolute() && tabDiskBacked && !fileInfo.exists();
     if (countsAsMissing) {
       if (firstMissingIndex < 0) {
         firstMissingIndex = i;
@@ -1508,7 +1593,7 @@ bool TabManager::restoreSession(const QString& path, int windowIndex)
       edt = editor;
     }
     setTabSessionData(edt, filepath, content, contentModified, parameterModified, customizerState,
-                      sessionLanguage);
+                      sessionLanguage, tabDiskBacked);
     if (findState < TabManager::FIND_HIDDEN || findState > TabManager::FIND_REPLACE_VISIBLE) {
       findState = TabManager::FIND_HIDDEN;
     }
@@ -1731,6 +1816,7 @@ bool TabManager::save(EditorInterface *edt, const QString& path)
     edt->parameterWidget->setModified(false);
     parent->updateRecentFiles(path);
     edt->filepath = path;
+    edt->diskBacked = true;
     QSettingsCached settings;
     settings.setValue(QStringLiteral("lastOpenDirName"), QFileInfo(path).absolutePath());
   } else {

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -54,6 +54,8 @@ public:
   static bool isMissingDesignDocumentPath(const QString& path);
   /// Ask whether to create a missing design file; shared by MainWindow (deferred CLI) and openTabFile.
   static bool confirmCreateMissingDesignFile(QWidget *parent, const QString& absPath);
+  /// Reset buffer and language for a new .scad/.py file at \a absPath (used before first save).
+  void prepareEditorBufferForNewDesignFile(EditorInterface *edt, const QString& absPath);
   size_t count();
   void switchToEditor(EditorInterface *editor);
 

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -52,6 +52,8 @@ public:
   void open(const QString& filename);
   /// True if \a path is a .scad/.py design path that does not exist on disk yet (CLI / open checks).
   static bool isMissingDesignDocumentPath(const QString& path);
+  /// Ask whether to create a missing design file; shared by MainWindow (deferred CLI) and openTabFile.
+  static bool confirmCreateMissingDesignFile(QWidget *parent, const QString& absPath);
   size_t count();
   void switchToEditor(EditorInterface *editor);
 

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -44,10 +44,14 @@ public:
   bool refreshDocument();  // returns false if the file could not be opened
   bool shouldClose();
   bool save(EditorInterface *edt);
+  /// Write \a edt to \a path (used for CLI "create missing file" and internal save).
+  bool save(EditorInterface *edt, const QString& path);
   bool saveAs(EditorInterface *edt);
   bool saveAs(EditorInterface *edt, const QString& filepath);
   bool saveACopy(EditorInterface *edt);
   void open(const QString& filename);
+  /// True if \a path is a .scad/.py design path that does not exist on disk yet (CLI / open checks).
+  static bool isMissingDesignDocumentPath(const QString& path);
   size_t count();
   void switchToEditor(EditorInterface *editor);
 
@@ -71,7 +75,7 @@ public:
   // Session file schema version. Increment when the format changes and add a
   // migration step in migrateSession().  Old files without a version field are
   // treated as version 1.
-  static constexpr int SESSION_VERSION = 4;
+  static constexpr int SESSION_VERSION = 5;
 
 public:
   static constexpr const int FIND_HIDDEN = 0;
@@ -98,14 +102,13 @@ private:
   bool maybeSave(int);
   /// Tab title for message boxes (no `&` doubling; see getEditorTabName for QTabWidget labels).
   QString plainEditorTitleForMessages(EditorInterface *edt) const;
-  bool save(EditorInterface *edt, const QString& path);
   void saveError(const QIODevice& file, const std::string& msg, const QString& filepath);
   void applyAction(QObject *object, const std::function<void(int, EditorInterface *)>& func);
   void setTabsCloseButtonVisibility(int tabIndice, bool isVisible);
   void setTabSessionData(EditorInterface *edt, const QString& filepath, const QString& content,
                          bool contentModified, bool parameterModified,
                          const QByteArray& customizerState = QByteArray(),
-                         std::optional<int> sessionLanguage = std::nullopt);
+                         std::optional<int> sessionLanguage = std::nullopt, bool diskBacked = false);
   static bool migrateSession(QJsonObject& root, int fromVersion);
 
   enum class SessionFileReadStatus {


### PR DESCRIPTION
## Summary
- Track whether each editor tab was ever loaded from disk or saved (`diskBacked`) and persist it in session JSON (schema v5).
- Session restore only shows the "could not be found on disk" warning when `diskBacked` is true and the path is missing (fixes phantom paths from `pythonscad missing.py` without save).
- For a missing `.py`/`.scad` CLI path: hide the tab widget until after a **Create file?** dialog; **Yes** initializes buffer/language for the target extension then saves; **No** leaves the default Untitled tab.
- `fileChangedOnDisk()` returns false when `!diskBacked` to avoid spurious reload prompts for never-persisted paths.
- If the CLI path exists but is a **directory**, show a warning and do not offer "create file" (permissive handling: only directories are special-cased; other non-regular paths keep prior behavior).

## Copilot review follow-ups
- **Pre-v5 sessions:** infer `diskBacked` from non-empty `diskIdentity` when the `diskBacked` key is absent, so dirty tabs that were loaded from disk still get reload/missing-path behavior.
- **Shared prompt:** `TabManager::confirmCreateMissingDesignFile()` used from `MainWindow` and `openTabFile`.
- **Deferred CLI vs extension:** `prepareEditorBufferForNewDesignFile()` ensures creating a missing `.scad` from the CLI does not write the Python template (same helper reused in `openTabFile` after create confirmation).
- **`TabManager::parent`:** `prepareEditorBufferForNewDesignFile` uses the existing `MainWindow *parent` member (`this->parent` for clarity); it is in scope in non-static methods.

## Testing
- `nice cmake --build build -j8`

Fixes #547