### PR TITLE
fix(ci): use PAT when promoting release so PyPI workflow gets triggered

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -258,6 +258,10 @@ jobs:
       - name: Publish release
         uses: actions/github-script@v8
         with:
+          # Use bot account PAT so the resulting `release: released` event
+          # can trigger downstream workflows (e.g. publish-to-pypi.yml).
+          # The default GITHUB_TOKEN cannot trigger other workflows.
+          github-token: ${{ secrets.RELEASE_TOKEN }}
           script: |
             const releaseId = ${{ needs.wait-for-builds.outputs.release_id }};
             const releaseTag = '${{ needs.wait-for-builds.outputs.release_tag }}';


### PR DESCRIPTION
## Summary

The `Publish to PyPI` workflow has never run since it was introduced in #493, even though four releases (v0.18.0, v0.19.1, v0.20.0, …) have happened since.

Root cause: `publish-release.yml`'s `publish` job promotes a prerelease into a full release via `actions/github-script` using the default `GITHUB_TOKEN`. GitHub deliberately does *not* fire downstream events (with the exception of `workflow_dispatch` / `repository_dispatch`) for actions performed with `GITHUB_TOKEN`, so the `release: released` event that `publish-to-pypi.yml` listens for is never produced.

This PR threads `secrets.RELEASE_TOKEN` (the same bot PAT `release-please.yml` already uses for exactly the same reason) into the `github-script` step. Once merged, promoting a prerelease will produce a real `release: released` event, which will trigger `publish-to-pypi.yml`.

The diff is intentionally tiny — one `github-token:` line and a 3-line comment explaining *why* the PAT is required, so it isn't accidentally "cleaned up" back to the default token later.

## Test plan

- [ ] Confirm the one-time PyPI setup described in the header of `.github/workflows/publish-to-pypi.yml` is in place (PyPI project `pythonscad` exists; trusted publisher configured for repo `pythonscad/pythonscad`, workflow `publish-to-pypi.yml`, environment `pypi`).
- [ ] After merge, optionally backfill the current release with `gh workflow run "Publish to PyPI" -R pythonscad/pythonscad` (the workflow already declares `workflow_dispatch:`).
- [ ] On the next release, verify in the Actions tab that `Publish to PyPI` is triggered automatically when `Publish Release` flips the prerelease → released, and that the resulting sdist appears on https://pypi.org/project/pythonscad/.


Made with [Cursor](https://cursor.com)