### PR TITLE
feat(gui): enable session management by default

### DIFF
--- a/src/core/Settings.cc
+++ b/src/core/Settings.cc
@@ -212,7 +212,7 @@ SettingsEntryEnum<std::string> Settings::singleInstanceOpenMode(
   {{"new-window", "new-window", _("Open in new window")},
    {"active-window", "active-window", _("Reuse active window")}},
   "active-window");
-SettingsEntryBool Settings::sessionManagementEnabled("advanced", "sessionManagementEnabled", false);
+SettingsEntryBool Settings::sessionManagementEnabled("advanced", "sessionManagementEnabled", true);
 SettingsEntryBool Settings::autosaveSessionEnabled("advanced", "autosaveSessionEnabled", true);
 SettingsEntryInt Settings::autosaveSessionIntervalSeconds("advanced", "autosaveSessionIntervalSeconds",
                                                           10, 600, 60);

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -193,7 +193,7 @@ void Preferences::init()
   this->defaultmap["advanced/enableParameterCheck"] = true;
   this->defaultmap["advanced/enableParameterRangeCheck"] = false;
   this->defaultmap["advanced/singleInstanceOpenMode"] = "active-window";
-  this->defaultmap["advanced/sessionManagementEnabled"] = false;
+  this->defaultmap["advanced/sessionManagementEnabled"] = true;
   this->defaultmap["advanced/autosaveSessionEnabled"] = true;
   this->defaultmap["advanced/autosaveSessionIntervalSeconds"] = 60;
   this->defaultmap["view/hideEditor"] = false;


### PR DESCRIPTION
## Summary

Enable **session management** by default for new installs and when the preference has never been set.

- `Settings::sessionManagementEnabled` default: `false` → `true` (`src/core/Settings.cc`)
- Preferences `defaultmap` aligned (`src/gui/Preferences.cc`)

**Session autosave** (`autosaveSessionEnabled`) was already default-on; no change.

## Notes

Users who already have `sessionManagementEnabled=false` stored in their config are unchanged. Only the built-in default and reset-to-defaults behavior change.

Build: `nice cmake --build build -j10` (success).

Made with [Cursor](https://cursor.com)