### PR TITLE
fix(gui): don't mark windows as quitting on session-manager checkpoint

### DIFF
--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -278,7 +278,12 @@ void setupAutosaveTimer(OpenSCADApp *app)
   timer->start();
 }
 
-bool saveSessionForShutdown()
+// Pure writer: serialize all open windows into the on-disk session file.
+// No side effects on window state. Safe to call from non-shutdown contexts
+// such as QGuiApplication::saveStateRequest, which the desktop session
+// manager may emit at any time (including very early in the lifecycle) and
+// which is NOT a shutdown signal.
+bool writeGlobalSessionFromAllWindows()
 {
   if (!Settings::Settings::sessionManagementEnabled.value()) return false;
   const auto& windows = scadApp->windowManager.getWindows();
@@ -289,20 +294,36 @@ bool saveSessionForShutdown()
     QFile::remove(TabManager::getAutosaveFilePath());
     return false;
   }
-  for (auto *win : windows) {
-    win->markSessionQuitting();
-  }
   QString saveError;
   const bool success =
     TabManager::saveGlobalSession(TabManager::getSessionFilePath(), &saveError, false);
   if (!success && !saveError.isEmpty()) {
-    LOG(message_group::UI_Warning, "Failed to save session on shutdown: %1$s",
-        saveError.toUtf8().constData());
+    LOG(message_group::UI_Warning, "Failed to save session: %1$s", saveError.toUtf8().constData());
   }
   if (success) {
     QFile::remove(TabManager::getAutosaveFilePath());
   }
   return success;
+}
+
+// Mark every open MainWindow as session-quitting so that subsequent
+// closeEvent() calls skip the interactive guards (single-window quit prompt
+// and shouldClose() unsaved-changes prompt). Only call from genuine shutdown
+// paths: QCoreApplication::aboutToQuit, QGuiApplication::commitDataRequest,
+// or POSIX termination signals.
+void markAllWindowsQuitting()
+{
+  for (auto *win : scadApp->windowManager.getWindows()) {
+    win->markSessionQuitting();
+  }
+}
+
+// Composite: mark windows as quitting and write the session. Use from
+// shutdown contexts only.
+bool saveSessionForShutdown()
+{
+  markAllWindowsQuitting();
+  return writeGlobalSessionFromAllWindows();
 }
 
 constexpr int kIpcTimeoutMs = 1500;
@@ -1029,8 +1050,12 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
 
   QObject::connect(&app, &QGuiApplication::commitDataRequest, &app,
                    [](QSessionManager&) { saveSessionForShutdown(); });
+  // saveStateRequest is a session-manager checkpoint, NOT a shutdown signal.
+  // Persist current state but do NOT mark windows as quitting; otherwise a
+  // subsequent X-button close skips quitApplication() and the user's edits
+  // never reach disk.
   QObject::connect(&app, &QGuiApplication::saveStateRequest, &app,
-                   [](QSessionManager&) { saveSessionForShutdown(); });
+                   [](QSessionManager&) { writeGlobalSessionFromAllWindows(); });
 
 #ifdef Q_OS_UNIX
   setupUnixSignalHandlers(&app);


### PR DESCRIPTION
Fixes #580.

## Summary

`QGuiApplication::saveStateRequest` is a session-manager checkpoint, not a
shutdown signal. Wiring it through `saveSessionForShutdown()` caused
`markSessionQuitting()` to fire on every open `MainWindow` at startup under
XSMP-compatible session managers (KDE, GNOME), poisoning `isSessionQuitting`.
A subsequent X-button close then skipped the `!isSessionQuitting` branch in
`closeEvent()`, bypassed `quitApplication()` (the only path that runs the
interactive save with retry dialog), and the user's edits never reached the
session file. The `aboutToQuit` safety-net save couldn't recover either,
because by the time it fires the `WA_DeleteOnClose` window has already been
removed from `windowManager`.

## Changes

Split `saveSessionForShutdown()` into:

- `writeGlobalSessionFromAllWindows()` &mdash; pure writer, no side effects on
  window state.
- `markAllWindowsQuitting()` &mdash; state mutation only.
- `saveSessionForShutdown()` &mdash; composite, calls both. Reserved for
  genuine shutdown contexts.

Wire the connections accordingly:

- `saveStateRequest` &rarr; `writeGlobalSessionFromAllWindows()` (pure writer).
- `commitDataRequest`, `aboutToQuit`, and the POSIX termination signal handler
  &rarr; `saveSessionForShutdown()` (real shutdowns).

## Test plan

- [x] Builds cleanly with the existing CMake/ninja configuration.
- [ ] Manual repro on KDE/GNOME: ``pythonscad somedesign.py``, edit a line,
  close via X, relaunch &mdash; the line is preserved.
- [ ] Manual: explicit Quit (Ctrl+Q / menu) still saves the session via the
  interactive retry dialog when the on-disk write fails.
- [ ] Manual: SIGTERM to the running process still saves the session.
- [ ] Existing ``ctest`` suite passes.

## Notes

This PR addresses only the primary bug described in #580. The secondary
observation (the `aboutToQuit` safety-net save being a no-op once
`WA_DeleteOnClose` has destroyed the last window) is left as-is, because the
canonical save in `quitApplication()` runs *before* window destruction and
already covers the X-button-on-last-window case once the primary bug is gone.
A future cleanup could remove the now-redundant `aboutToQuit` save or replace
it with a snapshot taken earlier in the close path.

Made with [Cursor](https://cursor.com)