### PR TITLE
feat(gui): terminal notice on single-instance IPC handoff

### DIFF
--- a/locale/openscad.pot
+++ b/locale/openscad.pot
@@ -3138,3 +3138,15 @@ msgstr ""
 #: src/openscad_gui.cc
 msgid "Try again if the running instance may have recovered, or close it to start a new one."
 msgstr ""
+
+#: src/openscad_gui.cc
+msgid ""
+"PythonSCAD is already running. The existing window was brought to the front; "
+"this process exits."
+msgstr ""
+
+#: src/openscad_gui.cc
+msgid ""
+"PythonSCAD is already running. An open request for the requested design file(s) was sent "
+"to that instance; this process exits."
+msgstr ""

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -669,6 +669,19 @@ QString assemblePath(const std::filesystem::path& absoluteBaseDir, const std::st
   return fileInfo.absoluteFilePath();
 }
 
+void printSingleInstanceIpcHandoffNotice(const QStringList& ipcFiles)
+{
+  if (ipcFiles.isEmpty()) {
+    LOG(
+      _("PythonSCAD is already running. The existing window was brought to the front; this process "
+        "exits."));
+  } else {
+    LOG(
+      _("PythonSCAD is already running. An open request for the requested design file(s) was sent to "
+        "that instance; this process exits."));
+  }
+}
+
 void dialogThreadFunc(FontCacheInitializer *initializer)
 {
   initializer->run();
@@ -782,6 +795,7 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
     const QJsonObject message = buildIpcMessage(action, ipcFiles, openMode, cwd);
 
     if (sendIpcMessage(message)) {
+      printSingleInstanceIpcHandoffNotice(ipcFiles);
       return 0;
     }
 
@@ -806,6 +820,7 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
       }
       if (clicked == retryBtn) {
         if (sendIpcMessage(message)) {
+          printSingleInstanceIpcHandoffNotice(ipcFiles);
           return 0;
         }
         continue;
@@ -815,6 +830,7 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
         break;
       }
       if (sendIpcMessage(message)) {
+        printSingleInstanceIpcHandoffNotice(ipcFiles);
         return 0;
       }
     }


### PR DESCRIPTION
## Summary

When a user starts a second PythonSCAD while one is already running, the new process forwards open/focus to the primary instance over IPC and exits with code 0. That is easy to misread as a silent failure from the terminal.

This change prints one line to stderr (via the existing `LOG` path, same as other user-facing messages such as in `export.cc`) explaining that the running instance was contacted and this process is exiting. Strings use `_()` so they are picked up for gettext like the nearby single-instance dialog text.

`locale/openscad.pot` is updated with the new msgids.

## Test plan

- [ ] Build succeeds (`cmake --build build`).
- [ ] With PythonSCAD running, run `pythonscad /path/to/file.py` (or `.scad`) from a terminal; expect a short explanatory message on stderr before exit.


Made with [Cursor](https://cursor.com)