### PR TITLE
fix(svg): fix function of osimport:stroke parameter

### DIFF
--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -46,6 +46,6 @@ public:
   CurveDiscretizer discretizer;
   double origin_x, origin_y, scale;
   double width, height;
-  bool stroke = true;
+  bool stroke = false;
   std::unique_ptr<const class Geometry> createGeometry() const override;
 };

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -211,7 +211,7 @@ std::unique_ptr<Polygon2d> import_svg(CurveDiscretizer discretizer, const std::s
             outline.vertices.emplace_back(x, y);
             outline.positive = true;
           }
-          if (outline.vertices[0] == outline.vertices[outline.vertices.size() - 1])
+          if (outline.vertices[0] == outline.vertices[outline.vertices.size() - 1] && stroke == false)
             poly.addOutline(outline);
           else poly.addPolyline(outline);
         }

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -487,7 +487,7 @@ void path::set_attrs(attr_map_t& attrs, void *context)
 
   if (!path_closed && !path_list.empty()) {
     path_t path = path_list.back();
-    if (is_open_path(path) && fValues->stroke) {
+    if (is_open_path(path) && !fValues->stroke) {
       path_list.pop_back();
       offset_path(path_list, path, get_stroke_width(), get_stroke_linecap());
     }


### PR DESCRIPTION
stroke shall make sure, that whole svg files will import as polylines only