### PR TITLE
feat(python): add MultiToolExporter helper to pythonscad module

### DIFF
--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -200,6 +200,19 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         else:
             super().__setitem__(index, self._validate_item(value))
 
+    def __iadd__(self, other):
+        """Validate each item then in-place extend (``self += other``).
+
+        Without this override, CPython's ``list.__iadd__`` calls
+        ``list_extend`` at the C level and bypasses :meth:`extend`,
+        which would let ``self += [bad_item]`` smuggle invalid entries
+        past the validation hooks. Validation is atomic: every item in
+        ``other`` is checked *before* anything is appended, so a bad
+        item in the middle leaves ``self`` unchanged.
+        """
+        validated = [self._validate_item(item) for item in other]
+        return super().__iadd__(validated)
+
     def _filename(self, i: int) -> str:
         """Return the output filename for part ``i``."""
         return f"{self.prefix}{self[i][0]}{self.suffix}"

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -72,10 +72,11 @@ class MultiToolExporter(list[Tuple[Any, str]]):
     files written by earlier ones).
 
     Example:
+        >>> # Append base/background parts first; later entries "win" overlap.
         >>> exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
-        >>> exporter.append((red_geometry, "red"))
-        >>> exporter.append((blue_geometry, "blue"))
-        >>> exporter.export()  # writes out/flag-red.stl and out/flag-blue.stl
+        >>> exporter.append((base_geometry, "base"))
+        >>> exporter.append((overlay_geometry, "overlay"))
+        >>> exporter.export()  # writes out/flag-base.stl and out/flag-overlay.stl
     """
 
     def __init__(

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -53,24 +53,30 @@ def _normalize_filename_key(filename: str) -> str:
     return key
 
 
-class MultiToolExporter(list[tuple[_typing.Any, str]]):
+class MultiToolExporter(list[tuple[str, _typing.Any]]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
-    Each item in the list is a ``(object, name)`` tuple, where ``object`` is a
-    PythonSCAD geometry and ``name`` is a label used to build the output
-    filename. The exporter is designed for workflows where a single model is
+    Each item in the list is a ``(name, object)`` tuple, where ``name`` is a
+    label used to build the output filename and ``object`` is a PythonSCAD
+    geometry. The exporter is designed for workflows where a single model is
     split into several parts (for example, one part per filament color on a
     multi-tool 3D printer).
+
+    Item order matches :func:`dict.items` and the multi-object form of
+    :func:`export` (``export({"part1": obj1, "part2": obj2}, "out.3mf")``),
+    so a :class:`MultiToolExporter` and a ``dict`` of parts are
+    interchangeable: ``exporter = MultiToolExporter(..., items=parts.items())``
+    and ``parts = dict(exporter.parts())``.
 
     Semantics
     ---------
     For each index ``i`` in the list, the exporter produces the geometry
-    obtained by taking ``self[i][0]`` and subtracting all later objects
-    ``self[i+1:][...]`` from it. Overlapping regions are therefore assigned to
-    exactly one part: **later entries "win" over earlier ones**, so each part
-    only keeps the volume not claimed by any subsequent part. The last entry
-    is emitted as-is (no degenerate one-child ``difference`` node) and
-    therefore "wins" everything that overlaps with it.
+    obtained by taking ``self[i]``'s object and subtracting every later
+    item's object from it. Overlapping regions are therefore assigned to
+    exactly one part: **later entries "win" over earlier ones**, so each
+    part only keeps the volume not claimed by any subsequent part. The
+    last entry is emitted as-is (no degenerate one-child ``difference``
+    node) and therefore "wins" everything that overlaps with it.
 
     Attributes:
         prefix: String prepended to each output filename. Typically a path
@@ -86,7 +92,7 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
     ----------
     Items are validated on insertion (constructor argument, :meth:`append`,
     :meth:`extend`, :meth:`insert`, ``self[i] = ...``). A :class:`TypeError`
-    is raised if the item is not a 2-tuple of ``(object, str)``, and a
+    is raised if the item is not a 2-tuple of ``(str, object)``, and a
     :class:`ValueError` is raised if the name is empty.
 
     Output paths must be unique per item: at :meth:`export` time, every
@@ -103,8 +109,8 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
     Example:
         >>> # Append base/background parts first; later entries "win" overlap.
         >>> exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
-        >>> exporter.append((base_geometry, "base"))
-        >>> exporter.append((overlay_geometry, "overlay"))
+        >>> exporter.append(("base", base_geometry))
+        >>> exporter.append(("overlay", overlay_geometry))
         >>> exporter.export()  # writes out/flag-base.stl and out/flag-overlay.stl
     """
 
@@ -113,7 +119,7 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         prefix: str,
         suffix: str,
         mkdir: bool = False,
-        items: _typing.Iterable[tuple[_typing.Any, str]] = (),
+        items: _typing.Iterable[tuple[str, _typing.Any]] = (),
     ):
         """Initialize a (possibly empty) MultiToolExporter.
 
@@ -123,12 +129,13 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
                 extension.
             mkdir: If ``True``, create the output directory for each file
                 before exporting. Defaults to ``False``.
-            items: Optional iterable of initial ``(object, name)`` tuples.
-                Each item is validated as if it were appended.
+            items: Optional iterable of initial ``(name, object)`` tuples
+                (e.g. ``a_dict.items()``). Each item is validated as if it
+                were appended.
 
         Raises:
             TypeError: If any item in ``items`` is not a 2-tuple of
-                ``(object, str)``.
+                ``(str, object)``.
             ValueError: If any name in ``items`` is empty.
         """
         super().__init__()
@@ -139,20 +146,20 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
             self.append(item)
 
     @staticmethod
-    def _validate_item(item: _typing.Any) -> tuple[_typing.Any, str]:
-        """Return ``item`` if it is a valid ``(object, str)`` 2-tuple.
+    def _validate_item(item: _typing.Any) -> tuple[str, _typing.Any]:
+        """Return ``item`` if it is a valid ``(str, object)`` 2-tuple.
 
         Raises:
-            TypeError: If ``item`` is not a 2-tuple whose second element is
+            TypeError: If ``item`` is not a 2-tuple whose first element is
                 a string. Lists and other sequences are rejected.
             ValueError: If the name is empty.
         """
         if not isinstance(item, tuple) or len(item) != 2:
             raise TypeError(
-                f"MultiToolExporter items must be (object, name) 2-tuples, "
+                f"MultiToolExporter items must be (name, object) 2-tuples, "
                 f"got {type(item).__name__}: {item!r}"
             )
-        _, name = item
+        name, _ = item
         if not isinstance(name, str):
             raise TypeError(
                 f"MultiToolExporter item name must be a str, "
@@ -162,12 +169,12 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
             raise ValueError("MultiToolExporter item name must be a non-empty string")
         return item
 
-    def append(self, item: tuple[_typing.Any, str]) -> None:
-        """Append a validated ``(object, name)`` tuple."""
+    def append(self, item: tuple[str, _typing.Any]) -> None:
+        """Append a validated ``(name, object)`` tuple."""
         super().append(self._validate_item(item))
 
-    def extend(self, items: _typing.Iterable[tuple[_typing.Any, str]]) -> None:
-        """Append each ``(object, name)`` tuple from ``items``.
+    def extend(self, items: _typing.Iterable[tuple[str, _typing.Any]]) -> None:
+        """Append each ``(name, object)`` tuple from ``items``.
 
         Atomic: every item is validated *before* anything is appended, so a
         bad item in the middle of the iterable leaves the exporter unchanged.
@@ -175,12 +182,12 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         validated = [self._validate_item(item) for item in items]
         super().extend(validated)
 
-    def insert(self, index: _typing.SupportsIndex, item: tuple[_typing.Any, str]) -> None:
-        """Insert a validated ``(object, name)`` tuple at ``index``."""
+    def insert(self, index: _typing.SupportsIndex, item: tuple[str, _typing.Any]) -> None:
+        """Insert a validated ``(name, object)`` tuple at ``index``."""
         super().insert(index, self._validate_item(item))
 
     def __setitem__(self, index, value):
-        """Replace one or more items, validating each new ``(object, name)``."""
+        """Replace one or more items, validating each new ``(name, object)``."""
         if isinstance(index, slice):
             super().__setitem__(index, [self._validate_item(v) for v in value])
         else:
@@ -188,15 +195,15 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
 
     def _filename(self, i: int) -> str:
         """Return the output filename for part ``i``."""
-        return f"{self.prefix}{self[i][1]}{self.suffix}"
+        return f"{self.prefix}{self[i][0]}{self.suffix}"
 
     def _part(self, i: int):
-        """Return the geometry for part ``i``: ``self[i][0]`` minus all later parts.
+        """Return the geometry for part ``i``: ``self[i]``'s object minus all later parts.
 
         For the last entry, the object is returned as-is rather than wrapped
         in a one-child ``difference`` node.
         """
-        rest = [obj for obj, _name in self[i:]]
+        rest = [obj for _name, obj in self[i:]]
         return rest[0] if len(rest) == 1 else difference(*rest)  # noqa: F405
 
     def _check_unique_filenames(self) -> None:
@@ -213,7 +220,7 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         """
         seen: dict[str, tuple[str, str]] = {}
         for i in range(len(self)):
-            name = self[i][1]
+            name = self[i][0]
             filename = self._filename(i)
             key = _normalize_filename_key(filename)
             if key in seen:
@@ -230,9 +237,9 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
 
         Each geometry is the cumulative-difference result identical to
         what :meth:`export` would write or :meth:`show` would preview:
-        for index ``i``, ``self[i][0]`` minus every later object, with
-        the last entry returned as-is (no degenerate one-child
-        ``difference`` node).
+        for index ``i``, ``self[i]``'s object minus every later item's
+        object, with the last entry returned as-is (no degenerate
+        one-child ``difference`` node).
 
         This is the programmatic accessor used internally by
         :meth:`export` and :meth:`show`. It is also the natural input
@@ -242,7 +249,7 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         Returns:
             A new list of ``(name, computed_geometry)`` tuples.
         """
-        return [(self[i][1], self._part(i)) for i in range(len(self))]
+        return [(self[i][0], self._part(i)) for i in range(len(self))]
 
     def export(self) -> None:
         """Export each part to a file via PythonSCAD.

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -225,12 +225,30 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
                 )
             seen[key] = (name, filename)
 
+    def parts(self) -> list[tuple[str, _typing.Any]]:
+        """Return the computed ``(name, geometry)`` pairs in declaration order.
+
+        Each geometry is the cumulative-difference result identical to
+        what :meth:`export` would write or :meth:`show` would preview:
+        for index ``i``, ``self[i][0]`` minus every later object, with
+        the last entry returned as-is (no degenerate one-child
+        ``difference`` node).
+
+        This is the programmatic accessor used internally by
+        :meth:`export` and :meth:`show`. It is also the natural input
+        to the multi-object 3MF export form
+        (``export(dict(exporter.parts()), "out.3mf")``).
+
+        Returns:
+            A new list of ``(name, computed_geometry)`` tuples.
+        """
+        return [(self[i][1], self._part(i)) for i in range(len(self))]
+
     def export(self) -> None:
         """Export each part to a file via PythonSCAD.
 
-        For each index ``i``, exports the difference of ``self[i][0]`` and
-        all subsequent objects to ``f"{prefix}{name}{suffix}"``. The last
-        entry is exported as-is without a degenerate ``difference`` node.
+        For each item, exports the result of :meth:`parts` to
+        ``f"{prefix}{name}{suffix}"``.
 
         If :attr:`mkdir` is ``True``, the parent directory of each output
         file is created beforehand (filenames without a directory component
@@ -242,21 +260,20 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
                 Windows/macOS, case-only collisions).
         """
         self._check_unique_filenames()
-        for i in range(len(self)):
-            filename = self._filename(i)
+        for name, geometry in self.parts():
+            filename = f"{self.prefix}{name}{self.suffix}"
             if self.mkdir:
                 directory = _os.path.dirname(filename)
                 if directory:
                     _os.makedirs(directory, exist_ok=True)
-            export(self._part(i), filename)  # noqa: F405
+            export(geometry, filename)  # noqa: F405
 
     def show(self) -> None:
         """Display each part in the PythonSCAD preview.
 
-        For each index ``i``, computes the difference of ``self[i][0]`` and
-        all subsequent objects and passes the result to :func:`show`,
-        producing a layered preview equivalent to what :meth:`export` would
-        write to disk.
+        Iterates :meth:`parts` and passes each computed geometry to
+        :func:`show`, producing a layered preview equivalent to what
+        :meth:`export` would write to disk.
         """
-        for i in range(len(self)):
-            show(self._part(i))  # noqa: F405
+        for _name, geometry in self.parts():
+            show(geometry)  # noqa: F405

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -28,10 +28,10 @@ from openscad import (  # noqa: F401
 )
 
 import os as _os
-from typing import Any, Iterable, List, SupportsIndex, Tuple
+from typing import Any, Iterable, SupportsIndex, Tuple
 
 
-class MultiToolExporter(List[Tuple[Any, str]]):
+class MultiToolExporter(list[Tuple[Any, str]]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
     Each item in the list is a ``(object, name)`` tuple, where ``object`` is a

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -45,9 +45,10 @@ class MultiToolExporter(list[Tuple[Any, str]]):
     For each index ``i`` in the list, the exporter produces the geometry
     obtained by taking ``self[i][0]`` and subtracting all later objects
     ``self[i+1:][...]`` from it. Overlapping regions are therefore assigned to
-    exactly one part: earlier entries "win" over later ones, so later parts
-    only contain the volume not already claimed by earlier parts. The last
-    entry is emitted as-is (no degenerate one-child ``difference`` node).
+    exactly one part: **later entries "win" over earlier ones**, so each part
+    only keeps the volume not claimed by any subsequent part. The last entry
+    is emitted as-is (no degenerate one-child ``difference`` node) and
+    therefore "wins" everything that overlaps with it.
 
     Attributes:
         prefix: String prepended to each output filename. Typically a path

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -28,7 +28,29 @@ from openscad import (  # noqa: F401
 )
 
 import os as _os
+import sys as _sys
 import typing as _typing
+
+
+def _normalize_filename_key(filename: str) -> str:
+    """Return a comparison key that matches what the OS uses for filenames.
+
+    * :func:`os.path.normpath` collapses ``foo/../bar`` aliases and redundant
+      separators on every OS.
+    * :func:`os.path.normcase` lowercases and unifies separators on Windows;
+      it is a no-op on POSIX.
+    * On ``darwin`` we additionally apply :meth:`str.casefold` because the
+      default macOS APFS volume is case-insensitive but :func:`os.path.normcase`
+      is identity on POSIX. The trade-off is that case-sensitive APFS users
+      see a false-positive collision rejection, which is the safer direction.
+
+    On Linux the result is just ``os.path.normpath(filename)``, so two items
+    differing only in case (``"a.stl"`` vs ``"A.stl"``) coexist as expected.
+    """
+    key = _os.path.normcase(_os.path.normpath(filename))
+    if _sys.platform == "darwin":
+        key = key.casefold()
+    return key
 
 
 class MultiToolExporter(list[tuple[_typing.Any, str]]):
@@ -67,9 +89,16 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
     is raised if the item is not a 2-tuple of ``(object, str)``, and a
     :class:`ValueError` is raised if the name is empty.
 
-    Duplicate names are detected at :meth:`export` time and raise
-    :class:`ValueError` (rather than silently letting later entries clobber
-    files written by earlier ones).
+    Output paths must be unique per item: at :meth:`export` time, every
+    item's full ``f"{prefix}{name}{suffix}"`` filename is normalised with
+    :func:`os.path.normcase` and :func:`os.path.normpath` (plus
+    :meth:`str.casefold` on macOS) and any collision raises
+    :class:`ValueError`. This rejects raw duplicate names on every
+    platform, plus path aliases such as ``"a/../b"`` vs ``"b"``, plus
+    case-only collisions (``"a.stl"`` vs ``"A.stl"``) on Windows and
+    macOS where the destination filesystem is typically case-insensitive.
+    On Linux such pairs are accepted because the kernel treats them as
+    distinct files.
 
     Example:
         >>> # Append base/background parts first; later entries "win" overlap.
@@ -170,21 +199,31 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         rest = [obj for obj, _name in self[i:]]
         return rest[0] if len(rest) == 1 else difference(*rest)  # noqa: F405
 
-    def _check_unique_names(self) -> None:
-        """Raise :class:`ValueError` if any two items share the same name.
+    def _check_unique_filenames(self) -> None:
+        """Raise :class:`ValueError` if any two items resolve to the same output path.
 
-        Duplicate names would produce duplicate filenames in :meth:`export`,
-        causing later parts to overwrite earlier ones. We refuse rather than
-        silently lose data.
+        The dedup key is the full output filename
+        (``f"{prefix}{name}{suffix}"``) normalised by
+        :func:`_normalize_filename_key`, so the check rejects raw
+        duplicate names plus path aliases (``"a/../b"`` vs ``"b"``) on
+        every platform, plus case-only collisions (``"a.stl"`` vs
+        ``"A.stl"``) on Windows and macOS where the destination
+        filesystem is typically case-insensitive. On Linux such pairs
+        are accepted as distinct files.
         """
-        seen = set()
-        for _, name in self:
-            if name in seen:
+        seen: dict[str, tuple[str, str]] = {}
+        for i in range(len(self)):
+            name = self[i][1]
+            filename = self._filename(i)
+            key = _normalize_filename_key(filename)
+            if key in seen:
+                prev_name, prev_filename = seen[key]
                 raise ValueError(
-                    f"MultiToolExporter has duplicate name {name!r}; "
-                    f"each item must have a unique name to avoid overwriting files"
+                    f"MultiToolExporter items would write to the same output "
+                    f"path: {prev_name!r} -> {prev_filename!r} and "
+                    f"{name!r} -> {filename!r}"
                 )
-            seen.add(name)
+            seen[key] = (name, filename)
 
     def export(self) -> None:
         """Export each part to a file via PythonSCAD.
@@ -198,9 +237,11 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         are skipped silently).
 
         Raises:
-            ValueError: If two or more items share the same name.
+            ValueError: If two or more items would write to the same
+                output path (raw duplicate names, path aliases, or, on
+                Windows/macOS, case-only collisions).
         """
-        self._check_unique_names()
+        self._check_unique_filenames()
         for i in range(len(self)):
             filename = self._filename(i)
             if self.mkdir:

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -27,6 +27,13 @@ from openscad import (  # noqa: F401
     Openscad,
 )
 
+# Convention: any module-level import that is NOT meant to be part of
+# the public `pythonscad` API must be aliased with a leading underscore
+# (e.g. ``import os as _os``). Without the underscore the name is
+# re-exported by ``from pythonscad import *``, leaks into IDE
+# auto-complete, and shows up in the public stub. The unaliased
+# re-exports above this line are deliberately public; everything below
+# is internal helper machinery.
 import os as _os
 import sys as _sys
 import typing as _typing

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -28,10 +28,10 @@ from openscad import (  # noqa: F401
 )
 
 import os as _os
-from typing import Any, Iterable, SupportsIndex, Tuple
+import typing as _typing
 
 
-class MultiToolExporter(list[Tuple[Any, str]]):
+class MultiToolExporter(list[tuple[_typing.Any, str]]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
     Each item in the list is a ``(object, name)`` tuple, where ``object`` is a
@@ -84,7 +84,7 @@ class MultiToolExporter(list[Tuple[Any, str]]):
         prefix: str,
         suffix: str,
         mkdir: bool = False,
-        items: Iterable[Tuple[Any, str]] = (),
+        items: _typing.Iterable[tuple[_typing.Any, str]] = (),
     ):
         """Initialize a (possibly empty) MultiToolExporter.
 
@@ -110,7 +110,7 @@ class MultiToolExporter(list[Tuple[Any, str]]):
             self.append(item)
 
     @staticmethod
-    def _validate_item(item: Any) -> Tuple[Any, str]:
+    def _validate_item(item: _typing.Any) -> tuple[_typing.Any, str]:
         """Return ``item`` if it is a valid ``(object, str)`` 2-tuple.
 
         Raises:
@@ -133,11 +133,11 @@ class MultiToolExporter(list[Tuple[Any, str]]):
             raise ValueError("MultiToolExporter item name must be a non-empty string")
         return item
 
-    def append(self, item: Tuple[Any, str]) -> None:
+    def append(self, item: tuple[_typing.Any, str]) -> None:
         """Append a validated ``(object, name)`` tuple."""
         super().append(self._validate_item(item))
 
-    def extend(self, items: Iterable[Tuple[Any, str]]) -> None:
+    def extend(self, items: _typing.Iterable[tuple[_typing.Any, str]]) -> None:
         """Append each ``(object, name)`` tuple from ``items``.
 
         Atomic: every item is validated *before* anything is appended, so a
@@ -146,7 +146,7 @@ class MultiToolExporter(list[Tuple[Any, str]]):
         validated = [self._validate_item(item) for item in items]
         super().extend(validated)
 
-    def insert(self, index: SupportsIndex, item: Tuple[Any, str]) -> None:
+    def insert(self, index: _typing.SupportsIndex, item: tuple[_typing.Any, str]) -> None:
         """Insert a validated ``(object, name)`` tuple at ``index``."""
         super().insert(index, self._validate_item(item))
 

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -26,3 +26,194 @@ from openscad import (  # noqa: F401
     ChildRef,
     Openscad,
 )
+
+import os as _os
+from typing import Any, Iterable, List, SupportsIndex, Tuple
+
+
+class MultiToolExporter(List[Tuple[Any, str]]):
+    """List-based helper for exporting multi-tool / multi-color 3D models.
+
+    Each item in the list is a ``(object, name)`` tuple, where ``object`` is a
+    PythonSCAD geometry and ``name`` is a label used to build the output
+    filename. The exporter is designed for workflows where a single model is
+    split into several parts (for example, one part per filament color on a
+    multi-tool 3D printer).
+
+    Semantics
+    ---------
+    For each index ``i`` in the list, the exporter produces the geometry
+    obtained by taking ``self[i][0]`` and subtracting all later objects
+    ``self[i+1:][...]`` from it. Overlapping regions are therefore assigned to
+    exactly one part: earlier entries "win" over later ones, so later parts
+    only contain the volume not already claimed by earlier parts. The last
+    entry is emitted as-is (no degenerate one-child ``difference`` node).
+
+    Attributes:
+        prefix: String prepended to each output filename. Typically a path
+            and/or base name, e.g. ``"out/model-"``.
+        suffix: String appended to each output filename, typically the file
+            extension, e.g. ``".stl"`` or ``".3mf"``.
+        mkdir: If ``True``, the directory portion of each output filename is
+            created (with :func:`os.makedirs`) before exporting. Defaults to
+            ``False``. Filenames without a directory component are exported
+            as-is, no error is raised.
+
+    Validation
+    ----------
+    Items are validated on insertion (constructor argument, :meth:`append`,
+    :meth:`extend`, :meth:`insert`, ``self[i] = ...``). A :class:`TypeError`
+    is raised if the item is not a 2-tuple of ``(object, str)``, and a
+    :class:`ValueError` is raised if the name is empty.
+
+    Duplicate names are detected at :meth:`export` time and raise
+    :class:`ValueError` (rather than silently letting later entries clobber
+    files written by earlier ones).
+
+    Example:
+        >>> exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
+        >>> exporter.append((red_geometry, "red"))
+        >>> exporter.append((blue_geometry, "blue"))
+        >>> exporter.export()  # writes out/flag-red.stl and out/flag-blue.stl
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        suffix: str,
+        mkdir: bool = False,
+        items: Iterable[Tuple[Any, str]] = (),
+    ):
+        """Initialize a (possibly empty) MultiToolExporter.
+
+        Args:
+            prefix: String prepended to each output filename.
+            suffix: String appended to each output filename, usually the file
+                extension.
+            mkdir: If ``True``, create the output directory for each file
+                before exporting. Defaults to ``False``.
+            items: Optional iterable of initial ``(object, name)`` tuples.
+                Each item is validated as if it were appended.
+
+        Raises:
+            TypeError: If any item in ``items`` is not a 2-tuple of
+                ``(object, str)``.
+            ValueError: If any name in ``items`` is empty.
+        """
+        super().__init__()
+        self.prefix = prefix
+        self.suffix = suffix
+        self.mkdir = mkdir
+        for item in items:
+            self.append(item)
+
+    @staticmethod
+    def _validate_item(item: Any) -> Tuple[Any, str]:
+        """Return ``item`` if it is a valid ``(object, str)`` 2-tuple.
+
+        Raises:
+            TypeError: If ``item`` is not a 2-element tuple/list whose second
+                element is a string.
+            ValueError: If the name is empty.
+        """
+        if not isinstance(item, tuple) or len(item) != 2:
+            raise TypeError(
+                f"MultiToolExporter items must be (object, name) 2-tuples, "
+                f"got {type(item).__name__}: {item!r}"
+            )
+        _, name = item
+        if not isinstance(name, str):
+            raise TypeError(
+                f"MultiToolExporter item name must be a str, "
+                f"got {type(name).__name__}: {name!r}"
+            )
+        if not name:
+            raise ValueError("MultiToolExporter item name must be a non-empty string")
+        return item
+
+    def append(self, item: Tuple[Any, str]) -> None:
+        """Append a validated ``(object, name)`` tuple."""
+        super().append(self._validate_item(item))
+
+    def extend(self, items: Iterable[Tuple[Any, str]]) -> None:
+        """Append each ``(object, name)`` tuple from ``items``.
+
+        Atomic: every item is validated *before* anything is appended, so a
+        bad item in the middle of the iterable leaves the exporter unchanged.
+        """
+        validated = [self._validate_item(item) for item in items]
+        super().extend(validated)
+
+    def insert(self, index: SupportsIndex, item: Tuple[Any, str]) -> None:
+        """Insert a validated ``(object, name)`` tuple at ``index``."""
+        super().insert(index, self._validate_item(item))
+
+    def __setitem__(self, index, value):
+        """Replace one or more items, validating each new ``(object, name)``."""
+        if isinstance(index, slice):
+            super().__setitem__(index, [self._validate_item(v) for v in value])
+        else:
+            super().__setitem__(index, self._validate_item(value))
+
+    def _filename(self, i: int) -> str:
+        """Return the output filename for part ``i``."""
+        return f"{self.prefix}{self[i][1]}{self.suffix}"
+
+    def _part(self, i: int):
+        """Return the geometry for part ``i``: ``self[i][0]`` minus all later parts.
+
+        For the last entry, the object is returned as-is rather than wrapped
+        in a one-child ``difference`` node.
+        """
+        rest = [obj for obj, _name in self[i:]]
+        return rest[0] if len(rest) == 1 else difference(*rest)  # noqa: F405
+
+    def _check_unique_names(self) -> None:
+        """Raise :class:`ValueError` if any two items share the same name.
+
+        Duplicate names would produce duplicate filenames in :meth:`export`,
+        causing later parts to overwrite earlier ones. We refuse rather than
+        silently lose data.
+        """
+        seen = set()
+        for _, name in self:
+            if name in seen:
+                raise ValueError(
+                    f"MultiToolExporter has duplicate name {name!r}; "
+                    f"each item must have a unique name to avoid overwriting files"
+                )
+            seen.add(name)
+
+    def export(self) -> None:
+        """Export each part to a file via PythonSCAD.
+
+        For each index ``i``, exports the difference of ``self[i][0]`` and
+        all subsequent objects to ``f"{prefix}{name}{suffix}"``. The last
+        entry is exported as-is without a degenerate ``difference`` node.
+
+        If :attr:`mkdir` is ``True``, the parent directory of each output
+        file is created beforehand (filenames without a directory component
+        are skipped silently).
+
+        Raises:
+            ValueError: If two or more items share the same name.
+        """
+        self._check_unique_names()
+        for i in range(len(self)):
+            filename = self._filename(i)
+            if self.mkdir:
+                directory = _os.path.dirname(filename)
+                if directory:
+                    _os.makedirs(directory, exist_ok=True)
+            export(self._part(i), filename)  # noqa: F405
+
+    def show(self) -> None:
+        """Display each part in the PythonSCAD preview.
+
+        For each index ``i``, computes the difference of ``self[i][0]`` and
+        all subsequent objects and passes the result to :func:`show`,
+        producing a layered preview equivalent to what :meth:`export` would
+        write to disk.
+        """
+        for i in range(len(self)):
+            show(self._part(i))  # noqa: F405

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -113,8 +113,8 @@ class MultiToolExporter(list[Tuple[Any, str]]):
         """Return ``item`` if it is a valid ``(object, str)`` 2-tuple.
 
         Raises:
-            TypeError: If ``item`` is not a 2-element tuple/list whose second
-                element is a string.
+            TypeError: If ``item`` is not a 2-tuple whose second element is
+                a string. Lists and other sequences are rejected.
             ValueError: If the name is empty.
         """
         if not isinstance(item, tuple) or len(item) != 2:

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -3,7 +3,7 @@
 The `pythonscad` package is a strict superset of `openscad` (which itself
 re-exports `_openscad`). PythonSCAD-only additions are surfaced here.
 """
-from typing import Any, Iterable, List, SupportsIndex, Tuple
+from typing import Any, Iterable, SupportsIndex, Tuple
 
 from openscad import *  # noqa: F401,F403
 from openscad import (  # noqa: F401
@@ -17,7 +17,7 @@ from openscad import (  # noqa: F401
 )
 
 
-class MultiToolExporter(List[Tuple[Any, str]]):
+class MultiToolExporter(list[Tuple[Any, str]]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
     Each item is an ``(object, name)`` 2-tuple. For each index ``i``,

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -3,7 +3,7 @@
 The `pythonscad` package is a strict superset of `openscad` (which itself
 re-exports `_openscad`). PythonSCAD-only additions are surfaced here.
 """
-from typing import Any, Iterable, SupportsIndex, Tuple
+import typing as _typing
 
 from openscad import *  # noqa: F401,F403
 from openscad import (  # noqa: F401
@@ -17,7 +17,7 @@ from openscad import (  # noqa: F401
 )
 
 
-class MultiToolExporter(list[Tuple[Any, str]]):
+class MultiToolExporter(list[tuple[_typing.Any, str]]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
     Each item is an ``(object, name)`` 2-tuple. For each index ``i``,
@@ -42,20 +42,20 @@ class MultiToolExporter(list[Tuple[Any, str]]):
         prefix: str,
         suffix: str,
         mkdir: bool = ...,
-        items: Iterable[Tuple[Any, str]] = ...,
+        items: _typing.Iterable[tuple[_typing.Any, str]] = ...,
     ) -> None:
         """Initialize the exporter, optionally seeding it with ``items``."""
         ...
 
-    def append(self, item: Tuple[Any, str]) -> None:
+    def append(self, item: tuple[_typing.Any, str]) -> None:
         """Append a validated ``(object, name)`` tuple."""
         ...
 
-    def extend(self, items: Iterable[Tuple[Any, str]]) -> None:
+    def extend(self, items: _typing.Iterable[tuple[_typing.Any, str]]) -> None:
         """Append each validated ``(object, name)`` tuple from ``items``."""
         ...
 
-    def insert(self, index: SupportsIndex, item: Tuple[Any, str]) -> None:
+    def insert(self, index: _typing.SupportsIndex, item: tuple[_typing.Any, str]) -> None:
         """Insert a validated ``(object, name)`` tuple at ``index``."""
         ...
 

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -3,6 +3,13 @@
 The `pythonscad` package is a strict superset of `openscad` (which itself
 re-exports `_openscad`). PythonSCAD-only additions are surfaced here.
 """
+
+# Convention (mirrors libraries/python/pythonscad/__init__.py): any
+# import that is NOT part of the public `pythonscad` stub must be
+# aliased with a leading underscore (e.g. ``import typing as _typing``).
+# Type-checkers treat unaliased names in a stub as part of the public
+# API surface, so leaking helpers here is just as bad as leaking them
+# at runtime.
 import typing as _typing
 
 from openscad import *  # noqa: F401,F403

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -59,6 +59,10 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         """Insert a validated ``(object, name)`` tuple at ``index``."""
         ...
 
+    def parts(self) -> list[tuple[str, _typing.Any]]:
+        """Return computed ``(name, geometry)`` pairs in declaration order."""
+        ...
+
     def export(self) -> None:
         """Export each part to a file via PythonSCAD."""
         ...

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -17,14 +17,17 @@ from openscad import (  # noqa: F401
 )
 
 
-class MultiToolExporter(list[tuple[_typing.Any, str]]):
+class MultiToolExporter(list[tuple[str, _typing.Any]]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
-    Each item is an ``(object, name)`` 2-tuple. For each index ``i``,
-    :meth:`export` writes the geometry obtained by subtracting all later
-    objects from ``self[i][0]`` into the file ``f"{prefix}{name}{suffix}"``.
-    The last entry is emitted as-is (no degenerate one-child ``difference``
-    node). Names must be unique; duplicates raise :class:`ValueError` at
+    Each item is a ``(name, object)`` 2-tuple (matching :func:`dict.items`
+    and the multi-object form of :func:`export`). For each index ``i``,
+    :meth:`export` writes the geometry obtained by subtracting every later
+    item's object from ``self[i]``'s object into the file
+    ``f"{prefix}{name}{suffix}"``. The last entry is emitted as-is (no
+    degenerate one-child ``difference`` node). Output paths must be
+    unique; collisions (raw duplicate names, path aliases, or - on
+    Windows/macOS - case-only collisions) raise :class:`ValueError` at
     export time.
     """
 
@@ -42,21 +45,21 @@ class MultiToolExporter(list[tuple[_typing.Any, str]]):
         prefix: str,
         suffix: str,
         mkdir: bool = ...,
-        items: _typing.Iterable[tuple[_typing.Any, str]] = ...,
+        items: _typing.Iterable[tuple[str, _typing.Any]] = ...,
     ) -> None:
         """Initialize the exporter, optionally seeding it with ``items``."""
         ...
 
-    def append(self, item: tuple[_typing.Any, str]) -> None:
-        """Append a validated ``(object, name)`` tuple."""
+    def append(self, item: tuple[str, _typing.Any]) -> None:
+        """Append a validated ``(name, object)`` tuple."""
         ...
 
-    def extend(self, items: _typing.Iterable[tuple[_typing.Any, str]]) -> None:
-        """Append each validated ``(object, name)`` tuple from ``items``."""
+    def extend(self, items: _typing.Iterable[tuple[str, _typing.Any]]) -> None:
+        """Append each validated ``(name, object)`` tuple from ``items``."""
         ...
 
-    def insert(self, index: _typing.SupportsIndex, item: tuple[_typing.Any, str]) -> None:
-        """Insert a validated ``(object, name)`` tuple at ``index``."""
+    def insert(self, index: _typing.SupportsIndex, item: tuple[str, _typing.Any]) -> None:
+        """Insert a validated ``(name, object)`` tuple at ``index``."""
         ...
 
     def parts(self) -> list[tuple[str, _typing.Any]]:

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -2,8 +2,9 @@
 
 The `pythonscad` package is a strict superset of `openscad` (which itself
 re-exports `_openscad`). PythonSCAD-only additions are surfaced here.
-Currently this stub is a 1:1 re-export of `openscad`'s stub.
 """
+from typing import Any, Iterable, List, SupportsIndex, Tuple
+
 from openscad import *  # noqa: F401,F403
 from openscad import (  # noqa: F401
     Color,
@@ -14,3 +15,54 @@ from openscad import (  # noqa: F401
     Vector2,
     Vector3,
 )
+
+
+class MultiToolExporter(List[Tuple[Any, str]]):
+    """List-based helper for exporting multi-tool / multi-color 3D models.
+
+    Each item is an ``(object, name)`` 2-tuple. For each index ``i``,
+    :meth:`export` writes the geometry obtained by subtracting all later
+    objects from ``self[i][0]`` into the file ``f"{prefix}{name}{suffix}"``.
+    The last entry is emitted as-is (no degenerate one-child ``difference``
+    node). Names must be unique; duplicates raise :class:`ValueError` at
+    export time.
+    """
+
+    prefix: str
+    """String prepended to each output filename."""
+
+    suffix: str
+    """String appended to each output filename (typically the file extension)."""
+
+    mkdir: bool
+    """If True, create each output file's directory before exporting."""
+
+    def __init__(
+        self,
+        prefix: str,
+        suffix: str,
+        mkdir: bool = ...,
+        items: Iterable[Tuple[Any, str]] = ...,
+    ) -> None:
+        """Initialize the exporter, optionally seeding it with ``items``."""
+        ...
+
+    def append(self, item: Tuple[Any, str]) -> None:
+        """Append a validated ``(object, name)`` tuple."""
+        ...
+
+    def extend(self, items: Iterable[Tuple[Any, str]]) -> None:
+        """Append each validated ``(object, name)`` tuple from ``items``."""
+        ...
+
+    def insert(self, index: SupportsIndex, item: Tuple[Any, str]) -> None:
+        """Insert a validated ``(object, name)`` tuple at ``index``."""
+        ...
+
+    def export(self) -> None:
+        """Export each part to a file via PythonSCAD."""
+        ...
+
+    def show(self) -> None:
+        """Display each part in the PythonSCAD preview."""
+        ...

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -69,6 +69,13 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         """Insert a validated ``(name, object)`` tuple at ``index``."""
         ...
 
+    def __iadd__(  # type: ignore[override]
+        self,
+        other: _typing.Iterable[tuple[str, _typing.Any]],
+    ) -> "MultiToolExporter":
+        """Validate each item then in-place extend (``self += other``)."""
+        ...
+
     def parts(self) -> list[tuple[str, _typing.Any]]:
         """Return computed ``(name, geometry)`` pairs in declaration order."""
         ...

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1364,9 +1364,10 @@ endif()
 #
 # Each fixture runs with a per-test scratch CWD and writes one or more
 # files via in-script export() (or helpers like MultiToolExporter); each
-# produced *.stl is auto-discovered and byte-compared to a golden under
-# tests/regression/<testname>/<basename>-<stem>-expected.stl. Use
-# TEST_GENERATE=1 to create or refresh goldens.
+# produced *.<suffix> is auto-discovered and compared against a golden
+# under tests/regression/<testname>/<basename>/<filename> (the expected
+# directory mirrors the actual one) after format-aware post-processing.
+# Use TEST_GENERATE=1 to create or refresh goldens.
 #
 add_export_files_test(multitool-export
     EXPERIMENTAL

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,7 @@ set(TEST_PYTHONSCAD_DIR "${CCSD}/data/pythonscad")
 set(TEST_PYTHONSCAD_ECHO_DIR "${CCSD}/data/pythonscad-echo")
 set(TEST_PYTHONSCAD_LASER_DIR "${CCSD}/data/pythonscad-laser")
 set(TEST_PYTHONSCAD_3D_EXPORT_DIR "${CCSD}/data/pythonscad-3d-export")
+set(TEST_PYTHONSCAD_MULTITOOL_EXPORT_DIR "${CCSD}/data/pythonscad-multitool-export")
 set(TEST_PYTHONSCAD_OVERLAY_DIR "${CCSD}/data/pythonscad-overlay")
 set(TEST_PYTHONSCAD_OVERLAY_ECHO_DIR "${CCSD}/data/pythonscad-overlay-echo")
 set(TEST_CUSTOMIZER_DIR "${CCSD}/data/scad/customizer")
@@ -267,6 +268,7 @@ file(GLOB PYTHONSCAD_FILES    ${TEST_PYTHONSCAD_DIR}/*.py)
 file(GLOB PYTHONSCAD_ECHO_FILES    ${TEST_PYTHONSCAD_ECHO_DIR}/*.py)
 file(GLOB PYTHONSCAD_LASER_FILES    ${TEST_PYTHONSCAD_LASER_DIR}/*.py)
 file(GLOB PYTHONSCAD_3D_EXPORT_FILES ${TEST_PYTHONSCAD_3D_EXPORT_DIR}/*.py)
+file(GLOB PYTHONSCAD_MULTITOOL_EXPORT_FILES ${TEST_PYTHONSCAD_MULTITOOL_EXPORT_DIR}/*.py)
 file(GLOB PYTHONSCAD_OVERLAY_FILES ${TEST_PYTHONSCAD_OVERLAY_DIR}/*.py)
 file(GLOB PYTHONSCAD_OVERLAY_ECHO_FILES ${TEST_PYTHONSCAD_OVERLAY_ECHO_DIR}/*.py)
 file(GLOB SCAD_3D_EXPORT_FILES      ${TEST_SCAD_DIR}/3d-export/*.scad)
@@ -1356,6 +1358,21 @@ endif()
 if (ENABLE_LIB3MF_TESTS)
   add_cmdline_test(export-3d-pythonscad EXPERIMENTAL OPENSCAD SUFFIX 3mf FILES ${PYTHONSCAD_3D_EXPORT_FILES} ARGS --enable=predictible-output --render --trust-python)
 endif()
+
+#
+# In-script export() tests for PythonSCAD
+#
+# Each fixture runs with a per-test scratch CWD and writes one or more
+# files via in-script export() (or helpers like MultiToolExporter); each
+# produced *.stl is auto-discovered and byte-compared to a golden under
+# tests/regression/<testname>/<basename>-<stem>-expected.stl. Use
+# TEST_GENERATE=1 to create or refresh goldens.
+#
+add_export_files_test(multitool-export
+    EXPERIMENTAL
+    SUFFIX stl
+    FILES ${PYTHONSCAD_MULTITOOL_EXPORT_FILES}
+)
 
 #
 # --enable=discretization-by-error tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1363,15 +1363,16 @@ endif()
 # In-script export() tests for PythonSCAD
 #
 # Each fixture runs with a per-test scratch CWD and writes one or more
-# files via in-script export() (or helpers like MultiToolExporter); each
-# produced *.<suffix> is auto-discovered and compared against a golden
-# under tests/regression/<testname>/<basename>/<filename> (the expected
-# directory mirrors the actual one) after format-aware post-processing.
-# Use TEST_GENERATE=1 to create or refresh goldens.
+# files via in-script export() (or helpers like MultiToolExporter). The
+# scratch directory tree is then auto-discovered recursively (every
+# file, every extension, every subdirectory) and tree-diffed against
+# tests/regression/<testname>/<basename>/<rel-path>, which mirrors the
+# actual layout one-for-one, after format-aware post-processing keyed
+# by each file's own extension. A single fixture can legitimately
+# mix formats. Use TEST_GENERATE=1 to create or refresh goldens.
 #
 add_export_files_test(multitool-export
     EXPERIMENTAL
-    SUFFIX stl
     FILES ${PYTHONSCAD_MULTITOOL_EXPORT_FILES}
 )
 

--- a/tests/cmake/TestFunctions.cmake
+++ b/tests/cmake/TestFunctions.cmake
@@ -500,11 +500,15 @@ endfunction()
 # `export(geom, "foo.stl")` or `MultiToolExporter(...).export()`).
 #
 # Each fixture is run with a per-test scratch directory as CWD; every
-# produced *.<SUFFIX> file is then auto-discovered and byte-compared
-# against the matching golden under
+# produced *.<SUFFIX> file is then auto-discovered and compared against
+# the matching golden under
 #   tests/regression/<testname>/<basename>/<filename>
-# (the expected directory mirrors the actual one), after format-appropriate
-# normalization (header progname for STL/SVG/OBJ, 3MF XML extraction).
+# (the expected directory mirrors the actual one), after format-aware
+# post-processing (header progname rewrite for STL/SVG/OBJ, inner-XML
+# extraction for 3MF). The comparison is the same normalized text
+# compare (line-ending normalization + unified diff) used by
+# test_cmdline_tool.py -- not a raw bytes-equality check -- which is
+# suitable for the ASCII / text-derived formats post-processed above.
 # Missing or extra files in either side cause the test to fail. Use
 # TEST_GENERATE=1 to (re)create goldens.
 #

--- a/tests/cmake/TestFunctions.cmake
+++ b/tests/cmake/TestFunctions.cmake
@@ -478,7 +478,7 @@ function(add_cmdline_test TESTCMD_BASENAME)
     # only add test if it is not experimental or if it is and experimental option is enabled
     if (NOT TEST_IS_EXPERIMENTAL OR EXPERIMENTAL)
       # Use cmake option "--log-level DEBUG" during top level config to see this
-      message(DEBUG "${DBG_COMMAND_STR}")      
+      message(DEBUG "${DBG_COMMAND_STR}")
       add_test(NAME ${TEST_FULLNAME} CONFIGURATIONS ${CONFVAL}
         COMMAND ${Python3_EXECUTABLE} -Xutf8=1
         ${TEST_CMDLINE_TOOL_PY} ${COMPARATOR} -c ${IMAGE_COMPARE_EXE}
@@ -492,6 +492,78 @@ function(add_cmdline_test TESTCMD_BASENAME)
     endif()
   endforeach()
 endfunction()
+
+
+#
+# Adds tests for fixtures that drive PythonSCAD with --trust-python and
+# write one or more output files via in-script export() calls (e.g.
+# `export(geom, "foo.stl")` or `MultiToolExporter(...).export()`).
+#
+# Each fixture is run with a per-test scratch directory as CWD; every
+# produced *.<SUFFIX> file is then auto-discovered and byte-compared
+# against the matching golden under
+#   tests/regression/<testname>/<basename>/<filename>
+# (the expected directory mirrors the actual one), after format-appropriate
+# normalization (header progname for STL/SVG/OBJ, 3MF XML extraction).
+# Missing or extra files in either side cause the test to fail. Use
+# TEST_GENERATE=1 to (re)create goldens.
+#
+# Usage:
+#   add_export_files_test(testbasename
+#       SUFFIX <ext, no leading dot>
+#       FILES <list of .py fixtures>
+#       [ARGS <extra pythonscad args>]
+#       [EXPERIMENTAL])
+#
+# EXPERIMENTAL: If set, tag all tests as experimental.
+#
+function(add_export_files_test TESTCMD_BASENAME)
+  cmake_parse_arguments(TESTCMD "EXPERIMENTAL" "SUFFIX" "FILES;ARGS" ${ARGN})
+
+  if (NOT TESTCMD_SUFFIX)
+    message(FATAL_ERROR "add_export_files_test() requires SUFFIX")
+  endif()
+
+  foreach (FIXTURE ${TESTCMD_FILES})
+    get_filename_component(FILE_BASENAME ${FIXTURE} NAME_WE)
+    string(REPLACE " " "_" FILE_BASENAME ${FILE_BASENAME})
+    set(TEST_FULLNAME "${TESTCMD_BASENAME}_${FILE_BASENAME}")
+
+    if (TESTCMD_EXPERIMENTAL)
+      set(TEST_IS_EXPERIMENTAL true)
+    else()
+      set(TEST_IS_EXPERIMENTAL false)
+    endif()
+
+    # Handle configurations
+    get_test_config(${TEST_FULLNAME} FOUNDCONFIGS)
+    if (NOT FOUNDCONFIGS)
+      set_test_config(Default FILES ${TEST_FULLNAME})
+    endif()
+    set_test_config(All FILES ${TEST_FULLNAME})
+    list(FIND FOUNDCONFIGS Bugs FOUND)
+    if (FOUND EQUAL -1)
+      set_test_config(Good FILES ${TEST_FULLNAME})
+    endif()
+    get_test_config(${TEST_FULLNAME} CONFVAL)
+
+    if (NOT TEST_IS_EXPERIMENTAL OR EXPERIMENTAL)
+      add_test(NAME ${TEST_FULLNAME} CONFIGURATIONS ${CONFVAL}
+        COMMAND ${Python3_EXECUTABLE} -Xutf8=1
+          ${CCSD}/test_export_files.py
+          --pythonscad ${OPENSCAD_BINPATH}
+          --testname ${TESTCMD_BASENAME}
+          --basename ${FILE_BASENAME}
+          --suffix ${TESTCMD_SUFFIX}
+          ${FIXTURE}
+          ${TESTCMD_ARGS}
+      )
+      set_property(TEST ${TEST_FULLNAME} PROPERTY ENVIRONMENT
+                   ${CTEST_ENVIRONMENT})
+    endif()
+  endforeach()
+endfunction()
+
 
 #
 function(add_failing_test TESTCMD_BASENAME)

--- a/tests/cmake/TestFunctions.cmake
+++ b/tests/cmake/TestFunctions.cmake
@@ -499,22 +499,25 @@ endfunction()
 # write one or more output files via in-script export() calls (e.g.
 # `export(geom, "foo.stl")` or `MultiToolExporter(...).export()`).
 #
-# Each fixture is run with a per-test scratch directory as CWD; every
-# produced *.<SUFFIX> file is then auto-discovered and compared against
-# the matching golden under
-#   tests/regression/<testname>/<basename>/<filename>
-# (the expected directory mirrors the actual one), after format-aware
-# post-processing (header progname rewrite for STL/SVG/OBJ, inner-XML
-# extraction for 3MF). The comparison is the same normalized text
-# compare (line-ending normalization + unified diff) used by
-# test_cmdline_tool.py -- not a raw bytes-equality check -- which is
-# suitable for the ASCII / text-derived formats post-processed above.
-# Missing or extra files in either side cause the test to fail. Use
-# TEST_GENERATE=1 to (re)create goldens.
+# Each fixture is run with a per-test scratch directory as CWD; the
+# scratch directory tree is then auto-discovered (recursively, across
+# every extension) and compared file-for-file against the matching
+# golden tree under
+#   tests/regression/<testname>/<basename>/<rel-path>
+# (the expected directory mirrors the actual one one-for-one), after
+# format-aware post-processing keyed by each file's own extension
+# (header progname rewrite for STL/SVG/OBJ, inner-XML extraction for
+# 3MF; other extensions pass through). The comparison is the same
+# normalized text compare (line-ending normalization + unified diff)
+# used by test_cmdline_tool.py -- not a raw bytes-equality check --
+# which is suitable for the ASCII / text-derived formats post-processed
+# above. Missing or extra files on either side cause the test to fail.
+# A single fixture can legitimately mix formats and subdirectories;
+# they all get diffed in one pass. Use TEST_GENERATE=1 to (re)create
+# goldens.
 #
 # Usage:
 #   add_export_files_test(testbasename
-#       SUFFIX <ext, no leading dot>
 #       FILES <list of .py fixtures>
 #       [ARGS <extra pythonscad args>]
 #       [EXPERIMENTAL])
@@ -522,11 +525,7 @@ endfunction()
 # EXPERIMENTAL: If set, tag all tests as experimental.
 #
 function(add_export_files_test TESTCMD_BASENAME)
-  cmake_parse_arguments(TESTCMD "EXPERIMENTAL" "SUFFIX" "FILES;ARGS" ${ARGN})
-
-  if (NOT TESTCMD_SUFFIX)
-    message(FATAL_ERROR "add_export_files_test() requires SUFFIX")
-  endif()
+  cmake_parse_arguments(TESTCMD "EXPERIMENTAL" "" "FILES;ARGS" ${ARGN})
 
   foreach (FIXTURE ${TESTCMD_FILES})
     get_filename_component(FILE_BASENAME ${FIXTURE} NAME_WE)
@@ -558,7 +557,6 @@ function(add_export_files_test TESTCMD_BASENAME)
           --pythonscad ${OPENSCAD_BINPATH}
           --testname ${TESTCMD_BASENAME}
           --basename ${FILE_BASENAME}
-          --suffix ${TESTCMD_SUFFIX}
           ${FIXTURE}
           ${TESTCMD_ARGS}
       )

--- a/tests/data/pythonscad-echo/multitool-exporter.py
+++ b/tests/data/pythonscad-echo/multitool-exporter.py
@@ -3,7 +3,7 @@
 Exercises:
   * constructor (positional + ``items=`` seeding) and ``len()``
   * shape and name validation in ``append`` / ``extend`` / ``insert`` /
-    ``__setitem__``
+    ``__setitem__`` / ``__iadd__`` (``+=``)
   * ``_part(last)`` returning the underlying object as-is (no degenerate
     one-child ``difference`` node)
   * duplicate-name detection at ``export()`` time
@@ -58,13 +58,18 @@ expect("extend bad item", lambda: exp.extend([("ok", red), red]), TypeError)
 expect("insert bad item", lambda: exp.insert(0, red), TypeError)
 expect("setitem bad item", lambda: exp.__setitem__(0, red), TypeError)
 expect("setitem slice bad", lambda: exp.__setitem__(slice(0, 1), [red]), TypeError)
+# `+=` goes through list.__iadd__ at the C level, which bypasses the
+# extend() override unless __iadd__ is also overridden -- exercise it.
+expect("iadd bad item", lambda: exp.__iadd__([red]), TypeError)
+expect("iadd mid-bad item", lambda: exp.__iadd__([("ok", red), red]), TypeError)
 expect(
     "constructor bad item",
     lambda: MultiToolExporter("p-", ".stl", items=[("ok", red), ("", blue)]),
     ValueError,
 )
 
-# Make sure no half-applied state was left behind by the failed extend.
+# Make sure no half-applied state was left behind by the failed extend
+# or the failed +=.
 print("len after failed extend:", len(exp))
 
 # --- 4. Duplicate-name detection at export time ------------------------

--- a/tests/data/pythonscad-echo/multitool-exporter.py
+++ b/tests/data/pythonscad-echo/multitool-exporter.py
@@ -1,0 +1,100 @@
+"""Echo test for ``MultiToolExporter`` (pythonscad-only helper).
+
+Exercises:
+  * constructor (positional + ``items=`` seeding) and ``len()``
+  * shape and name validation in ``append`` / ``extend`` / ``insert`` /
+    ``__setitem__``
+  * ``_part(last)`` returning the underlying object as-is (no degenerate
+    one-child ``difference`` node)
+  * duplicate-name detection at ``export()`` time
+  * ``mkdir=True`` with a directory-less filename (must not raise)
+  * end-to-end ``export()`` calling the underlying ``pythonscad.export``
+    once per part with the expected filename
+
+The underlying ``pythonscad.export`` is monkey-patched to a deterministic
+recorder so the test does not depend on a render backend, file system
+state, or output formatting of any export format.
+"""
+
+import pythonscad
+from pythonscad import MultiToolExporter, cube
+
+# --- 1. Constructor and basic list semantics ----------------------------
+red = cube(10)
+blue = cube(10).right(5)
+green = cube(10).right(10)
+
+exp = MultiToolExporter("p-", ".stl")
+exp.append((red, "red"))
+exp.append((blue, "blue"))
+print("len:", len(exp))
+print("filename[0]:", exp._filename(0))
+print("filename[1]:", exp._filename(1))
+
+# --- 2. _part(last) returns the bare object -----------------------------
+print("part(last) is bare object:", exp._part(len(exp) - 1) is exp[-1][0])
+
+# --- 3. Validation: every entry path -----------------------------------
+def expect(label, fn, exc):
+    """Run ``fn`` and print whether it raised ``exc``."""
+    try:
+        fn()
+    except exc as e:
+        print(f"{label}: {type(e).__name__}")
+    else:
+        print(f"{label}: NO EXCEPTION (expected {exc.__name__})")
+
+expect("append non-tuple", lambda: exp.append(red), TypeError)
+expect("append wrong arity", lambda: exp.append((red, "x", "y")), TypeError)
+expect("append non-str name", lambda: exp.append((red, 42)), TypeError)
+expect("append empty name", lambda: exp.append((red, "")), ValueError)
+expect("extend bad item", lambda: exp.extend([(red, "ok"), red]), TypeError)
+expect("insert bad item", lambda: exp.insert(0, red), TypeError)
+expect("setitem bad item", lambda: exp.__setitem__(0, red), TypeError)
+expect("setitem slice bad", lambda: exp.__setitem__(slice(0, 1), [red]), TypeError)
+expect(
+    "constructor bad item",
+    lambda: MultiToolExporter("p-", ".stl", items=[(red, "ok"), (blue, "")]),
+    ValueError,
+)
+
+# Make sure no half-applied state was left behind by the failed extend.
+print("len after failed extend:", len(exp))
+
+# --- 4. Duplicate-name detection at export time ------------------------
+dup = MultiToolExporter("p-", ".stl", items=[(red, "x"), (blue, "x")])
+expect("export duplicate names", dup.export, ValueError)
+
+# --- 5. End-to-end export(), with monkey-patched underlying export -----
+calls = []
+real_export = pythonscad.export
+def recording_export(obj, filename):
+    calls.append((obj is not None, filename))
+pythonscad.export = recording_export
+try:
+    # 5a. Two parts, no directory in prefix, mkdir=True -- must not crash
+    e1 = MultiToolExporter(
+        "nodir-",
+        ".stl",
+        mkdir=True,
+        items=[(red, "red"), (blue, "blue"), (green, "green")],
+    )
+    e1.export()
+    # 5b. With a real directory portion, mkdir=True -- still works
+    import tempfile, os
+    with tempfile.TemporaryDirectory() as tmp:
+        out_prefix = os.path.join(tmp, "nested", "x-")
+        e2 = MultiToolExporter(
+            out_prefix, ".3mf", mkdir=True, items=[(red, "a"), (blue, "b")]
+        )
+        e2.export()
+        print("created nested dir:", os.path.isdir(os.path.join(tmp, "nested")))
+finally:
+    pythonscad.export = real_export
+
+# Print the recorded export calls (last filename only -- temp paths vary).
+for has_obj, filename in calls:
+    if filename.startswith("nodir-"):
+        print("export call:", has_obj, filename)
+    else:
+        print("export call:", has_obj, "tmp/.../" + os.path.basename(filename))

--- a/tests/data/pythonscad-echo/multitool-exporter.py
+++ b/tests/data/pythonscad-echo/multitool-exporter.py
@@ -16,6 +16,9 @@ recorder so the test does not depend on a render backend, file system
 state, or output formatting of any export format.
 """
 
+import os
+import tempfile
+
 import pythonscad
 from pythonscad import MultiToolExporter, cube
 
@@ -92,7 +95,6 @@ try:
     )
     e1.export()
     # 5b. With a real directory portion, mkdir=True -- still works
-    import tempfile, os
     with tempfile.TemporaryDirectory() as tmp:
         out_prefix = os.path.join(tmp, "nested", "x-")
         e2 = MultiToolExporter(

--- a/tests/data/pythonscad-echo/multitool-exporter.py
+++ b/tests/data/pythonscad-echo/multitool-exporter.py
@@ -25,20 +25,20 @@ blue = cube(10).right(5)
 green = cube(10).right(10)
 
 exp = MultiToolExporter("p-", ".stl")
-exp.append((red, "red"))
-exp.append((blue, "blue"))
+exp.append(("red", red))
+exp.append(("blue", blue))
 print("len:", len(exp))
 print("filename[0]:", exp._filename(0))
 print("filename[1]:", exp._filename(1))
 
 # --- 2. _part(last) returns the bare object -----------------------------
-print("part(last) is bare object:", exp._part(len(exp) - 1) is exp[-1][0])
+print("part(last) is bare object:", exp._part(len(exp) - 1) is exp[-1][1])
 
 # --- 2b. parts() shape: ordered list of (name, geometry) pairs ----------
 ps = exp.parts()
 print("parts len:", len(ps))
 print("parts names:", [name for name, _g in ps])
-print("parts last is bare:", ps[-1][1] is exp[-1][0])
+print("parts last is bare:", ps[-1][1] is exp[-1][1])
 
 # --- 3. Validation: every entry path -----------------------------------
 def expect(label, fn, exc):
@@ -51,16 +51,16 @@ def expect(label, fn, exc):
         print(f"{label}: NO EXCEPTION (expected {exc.__name__})")
 
 expect("append non-tuple", lambda: exp.append(red), TypeError)
-expect("append wrong arity", lambda: exp.append((red, "x", "y")), TypeError)
-expect("append non-str name", lambda: exp.append((red, 42)), TypeError)
-expect("append empty name", lambda: exp.append((red, "")), ValueError)
-expect("extend bad item", lambda: exp.extend([(red, "ok"), red]), TypeError)
+expect("append wrong arity", lambda: exp.append(("x", red, "y")), TypeError)
+expect("append non-str name", lambda: exp.append((42, red)), TypeError)
+expect("append empty name", lambda: exp.append(("", red)), ValueError)
+expect("extend bad item", lambda: exp.extend([("ok", red), red]), TypeError)
 expect("insert bad item", lambda: exp.insert(0, red), TypeError)
 expect("setitem bad item", lambda: exp.__setitem__(0, red), TypeError)
 expect("setitem slice bad", lambda: exp.__setitem__(slice(0, 1), [red]), TypeError)
 expect(
     "constructor bad item",
-    lambda: MultiToolExporter("p-", ".stl", items=[(red, "ok"), (blue, "")]),
+    lambda: MultiToolExporter("p-", ".stl", items=[("ok", red), ("", blue)]),
     ValueError,
 )
 
@@ -68,7 +68,7 @@ expect(
 print("len after failed extend:", len(exp))
 
 # --- 4. Duplicate-name detection at export time ------------------------
-dup = MultiToolExporter("p-", ".stl", items=[(red, "x"), (blue, "x")])
+dup = MultiToolExporter("p-", ".stl", items=[("x", red), ("x", blue)])
 expect("export duplicate names", dup.export, ValueError)
 
 # --- 5. End-to-end export(), with monkey-patched underlying export -----
@@ -83,7 +83,7 @@ try:
         "nodir-",
         ".stl",
         mkdir=True,
-        items=[(red, "red"), (blue, "blue"), (green, "green")],
+        items=[("red", red), ("blue", blue), ("green", green)],
     )
     e1.export()
     # 5b. With a real directory portion, mkdir=True -- still works
@@ -91,7 +91,7 @@ try:
     with tempfile.TemporaryDirectory() as tmp:
         out_prefix = os.path.join(tmp, "nested", "x-")
         e2 = MultiToolExporter(
-            out_prefix, ".3mf", mkdir=True, items=[(red, "a"), (blue, "b")]
+            out_prefix, ".3mf", mkdir=True, items=[("a", red), ("b", blue)]
         )
         e2.export()
         print("created nested dir:", os.path.isdir(os.path.join(tmp, "nested")))

--- a/tests/data/pythonscad-echo/multitool-exporter.py
+++ b/tests/data/pythonscad-echo/multitool-exporter.py
@@ -34,6 +34,12 @@ print("filename[1]:", exp._filename(1))
 # --- 2. _part(last) returns the bare object -----------------------------
 print("part(last) is bare object:", exp._part(len(exp) - 1) is exp[-1][0])
 
+# --- 2b. parts() shape: ordered list of (name, geometry) pairs ----------
+ps = exp.parts()
+print("parts len:", len(ps))
+print("parts names:", [name for name, _g in ps])
+print("parts last is bare:", ps[-1][1] is exp[-1][0])
+
 # --- 3. Validation: every entry path -----------------------------------
 def expect(label, fn, exc):
     """Run ``fn`` and print whether it raised ``exc``."""

--- a/tests/data/pythonscad-multitool-export/two-color-flag.py
+++ b/tests/data/pythonscad-multitool-export/two-color-flag.py
@@ -1,14 +1,18 @@
 """MultiToolExporter regression fixture: two overlapping bricks split into
 red and blue parts.
 
-The test driver runs PythonSCAD with this script's directory set to a
-scratch run directory, so the exporter's relative filenames ("red.stl",
-"blue.stl") land where the driver expects them. The driver then byte-
-compares each produced file against a checked-in golden after running
-post_process_progname for header normalization.
+The test driver (``tests/test_export_files.py``) runs PythonSCAD with the
+*process CWD* set to a per-test scratch run directory, so the exporter's
+relative filenames (``"red.stl"``, ``"blue.stl"``) land where the driver
+expects them. The driver then post-processes each produced file
+(``post_process_progname`` for STL/SVG/OBJ, inner-XML extraction for 3MF)
+and compares it against a checked-in golden using
+``test_cmdline_tool.compare_default()`` -- a normalized text comparison
+(line-ending normalization + unified diff), not a raw byte-for-byte
+comparison.
 
 Geometry is intentionally small and axis-aligned so the resulting ASCII
-STL stays compact and stable under --enable=predictible-output.
+STL stays compact and stable under ``--enable=predictible-output``.
 """
 from pythonscad import MultiToolExporter, cube
 

--- a/tests/data/pythonscad-multitool-export/two-color-flag.py
+++ b/tests/data/pythonscad-multitool-export/two-color-flag.py
@@ -20,6 +20,6 @@ background = cube([20, 20, 4])
 star = cube([8, 8, 4]).translate([6, 6, 0])
 
 MultiToolExporter("", ".stl", items=[
-    (background, "blue"),
-    (star, "red"),
+    ("blue", background),
+    ("red", star),
 ]).export()

--- a/tests/data/pythonscad-multitool-export/two-color-flag.py
+++ b/tests/data/pythonscad-multitool-export/two-color-flag.py
@@ -1,0 +1,21 @@
+"""MultiToolExporter regression fixture: two overlapping bricks split into
+red and blue parts.
+
+The test driver runs PythonSCAD with this script's directory set to a
+scratch run directory, so the exporter's relative filenames ("red.stl",
+"blue.stl") land where the driver expects them. The driver then byte-
+compares each produced file against a checked-in golden after running
+post_process_progname for header normalization.
+
+Geometry is intentionally small and axis-aligned so the resulting ASCII
+STL stays compact and stable under --enable=predictible-output.
+"""
+from pythonscad import MultiToolExporter, cube
+
+background = cube([20, 20, 4])
+star = cube([8, 8, 4]).translate([6, 6, 0])
+
+MultiToolExporter("", ".stl", items=[
+    (background, "blue"),
+    (star, "red"),
+]).export()

--- a/tests/regression/multitool-export/two-color-flag/blue.stl
+++ b/tests/regression/multitool-export/two-color-flag/blue.stl
@@ -1,0 +1,226 @@
+solid OpenSCAD_Model
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 4
+      vertex 0 20 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 6 14 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 4
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 6 6 0
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 6 14 0
+      vertex 6 6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 14 6 0
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 0
+      vertex 20 0 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 20 0 4
+      vertex 0 0 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 4
+      vertex 6 6 4
+      vertex 0 20 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 4
+      vertex 20 0 4
+      vertex 6 6 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 4
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 20 0
+      vertex 20 20 0
+      vertex 6 14 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 4
+      vertex 6 6 4
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 4
+      vertex 6 14 4
+      vertex 14 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 4
+      vertex 14 14 4
+      vertex 20 20 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 4
+      vertex 20 20 4
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 6 4
+      vertex 14 6 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 0
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 4
+      vertex 6 6 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 6 0
+      vertex 14 6 4
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 6 4
+      vertex 20 0 4
+      vertex 14 6 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 14 0
+      vertex 14 14 0
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 14 0
+      vertex 20 20 0
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 14 4
+      vertex 14 14 0
+      vertex 14 14 4
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 14 6 0
+      vertex 14 6 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14 6 0
+      vertex 14 14 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14 6 0
+      vertex 20 20 0
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 14 6 4
+      vertex 14 14 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14 6 4
+      vertex 20 0 4
+      vertex 14 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14 14 4
+      vertex 20 0 4
+      vertex 20 20 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 0
+      vertex 20 0 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 4
+      vertex 20 20 0
+      vertex 20 20 4
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/tests/regression/multitool-export/two-color-flag/red.stl
+++ b/tests/regression/multitool-export/two-color-flag/red.stl
@@ -1,0 +1,86 @@
+solid OpenSCAD_Model
+  facet normal -1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 6 4
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 0
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 4
+      vertex 6 14 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 6 0
+      vertex 14 6 0
+      vertex 14 6 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 6 0
+      vertex 14 6 4
+      vertex 6 6 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 6 0
+      vertex 14 14 0
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 6 4
+      vertex 14 6 4
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 14 0
+      vertex 6 14 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 14 4
+      vertex 14 6 4
+      vertex 14 14 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 14 4
+      vertex 14 14 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 14 6 0
+      vertex 14 14 0
+      vertex 14 6 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 14 6 4
+      vertex 14 14 0
+      vertex 14 14 4
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/tests/regression/pythonscadecho/multitool-exporter-expected.echo
+++ b/tests/regression/pythonscadecho/multitool-exporter-expected.echo
@@ -13,6 +13,8 @@ extend bad item: TypeError
 insert bad item: TypeError
 setitem bad item: TypeError
 setitem slice bad: TypeError
+iadd bad item: TypeError
+iadd mid-bad item: TypeError
 constructor bad item: ValueError
 len after failed extend: 2
 export duplicate names: ValueError

--- a/tests/regression/pythonscadecho/multitool-exporter-expected.echo
+++ b/tests/regression/pythonscadecho/multitool-exporter-expected.echo
@@ -1,0 +1,21 @@
+len: 2
+filename[0]: p-red.stl
+filename[1]: p-blue.stl
+part(last) is bare object: True
+append non-tuple: TypeError
+append wrong arity: TypeError
+append non-str name: TypeError
+append empty name: ValueError
+extend bad item: TypeError
+insert bad item: TypeError
+setitem bad item: TypeError
+setitem slice bad: TypeError
+constructor bad item: ValueError
+len after failed extend: 2
+export duplicate names: ValueError
+created nested dir: True
+export call: True nodir-red.stl
+export call: True nodir-blue.stl
+export call: True nodir-green.stl
+export call: True tmp/.../x-a.3mf
+export call: True tmp/.../x-b.3mf

--- a/tests/regression/pythonscadecho/multitool-exporter-expected.echo
+++ b/tests/regression/pythonscadecho/multitool-exporter-expected.echo
@@ -2,6 +2,9 @@ len: 2
 filename[0]: p-red.stl
 filename[1]: p-blue.stl
 part(last) is bare object: True
+parts len: 2
+parts names: ['red', 'blue']
+parts last is bare: True
 append non-tuple: TypeError
 append wrong arity: TypeError
 append non-str name: TypeError

--- a/tests/test_export_files.py
+++ b/tests/test_export_files.py
@@ -29,11 +29,15 @@
 #      one-for-one, so missing or unexpected files are caught by simple
 #      set diffing.
 #
-# When TEST_GENERATE=1 is set in the environment (or -g/--generate is passed),
-# the produced files are copied into place as the new goldens instead of
-# being compared. Any stale goldens with the same suffix that the fixture no
-# longer writes are removed so the expected directory always mirrors the run
-# output.
+# When the TEST_GENERATE environment variable is set to any non-empty value
+# (or -g/--generate is passed), the produced files are copied into place as
+# the new goldens instead of being compared. Any stale goldens with the same
+# suffix that the fixture no longer writes are removed so the expected
+# directory always mirrors the run output. Note: this matches the existing
+# convention in `test_cmdline_tool.py` and `test_pretty_print.py`, which
+# also accept any non-empty value (the recommended idiom is `TEST_GENERATE=1`,
+# but `TEST_GENERATE=0` would also enable generation -- unset the variable
+# to disable instead).
 #
 # Usage:
 #   test_export_files.py
@@ -148,7 +152,9 @@ def main():
         help="Root regression directory (defaults to tests/regression).")
     parser.add_argument("-g", "--generate", action="store_true",
                         help="Generate goldens instead of comparing. Also "
-                             "honored via TEST_GENERATE=1 in the environment.")
+                             "honored when the TEST_GENERATE environment "
+                             "variable is set to any non-empty value "
+                             "(matches test_cmdline_tool.py).")
     parser.add_argument("fixture", help="Python fixture script to run.")
     parser.add_argument("extra_args", nargs=argparse.REMAINDER,
                         help="Extra arguments forwarded to pythonscad.")

--- a/tests/test_export_files.py
+++ b/tests/test_export_files.py
@@ -19,7 +19,11 @@
 #      contains the artifacts the fixture actually produces.
 #   3. Walks the scratch directory recursively and treats every regular
 #      file -- across any extension and any subdirectory -- as a fixture
-#      output to be checked.
+#      output to be checked. Coverage-instrumentation artifacts emitted
+#      by the binary itself (the ``.gcov/`` subtree from
+#      ``-fprofile-dir=.gcov`` plus stray ``*.gcda`` / ``*.gcno`` files)
+#      are skipped because they are runtime side-effects of
+#      ``-DPROFILE=ON`` builds, not fixture outputs.
 #   4. Applies format-aware post-processing (header progname rewrite for
 #      STL/SVG/OBJ, inner-XML extraction for 3MF; other extensions pass
 #      through untouched) keyed by each file's own extension, then
@@ -154,17 +158,43 @@ def _run_pythonscad(pythonscad, fixture, extra_args, rundir):
     return True
 
 
+# Coverage-instrumentation artifacts emitted by the running binary
+# itself when built with ``-DPROFILE=ON`` (see ``CMakeLists.txt``: the
+# project sets ``-fprofile-dir=.gcov`` so libgcov writes
+# path-mangled ``.gcda`` files into a ``.gcov/`` subdirectory of the
+# process's CWD on exit). These are runtime side-effects, not fixture
+# outputs, and must not participate in the tree-diff -- otherwise every
+# coverage build (Linux CI runs PROFILE=ON) reports the test as having
+# produced "unexpected files". The ``.gcno`` notes file is added
+# defensively in case a future build flag changes where it lands.
+_IGNORED_DIRS = frozenset({".gcov"})
+_IGNORED_SUFFIXES = frozenset({".gcda", ".gcno"})
+
+
+def _is_ignored(rel_parts: tuple, suffix: str) -> bool:
+    if suffix.lower() in _IGNORED_SUFFIXES:
+        return True
+    return any(part in _IGNORED_DIRS for part in rel_parts)
+
+
 def _discover(directory):
     """Return ``{rel_posix_path: absolute_path}`` for every file under
     ``directory``, recursing through subdirectories. Empty when
-    ``directory`` does not exist."""
+    ``directory`` does not exist. Coverage-instrumentation artifacts
+    from ``-DPROFILE=ON`` builds (``.gcov/`` subtree plus stray
+    ``*.gcda`` / ``*.gcno`` files) are skipped -- see ``_IGNORED_DIRS``
+    / ``_IGNORED_SUFFIXES`` above."""
     if not directory.is_dir():
         return {}
-    return {
-        p.relative_to(directory).as_posix(): p
-        for p in sorted(directory.rglob("*"))
-        if p.is_file()
-    }
+    out = {}
+    for p in sorted(directory.rglob("*")):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(directory)
+        if _is_ignored(rel.parts, p.suffix):
+            continue
+        out[rel.as_posix()] = p
+    return out
 
 
 def _wipe_dir(directory):

--- a/tests/test_export_files.py
+++ b/tests/test_export_files.py
@@ -15,12 +15,19 @@
 #      already running. The dummy is not inspected.
 #   3. Auto-discovers every produced file in the scratch directory matching
 #      `*.<suffix>`.
-#   4. Compares each produced file byte-for-byte against
-#      `tests/regression/<testname>/<basename>/<filename>` (after the same
-#      header / XML normalizations test_cmdline_tool.py applies for that
-#      suffix). The expected directory mirrors the actual directory layout
-#      one-for-one, so missing or unexpected files are caught by simple set
-#      diffing.
+#   4. Applies format-aware post-processing (header progname rewrite for
+#      STL/SVG/OBJ, inner-XML extraction for 3MF), then compares each
+#      produced file against
+#      `tests/regression/<testname>/<basename>/<filename>` using
+#      `test_cmdline_tool.compare_default()` -- a normalized text
+#      comparison (line-ending normalization + unified diff), not a raw
+#      bytes-equality check. For the ASCII / text-derived formats that the
+#      post-processors normalize, this is effectively bytes-equality;
+#      true binary outputs (binary STL, AMF, ...) would need a separate
+#      bytes-equality branch added to `_post_process` / the comparison
+#      step. The expected directory mirrors the actual directory layout
+#      one-for-one, so missing or unexpected files are caught by simple
+#      set diffing.
 #
 # When TEST_GENERATE=1 is set in the environment (or -g/--generate is passed),
 # the produced files are copied into place as the new goldens instead of

--- a/tests/test_export_files.py
+++ b/tests/test_export_files.py
@@ -6,47 +6,57 @@
 #
 # The driver:
 #
-#   1. Creates a per-test scratch directory (`output/<testname>/<basename>/`).
+#   1. Creates a per-test scratch directory (`output/<testname>/<basename>/`),
+#      wiping any leftover content from a previous run so the comparison
+#      below can never be polluted by stale files.
 #   2. Runs the PythonSCAD binary with the fixture as a script, with that
-#      scratch directory as CWD, so any `export("foo.stl")` call lands there.
-#      A throwaway `-o <tmp>/_cli_driver_dummy.echo` is supplied to force
-#      CLI / headless mode; without it, PythonSCAD treats the script as
-#      "open in GUI" and hits the single-instance lock if a desktop
-#      pythonscad is already running. The dummy is written into a private
-#      `tempfile.TemporaryDirectory()` so the rundir only ever contains
-#      the artifacts the fixture actually produces.
-#   3. Auto-discovers every produced file in the scratch directory matching
-#      `*.<suffix>`.
+#      scratch directory as CWD, so any `export("foo.stl")` call lands
+#      there. A throwaway `-o <tmp>/_cli_driver_dummy.echo` is supplied
+#      to force CLI / headless mode; without it, PythonSCAD treats the
+#      script as "open in GUI" and hits the single-instance lock if a
+#      desktop pythonscad is already running. The dummy is written into
+#      a private `tempfile.TemporaryDirectory()` so the rundir only ever
+#      contains the artifacts the fixture actually produces.
+#   3. Walks the scratch directory recursively and treats every regular
+#      file -- across any extension and any subdirectory -- as a fixture
+#      output to be checked.
 #   4. Applies format-aware post-processing (header progname rewrite for
-#      STL/SVG/OBJ, inner-XML extraction for 3MF), then compares each
-#      produced file against
-#      `tests/regression/<testname>/<basename>/<filename>` using
+#      STL/SVG/OBJ, inner-XML extraction for 3MF; other extensions pass
+#      through untouched) keyed by each file's own extension, then
+#      compares each produced file against
+#      `tests/regression/<testname>/<basename>/<rel-path>` using
 #      `test_cmdline_tool.compare_default()` -- a normalized text
 #      comparison (line-ending normalization + unified diff), not a raw
-#      bytes-equality check. For the ASCII / text-derived formats that the
-#      post-processors normalize, this is effectively bytes-equality;
-#      true binary outputs (binary STL, AMF, ...) would need a separate
-#      bytes-equality branch added to `_post_process` / the comparison
-#      step. The expected directory mirrors the actual directory layout
-#      one-for-one, so missing or unexpected files are caught by simple
+#      bytes-equality check. For the ASCII / text-derived formats that
+#      the post-processors normalize, this is effectively
+#      bytes-equality; true binary outputs (binary STL, AMF, ...) would
+#      need a separate bytes-equality branch added to `_post_process`
+#      and the comparison step. The expected directory mirrors the
+#      actual directory layout one-for-one (relative path is the key on
+#      both sides), so missing or unexpected files are caught by simple
 #      set diffing.
 #
-# When the TEST_GENERATE environment variable is set to any non-empty value
-# (or -g/--generate is passed), the produced files are copied into place as
-# the new goldens instead of being compared. Any stale goldens with the same
-# suffix that the fixture no longer writes are removed so the expected
-# directory always mirrors the run output. Note: this matches the existing
-# convention in `test_cmdline_tool.py` and `test_pretty_print.py`, which
-# also accept any non-empty value (the recommended idiom is `TEST_GENERATE=1`,
-# but `TEST_GENERATE=0` would also enable generation -- unset the variable
-# to disable instead).
+# Because discovery is "every file under rundir", a single fixture can
+# legitimately mix formats (e.g. an `MultiToolExporter` writing
+# `parts/red.stl` + `parts/blue.stl` alongside an assembly
+# `assembly.3mf`) and they all get checked together with no extra
+# wiring.
+#
+# When the TEST_GENERATE environment variable is set to any non-empty
+# value (or -g/--generate is passed), the produced files are copied into
+# place as the new goldens instead of being compared, and any stale
+# files under `expecteddir` that the fixture no longer writes are
+# removed so the expected tree always mirrors the run output. Note:
+# this matches the existing convention in `test_cmdline_tool.py` and
+# `test_pretty_print.py`, which also accept any non-empty value (the
+# recommended idiom is `TEST_GENERATE=1`, but `TEST_GENERATE=0` would
+# also enable generation -- unset the variable to disable instead).
 #
 # Usage:
 #   test_export_files.py
 #       --pythonscad <pythonscad-binary>
 #       --testname <test-group-name>
 #       --basename <fixture-basename>
-#       --suffix <stl|3mf|svg|obj|...>
 #       [--regressiondir <dir>]
 #       [--generate]
 #       <fixture.py> [<extra-args-for-pythonscad>...]
@@ -72,12 +82,24 @@ def _setup_tct_options():
     tct.options.exclude_debug = False
 
 
-def _post_process(filename, suffix):
-    """Apply the same normalization test_cmdline_tool.py uses post-export."""
-    if suffix in ("stl", "svg", "obj"):
-        tct.post_process_progname(filename)
-    elif suffix == "3mf":
-        tct.post_process_3mf(filename)
+# Format-aware post-processors, keyed by lowercase file extension
+# (including the leading dot). Files whose extension is not listed pass
+# through untouched and are compared as-is by ``tct.compare_default``,
+# which already does line-ending-tolerant text comparison. Add a new
+# entry here if a future format requires extra normalization.
+_POST_PROCESSORS = {
+    ".stl": tct.post_process_progname,
+    ".svg": tct.post_process_progname,
+    ".obj": tct.post_process_progname,
+    ".3mf": tct.post_process_3mf,
+}
+
+
+def _post_process(path):
+    """Normalize ``path`` in place based on its extension, if known."""
+    fn = _POST_PROCESSORS.get(Path(path).suffix.lower())
+    if fn is not None:
+        fn(str(path))
 
 
 def _run_pythonscad(pythonscad, fixture, extra_args, rundir):
@@ -132,24 +154,43 @@ def _run_pythonscad(pythonscad, fixture, extra_args, rundir):
     return True
 
 
-def _discover(directory, suffix):
+def _discover(directory):
+    """Return ``{rel_posix_path: absolute_path}`` for every file under
+    ``directory``, recursing through subdirectories. Empty when
+    ``directory`` does not exist."""
     if not directory.is_dir():
-        return []
-    return sorted(p for p in directory.glob(f"*.{suffix}") if p.is_file())
+        return {}
+    return {
+        p.relative_to(directory).as_posix(): p
+        for p in sorted(directory.rglob("*"))
+        if p.is_file()
+    }
+
+
+def _wipe_dir(directory):
+    """Remove everything *inside* ``directory`` but keep the directory
+    itself; create it if it does not exist yet. Used to give each run a
+    clean rundir without churning the parent ``output/`` tree."""
+    if directory.exists():
+        for child in directory.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+    else:
+        directory.mkdir(parents=True, exist_ok=True)
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Run a PythonSCAD fixture that writes files via in-script "
-                    "export() and compare the produced set against goldens.")
+                    "export() and tree-diff the produced set against goldens.")
     parser.add_argument("--pythonscad", required=True,
                         help="Path to the pythonscad executable.")
     parser.add_argument("--testname", required=True,
                         help="ctest group name; also the regression subdir.")
     parser.add_argument("--basename", required=True,
                         help="Fixture basename (without extension).")
-    parser.add_argument("--suffix", required=True,
-                        help="Output suffix without leading dot, e.g. 'stl'.")
     parser.add_argument(
         "--regressiondir",
         default=os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -165,18 +206,10 @@ def main():
                         help="Extra arguments forwarded to pythonscad.")
     args = parser.parse_args()
 
-    suffix = args.suffix.lstrip(".")
-    if not suffix:
-        print("Error: --suffix must be non-empty", file=sys.stderr)
-        return 2
-
     generate = args.generate or bool(os.getenv("TEST_GENERATE"))
 
     rundir = Path("output") / args.testname / args.basename
-    rundir.mkdir(parents=True, exist_ok=True)
-    for stale in rundir.glob(f"*.{suffix}"):
-        if stale.is_file():
-            stale.unlink()
+    _wipe_dir(rundir)
 
     expecteddir = Path(args.regressiondir) / args.testname / args.basename
     if generate:
@@ -186,65 +219,61 @@ def main():
             args.pythonscad, args.fixture, args.extra_args, rundir):
         return 1
 
-    actual_paths = _discover(rundir, suffix)
-    actual_names = {p.name for p in actual_paths}
+    actual = _discover(rundir)
 
-    if not actual_paths:
+    if not actual:
         print(
-            f"Error: fixture produced no .{suffix} files in {rundir}",
+            f"Error: fixture produced no files in {rundir}",
             file=sys.stderr,
         )
         return 1
 
     if generate:
-        # Drop stale goldens with this suffix that the fixture no longer
-        # writes, so the expected directory always mirrors the run output.
-        for stale in _discover(expecteddir, suffix):
-            if stale.name not in actual_names:
-                print(f"removing stale golden: {stale}", file=sys.stderr)
-                stale.unlink()
-        for produced in actual_paths:
-            _post_process(str(produced), suffix)
-            dst = expecteddir / produced.name
+        # Drop stale goldens that the fixture no longer writes so the
+        # expected tree always mirrors the run output.
+        for rel, golden in _discover(expecteddir).items():
+            if rel not in actual:
+                print(f"removing stale golden: {golden}", file=sys.stderr)
+                golden.unlink()
+        for rel, produced in actual.items():
+            _post_process(produced)
+            dst = expecteddir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(str(produced), str(dst))
             print(f"generated golden: {dst}", file=sys.stderr)
         return 0
 
-    expected_paths = _discover(expecteddir, suffix)
-    if not expected_paths:
+    expected = _discover(expecteddir)
+    if not expected:
         print(
-            f"Error: no .{suffix} goldens in {expecteddir}; regenerate with "
+            f"Error: no goldens in {expecteddir}; regenerate with "
             f"TEST_GENERATE=1.",
             file=sys.stderr,
         )
         return 1
-    expected_names = {p.name for p in expected_paths}
 
-    missing = expected_names - actual_names
-    extra = actual_names - expected_names
+    missing = sorted(expected.keys() - actual.keys())
+    extra = sorted(actual.keys() - expected.keys())
     ok = True
     if missing:
         print(
-            f"Error: fixture failed to produce expected file(s): "
-            f"{sorted(missing)}",
+            f"Error: fixture failed to produce expected file(s): {missing}",
             file=sys.stderr,
         )
         ok = False
     if extra:
         print(
             f"Error: fixture produced unexpected file(s) without goldens: "
-            f"{sorted(extra)}",
+            f"{extra}",
             file=sys.stderr,
         )
         ok = False
 
     _setup_tct_options()
-    for produced in actual_paths:
-        if produced.name not in expected_names:
-            continue
-        _post_process(str(produced), suffix)
-        expected = expecteddir / produced.name
-        tct.expectedfilename = str(expected)
+    for rel in sorted(actual.keys() & expected.keys()):
+        produced = actual[rel]
+        _post_process(produced)
+        tct.expectedfilename = str(expected[rel])
         if not tct.compare_default(str(produced)):
             ok = False
 

--- a/tests/test_export_files.py
+++ b/tests/test_export_files.py
@@ -41,7 +41,7 @@
 #      set diffing.
 #
 # Because discovery is "every file under rundir", a single fixture can
-# legitimately mix formats (e.g. an `MultiToolExporter` writing
+# legitimately mix formats (e.g. a `MultiToolExporter` writing
 # `parts/red.stl` + `parts/blue.stl` alongside an assembly
 # `assembly.3mf`) and they all get checked together with no extra
 # wiring.

--- a/tests/test_export_files.py
+++ b/tests/test_export_files.py
@@ -9,10 +9,12 @@
 #   1. Creates a per-test scratch directory (`output/<testname>/<basename>/`).
 #   2. Runs the PythonSCAD binary with the fixture as a script, with that
 #      scratch directory as CWD, so any `export("foo.stl")` call lands there.
-#      A throwaway `-o _cli_driver_dummy.echo` is supplied to force CLI /
-#      headless mode; without it, PythonSCAD treats the script as "open in
-#      GUI" and hits the single-instance lock if a desktop pythonscad is
-#      already running. The dummy is not inspected.
+#      A throwaway `-o <tmp>/_cli_driver_dummy.echo` is supplied to force
+#      CLI / headless mode; without it, PythonSCAD treats the script as
+#      "open in GUI" and hits the single-instance lock if a desktop
+#      pythonscad is already running. The dummy is written into a private
+#      `tempfile.TemporaryDirectory()` so the rundir only ever contains
+#      the artifacts the fixture actually produces.
 #   3. Auto-discovers every produced file in the scratch directory matching
 #      `*.<suffix>`.
 #   4. Applies format-aware post-processing (header progname rewrite for
@@ -56,6 +58,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -83,37 +86,39 @@ def _run_pythonscad(pythonscad, fixture, extra_args, rundir):
     A dummy ``-o`` is supplied to force CLI/headless mode; without it,
     PythonSCAD treats the script as "open this file in the GUI" and hits
     the single-instance lock if a desktop pythonscad is already running.
-    The dummy output file is not inspected; the fixture's own in-script
-    ``export()`` calls produce the artifacts we compare.
+    The dummy output is routed into a private ``TemporaryDirectory`` so
+    it never lands in ``rundir`` (which then only ever contains the
+    artifacts the fixture actually produces) and is cleaned up
+    automatically when the context manager exits.
     """
-    # Bare filename: resolves relative to pythonscad's CWD (= rundir).
-    cli_dummy_name = "_cli_driver_dummy.echo"
-    cmdline = [
-        pythonscad,
-        "--trust-python",
-        "--enable=predictible-output",
-        "--render",
-        "-o", cli_dummy_name,
-        os.path.abspath(fixture),
-    ] + list(extra_args)
-
     fontdir = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "data/ttf"))
     env = os.environ.copy()
     env["OPENSCAD_FONT_PATH"] = fontdir
 
-    print("export-files run cmdline:", " ".join(cmdline))
-    print("export-files run cwd:", str(rundir))
-    sys.stdout.flush()
-    sys.stderr.flush()
+    with tempfile.TemporaryDirectory(prefix="pythonscad-cli-dummy-") as tmp:
+        cli_dummy_path = os.path.join(tmp, "_cli_driver_dummy.echo")
+        cmdline = [
+            pythonscad,
+            "--trust-python",
+            "--enable=predictible-output",
+            "--render",
+            "-o", cli_dummy_path,
+            os.path.abspath(fixture),
+        ] + list(extra_args)
 
-    proc = subprocess.run(
-        cmdline,
-        cwd=str(rundir),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+        print("export-files run cmdline:", " ".join(cmdline))
+        print("export-files run cwd:", str(rundir))
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        proc = subprocess.run(
+            cmdline,
+            cwd=str(rundir),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
     if proc.stdout:
         sys.stderr.write(proc.stdout.decode("utf-8", "replace"))
     if proc.stderr:

--- a/tests/test_export_files.py
+++ b/tests/test_export_files.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+#
+# Regression test driver for fixtures that produce one or more output files
+# via in-script PythonSCAD `export()` calls (including helpers like
+# `MultiToolExporter`).
+#
+# The driver:
+#
+#   1. Creates a per-test scratch directory (`output/<testname>/<basename>/`).
+#   2. Runs the PythonSCAD binary with the fixture as a script, with that
+#      scratch directory as CWD, so any `export("foo.stl")` call lands there.
+#      A throwaway `-o _cli_driver_dummy.echo` is supplied to force CLI /
+#      headless mode; without it, PythonSCAD treats the script as "open in
+#      GUI" and hits the single-instance lock if a desktop pythonscad is
+#      already running. The dummy is not inspected.
+#   3. Auto-discovers every produced file in the scratch directory matching
+#      `*.<suffix>`.
+#   4. Compares each produced file byte-for-byte against
+#      `tests/regression/<testname>/<basename>/<filename>` (after the same
+#      header / XML normalizations test_cmdline_tool.py applies for that
+#      suffix). The expected directory mirrors the actual directory layout
+#      one-for-one, so missing or unexpected files are caught by simple set
+#      diffing.
+#
+# When TEST_GENERATE=1 is set in the environment (or -g/--generate is passed),
+# the produced files are copied into place as the new goldens instead of
+# being compared. Any stale goldens with the same suffix that the fixture no
+# longer writes are removed so the expected directory always mirrors the run
+# output.
+#
+# Usage:
+#   test_export_files.py
+#       --pythonscad <pythonscad-binary>
+#       --testname <test-group-name>
+#       --basename <fixture-basename>
+#       --suffix <stl|3mf|svg|obj|...>
+#       [--regressiondir <dir>]
+#       [--generate]
+#       <fixture.py> [<extra-args-for-pythonscad>...]
+#
+# Exit codes match test_cmdline_tool.py: 0 pass, 1 failure, 2 invalid args.
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import test_cmdline_tool as tct  # noqa: E402  reuse helpers and globals
+
+
+def _setup_tct_options():
+    """Populate the globals that ``tct.compare_default`` reads from."""
+    tct.options = tct.Options()
+    tct.options.exclude_line_re = None
+    tct.options.exclude_debug = False
+
+
+def _post_process(filename, suffix):
+    """Apply the same normalization test_cmdline_tool.py uses post-export."""
+    if suffix in ("stl", "svg", "obj"):
+        tct.post_process_progname(filename)
+    elif suffix == "3mf":
+        tct.post_process_3mf(filename)
+
+
+def _run_pythonscad(pythonscad, fixture, extra_args, rundir):
+    """Run the binary inside ``rundir`` so in-script ``export()`` writes there.
+
+    A dummy ``-o`` is supplied to force CLI/headless mode; without it,
+    PythonSCAD treats the script as "open this file in the GUI" and hits
+    the single-instance lock if a desktop pythonscad is already running.
+    The dummy output file is not inspected; the fixture's own in-script
+    ``export()`` calls produce the artifacts we compare.
+    """
+    # Bare filename: resolves relative to pythonscad's CWD (= rundir).
+    cli_dummy_name = "_cli_driver_dummy.echo"
+    cmdline = [
+        pythonscad,
+        "--trust-python",
+        "--enable=predictible-output",
+        "--render",
+        "-o", cli_dummy_name,
+        os.path.abspath(fixture),
+    ] + list(extra_args)
+
+    fontdir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "data/ttf"))
+    env = os.environ.copy()
+    env["OPENSCAD_FONT_PATH"] = fontdir
+
+    print("export-files run cmdline:", " ".join(cmdline))
+    print("export-files run cwd:", str(rundir))
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    proc = subprocess.run(
+        cmdline,
+        cwd=str(rundir),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.stdout:
+        sys.stderr.write(proc.stdout.decode("utf-8", "replace"))
+    if proc.stderr:
+        sys.stderr.write(proc.stderr.decode("utf-8", "replace"))
+    if proc.returncode != 0:
+        print(
+            f"Error: pythonscad failed with return code {proc.returncode}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _discover(directory, suffix):
+    if not directory.is_dir():
+        return []
+    return sorted(p for p in directory.glob(f"*.{suffix}") if p.is_file())
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run a PythonSCAD fixture that writes files via in-script "
+                    "export() and compare the produced set against goldens.")
+    parser.add_argument("--pythonscad", required=True,
+                        help="Path to the pythonscad executable.")
+    parser.add_argument("--testname", required=True,
+                        help="ctest group name; also the regression subdir.")
+    parser.add_argument("--basename", required=True,
+                        help="Fixture basename (without extension).")
+    parser.add_argument("--suffix", required=True,
+                        help="Output suffix without leading dot, e.g. 'stl'.")
+    parser.add_argument(
+        "--regressiondir",
+        default=os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "regression"),
+        help="Root regression directory (defaults to tests/regression).")
+    parser.add_argument("-g", "--generate", action="store_true",
+                        help="Generate goldens instead of comparing. Also "
+                             "honored via TEST_GENERATE=1 in the environment.")
+    parser.add_argument("fixture", help="Python fixture script to run.")
+    parser.add_argument("extra_args", nargs=argparse.REMAINDER,
+                        help="Extra arguments forwarded to pythonscad.")
+    args = parser.parse_args()
+
+    suffix = args.suffix.lstrip(".")
+    if not suffix:
+        print("Error: --suffix must be non-empty", file=sys.stderr)
+        return 2
+
+    generate = args.generate or bool(os.getenv("TEST_GENERATE"))
+
+    rundir = Path("output") / args.testname / args.basename
+    rundir.mkdir(parents=True, exist_ok=True)
+    for stale in rundir.glob(f"*.{suffix}"):
+        if stale.is_file():
+            stale.unlink()
+
+    expecteddir = Path(args.regressiondir) / args.testname / args.basename
+    if generate:
+        expecteddir.mkdir(parents=True, exist_ok=True)
+
+    if not _run_pythonscad(
+            args.pythonscad, args.fixture, args.extra_args, rundir):
+        return 1
+
+    actual_paths = _discover(rundir, suffix)
+    actual_names = {p.name for p in actual_paths}
+
+    if not actual_paths:
+        print(
+            f"Error: fixture produced no .{suffix} files in {rundir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if generate:
+        # Drop stale goldens with this suffix that the fixture no longer
+        # writes, so the expected directory always mirrors the run output.
+        for stale in _discover(expecteddir, suffix):
+            if stale.name not in actual_names:
+                print(f"removing stale golden: {stale}", file=sys.stderr)
+                stale.unlink()
+        for produced in actual_paths:
+            _post_process(str(produced), suffix)
+            dst = expecteddir / produced.name
+            shutil.copyfile(str(produced), str(dst))
+            print(f"generated golden: {dst}", file=sys.stderr)
+        return 0
+
+    expected_paths = _discover(expecteddir, suffix)
+    if not expected_paths:
+        print(
+            f"Error: no .{suffix} goldens in {expecteddir}; regenerate with "
+            f"TEST_GENERATE=1.",
+            file=sys.stderr,
+        )
+        return 1
+    expected_names = {p.name for p in expected_paths}
+
+    missing = expected_names - actual_names
+    extra = actual_names - expected_names
+    ok = True
+    if missing:
+        print(
+            f"Error: fixture failed to produce expected file(s): "
+            f"{sorted(missing)}",
+            file=sys.stderr,
+        )
+        ok = False
+    if extra:
+        print(
+            f"Error: fixture produced unexpected file(s) without goldens: "
+            f"{sorted(extra)}",
+            file=sys.stderr,
+        )
+        ok = False
+
+    _setup_tct_options()
+    for produced in actual_paths:
+        if produced.name not in expected_names:
+            continue
+        _post_process(str(produced), suffix)
+        expected = expecteddir / produced.name
+        tct.expectedfilename = str(expected)
+        if not tct.compare_default(str(produced)):
+            ok = False
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/docs/cheatsheet.md
+++ b/web/docs/cheatsheet.md
@@ -381,7 +381,7 @@
 
       <div class="func"><code><a href="../reference/multitool/#multitoolexporter">MultiToolExporter</a>(prefix, suffix, mkdir, items)</code></div>
       <div>Split a model into per-color/per-tool files via cumulative difference</div>
-      <div><code>MultiToolExporter("out/m-", ".stl", mkdir=True, items=[(red,"r"),(blue,"b")]).export()</code></div>
+      <div><code>MultiToolExporter("out/m-", ".stl", mkdir=True, items=[("r",red),("b",blue)]).export()</code></div>
   </div>
 </div>
 

--- a/web/docs/cheatsheet.md
+++ b/web/docs/cheatsheet.md
@@ -378,6 +378,10 @@
       <div class="func"><code><a href="../reference/display/#highlight">highlight</a> / <a href="../reference/display/#background">background</a> / <a href="../reference/display/#only">only</a></code></div>
       <div>Debug modifiers for visualization</div>
       <div><code>highlight(cube(5)).show()</code></div>
+
+      <div class="func"><code><a href="../reference/multitool/#multitoolexporter">MultiToolExporter</a>(prefix, suffix, mkdir, items)</code></div>
+      <div>Split a model into per-color/per-tool files via cumulative difference</div>
+      <div><code>MultiToolExporter("out/m-", ".stl", mkdir=True, items=[(red,"r"),(blue,"b")]).export()</code></div>
   </div>
 </div>
 

--- a/web/docs/cheatsheet.md
+++ b/web/docs/cheatsheet.md
@@ -363,6 +363,10 @@
       <div>Export object to a file (STL, 3MF, etc.)</div>
       <div><code>cube(10).export("output.stl")</code></div>
 
+      <div class="func"><code><a href="../reference/display/#multi-object-3mf-export">export</a>({"name": solid, ...}, "out.3mf")</code></div>
+      <div>Multi-object 3MF: dict keys = part names (.3mf only)</div>
+      <div><code>export({"a": cube(5), "b": sphere(3)}, "parts.3mf")</code></div>
+
       <div class="func"><code><a href="../reference/display/#render">render</a>(obj, convexity)</code></div>
       <div>Force full geometry evaluation</div>
       <div><code>cube(10).render().show()</code></div>

--- a/web/docs/reference/display.md
+++ b/web/docs/reference/display.md
@@ -67,12 +67,41 @@ obj.export(file)
 from openscad import *
 
 cube(10).export("mycube.stl")
+```
 
-# Multi-object 3MF export
-c = cube(10)
+### Multi-object 3MF export
+
+Passing a `dict` instead of a single solid emits one 3MF part per
+entry, all packed into the output file:
+
+=== "Python"
+
+```python
+from openscad import *
+
+c   = cube(10)
 cyl = cylinder(r=4, h=4)
 export({"cube": c, "cylinder": cyl}, "myfile.3mf")
 ```
+
+* **Keys** become part names in the 3MF metadata; **values** are the
+  solids. Insertion order is preserved (CPython 3.7+ `dict` semantics).
+* **3MF only.** A dict with two or more entries combined with any
+  non-3MF extension raises `TypeError: This Format can at most export
+  one object`. A *single*-entry dict still works for STL / OFF /
+  AMF / etc. because it ends up exporting just that one solid.
+* **Plain `dict` only.** A `collections.UserDict`, generic `Mapping`,
+  or any other mapping type that is not a `dict` is rejected with
+  `TypeError: Object not recognized`.
+* **Silent skip.** Dict values that aren't recognised as solids
+  (e.g. `None`, plain numbers) are silently dropped from the output.
+  If every value is unrecognised the file is still produced but
+  empty -- pass only solids to avoid surprises.
+
+This pairs naturally with [`MultiToolExporter`](multitool.md): the
+exporter computes cumulative-difference splits and you feed them
+through the multi-object form to land everything in one 3MF file
+(see the example on the multi-tool reference page).
 
 ---
 

--- a/web/docs/reference/display.md
+++ b/web/docs/reference/display.md
@@ -94,9 +94,10 @@ export({"cube": c, "cylinder": cyl}, "myfile.3mf")
   recognised value remains. STL / OFF / AMF / etc. therefore still
   work for a dict that yields zero or one recognised value after
   filtering.
-* **Plain `dict` only.** A `collections.UserDict`, generic `Mapping`,
-  or any other mapping type that is not a `dict` is rejected with
-  `TypeError: Object not recognized`.
+* **`dict` only (including `dict` subclasses).** Mapping types that
+  do not subclass `dict` -- `collections.UserDict`, generic
+  `collections.abc.Mapping` implementations, ... -- are rejected
+  with `TypeError: Object not recognized`.
 * **Value conversion.** Recognised values are
   :class:`PyOpenSCADObject` instances and lists of them (the list is
   unioned). The sentinels behave specially: `None` and `False`

--- a/web/docs/reference/display.md
+++ b/web/docs/reference/display.md
@@ -86,10 +86,12 @@ export({"cube": c, "cylinder": cyl}, "myfile.3mf")
 
 * **Keys** become part names in the 3MF metadata; **values** are the
   solids. Insertion order is preserved (CPython 3.7+ `dict` semantics).
-* **3MF only.** A dict with two or more entries combined with any
-  non-3MF extension raises `TypeError: This Format can at most export
-  one object`. A *single*-entry dict still works for STL / OFF /
-  AMF / etc. because it ends up exporting just that one solid.
+* **3MF only.** For non-3MF extensions, dict values that aren't
+  recognised as solids are skipped first; `TypeError: This Format
+  can at most export one object` is raised only when more than one
+  recognised solid remains. STL / OFF / AMF / etc. therefore still
+  work for a dict that yields zero or one recognised solid after
+  filtering.
 * **Plain `dict` only.** A `collections.UserDict`, generic `Mapping`,
   or any other mapping type that is not a `dict` is rejected with
   `TypeError: Object not recognized`.

--- a/web/docs/reference/display.md
+++ b/web/docs/reference/display.md
@@ -84,21 +84,28 @@ cyl = cylinder(r=4, h=4)
 export({"cube": c, "cylinder": cyl}, "myfile.3mf")
 ```
 
-* **Keys** become part names in the 3MF metadata; **values** are the
-  solids. Insertion order is preserved (CPython 3.7+ `dict` semantics).
+* **Keys** become part names in the 3MF metadata, so they must be
+  `str` / Unicode -- non-string keys are not supported and may error
+  or crash at runtime. **Values** are the solids. Insertion order is
+  preserved (CPython 3.7+ `dict` semantics).
 * **3MF only.** For non-3MF extensions, dict values that aren't
-  recognised as solids are skipped first; `TypeError: This Format
+  recognised as solids are filtered first; `TypeError: This Format
   can at most export one object` is raised only when more than one
-  recognised solid remains. STL / OFF / AMF / etc. therefore still
-  work for a dict that yields zero or one recognised solid after
+  recognised value remains. STL / OFF / AMF / etc. therefore still
+  work for a dict that yields zero or one recognised value after
   filtering.
 * **Plain `dict` only.** A `collections.UserDict`, generic `Mapping`,
   or any other mapping type that is not a `dict` is rejected with
   `TypeError: Object not recognized`.
-* **Silent skip.** Dict values that aren't recognised as solids
-  (e.g. `None`, plain numbers) are silently dropped from the output.
-  If every value is unrecognised the file is still produced but
-  empty -- pass only solids to avoid surprises.
+* **Value conversion.** Recognised values are
+  :class:`PyOpenSCADObject` instances and lists of them (the list is
+  unioned). The sentinels behave specially: `None` and `False`
+  resolve to the built-in *empty* object and `True` to the *full*
+  universe -- they are **not** dropped, they pass through as parts.
+  Other values (numbers, strings, ...) are silently filtered out.
+  If no value is recognised at all, `export()` raises
+  `TypeError: Object not recognized` rather than writing an empty
+  file.
 
 This pairs naturally with [`MultiToolExporter`](multitool.md): the
 exporter computes cumulative-difference splits and you feed them

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -19,8 +19,12 @@ from pythonscad import MultiToolExporter
 ## MultiToolExporter
 
 `MultiToolExporter` is a `list` subclass whose items are
-`(object, name)` 2-tuples. The `name` is a label used to build the output
-filename and must be a non-empty string and unique within the exporter.
+`(name, object)` 2-tuples. The `name` is a label used to build the output
+filename and must be a non-empty string; output paths must be unique.
+Item order matches `dict.items()` and the multi-object form of
+[`export`](display.md#export), so a `MultiToolExporter` and a `dict` of
+parts are interchangeable (`MultiToolExporter(..., items=parts.items())`
+and `dict(exporter.parts())`).
 
 **Filename layout:** for each item, the exporter writes to:
 
@@ -34,7 +38,7 @@ so a typical use is `prefix="out/model-"` and `suffix=".stl"`.
 exported is
 
 ```text
-self[i][0] − self[i+1][0] − self[i+2][0] − ... − self[-1][0]
+self[i].object − self[i+1].object − self[i+2].object − ... − self[-1].object
 ```
 
 i.e. each entry's volume minus every later entry's volume.
@@ -59,7 +63,7 @@ MultiToolExporter(prefix, suffix, mkdir=False, items=())
 | `prefix`  | `str`                           | —       | Prepended to every output filename                                                     |
 | `suffix`  | `str`                           | —       | Appended to every output filename (typically the extension, e.g. `".stl"`, `".3mf"`)   |
 | `mkdir`   | `bool`                          | `False` | If `True`, create each output file's directory with `os.makedirs(..., exist_ok=True)`. See note below. |
-| `items`   | iterable of `(object, name)`    | `()`    | Optional initial items, validated as if they were appended one at a time.              |
+| `items`   | iterable of `(name, object)`    | `()`    | Optional initial items (e.g. `a_dict.items()`), validated as if they were appended one at a time. |
 
 When `mkdir=True`, filenames without a directory component (e.g.
 `"flag-"` rather than `"out/flag-"`) are exported as-is - no directory
@@ -69,16 +73,16 @@ is created and no error is raised.
 
 | Method            | Description                                                                                                              |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `append(item)`    | Append a single `(object, name)` 2-tuple. Validates the shape.                                                           |
-| `extend(items)`   | Append each `(object, name)` from an iterable.                                                                           |
-| `insert(i, item)` | Insert a single `(object, name)` 2-tuple at position `i`.                                                                |
+| `append(item)`    | Append a single `(name, object)` 2-tuple. Validates the shape.                                                           |
+| `extend(items)`   | Append each `(name, object)` from an iterable.                                                                           |
+| `insert(i, item)` | Insert a single `(name, object)` 2-tuple at position `i`.                                                                |
 | `parts()`         | Return the computed `(name, geometry)` pairs in declaration order. Used internally by `export`/`show` and as input for `dict(exporter.parts())` to feed multi-object 3MF export. |
 | `export()`        | Write each part to its file. Raises `ValueError` if any two items would write to the same output path.                  |
 | `show()`          | Render each part into the preview viewport (same cumulative-difference semantics as `export`).                           |
 
 **Validation:**
 
-* Every inserted item must be a 2-tuple of `(object, str)`. Anything else
+* Every inserted item must be a 2-tuple of `(str, object)`. Anything else
   raises `TypeError`.
 * The `name` must be a non-empty string. Empty names raise `ValueError`.
 * At `export()` time, the full output filename
@@ -105,8 +109,8 @@ background = cube([200, 100, 1]).color("blue")
 star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
 
 exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
-exporter.append((background, "blue"))    # blue: rectangle minus the star area
-exporter.append((star,       "red"))     # red: the star itself (later wins)
+exporter.append(("blue", background))    # blue: rectangle minus the star area
+exporter.append(("red",  star))          # red: the star itself (later wins)
 exporter.export()
 # -> writes out/flag-blue.stl and out/flag-red.stl
 ```
@@ -125,7 +129,7 @@ MultiToolExporter(
     prefix="out/cube-",
     suffix=".3mf",
     mkdir=True,
-    items=[(red, "red"), (blue, "blue")],
+    items=[("red", red), ("blue", blue)],
 ).export()
 ```
 
@@ -137,7 +141,7 @@ Previewing the same split inside the GUI without writing files:
 from pythonscad import *
 
 exporter = MultiToolExporter("ignored-", ".stl")
-exporter.append((red,  "red"))
-exporter.append((blue, "blue"))
+exporter.append(("red",  red))
+exporter.append(("blue", blue))
 exporter.show()
 ```

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -1,0 +1,133 @@
+# Multi-tool Export
+
+PythonSCAD ships a small helper, `MultiToolExporter`, for the common
+multi-tool / multi-color workflow where a single model is split into several
+parts (typically one per filament color or print head) and each part is
+exported to its own file.
+
+The class lives in the `pythonscad` package (a strict superset of `openscad`),
+so it is available under either of these imports:
+
+=== "Python"
+
+```python
+from pythonscad import *
+# or, equivalently for this class:
+from pythonscad import MultiToolExporter
+```
+
+## MultiToolExporter
+
+`MultiToolExporter` is a `list` subclass whose items are
+`(object, name)` 2-tuples. The `name` is a label used to build the output
+filename and must be a non-empty string and unique within the exporter.
+
+**Filename layout:** for each item, the exporter writes to:
+
+```text
+{prefix}{name}{suffix}
+```
+
+so a typical use is `prefix="out/model-"` and `suffix=".stl"`.
+
+**Cumulative-difference semantics:** for each index `i`, the geometry
+exported is
+
+```text
+self[i][0] − self[i+1][0] − self[i+2][0] − ... − self[-1][0]
+```
+
+i.e. the first object's volume minus every later object's volume.
+This guarantees that overlapping regions are claimed by exactly one part:
+earlier entries "win", later parts only contain the volume not already
+claimed. The last entry is exported as-is (no degenerate one-child
+`difference` node).
+
+**Constructor:**
+
+=== "Python"
+
+```python
+MultiToolExporter(prefix, suffix, mkdir=False, items=())
+```
+
+**Parameters:**
+
+| Parameter | Type                            | Default | Description                                                                            |
+|-----------|---------------------------------|---------|----------------------------------------------------------------------------------------|
+| `prefix`  | `str`                           | —       | Prepended to every output filename                                                     |
+| `suffix`  | `str`                           | —       | Appended to every output filename (typically the extension, e.g. `".stl"`, `".3mf"`)   |
+| `mkdir`   | `bool`                          | `False` | If `True`, create each output file's directory with `os.makedirs(..., exist_ok=True)`. See note below. |
+| `items`   | iterable of `(object, name)`    | `()`    | Optional initial items, validated as if they were appended one at a time.              |
+
+When `mkdir=True`, filenames without a directory component (e.g.
+`"flag-"` rather than `"out/flag-"`) are exported as-is - no directory
+is created and no error is raised.
+
+**Methods:**
+
+| Method            | Description                                                                                                              |
+|-------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `append(item)`    | Append a single `(object, name)` 2-tuple. Validates the shape.                                                           |
+| `extend(items)`   | Append each `(object, name)` from an iterable.                                                                           |
+| `insert(i, item)` | Insert a single `(object, name)` 2-tuple at position `i`.                                                                |
+| `export()`        | Write each part to its file. Raises `ValueError` if any two items share the same name.                                  |
+| `show()`          | Render each part into the preview viewport (same cumulative-difference semantics as `export`).                           |
+
+**Validation:**
+
+* Every inserted item must be a 2-tuple of `(object, str)`. Anything else
+  raises `TypeError`.
+* The `name` must be a non-empty string. Empty names raise `ValueError`.
+* At `export()` time, duplicate names raise `ValueError` rather than letting
+  later parts silently overwrite the files written by earlier parts.
+
+**Examples:**
+
+A two-color flag (red star cut out of a blue background):
+
+=== "Python"
+
+```python
+from pythonscad import *
+
+background = cube([200, 100, 1]).color("blue")
+star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
+
+exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
+exporter.append((star,       "red"))     # earlier wins
+exporter.append((background, "blue"))    # blue gets background minus star
+exporter.export()
+# -> writes out/flag-red.stl and out/flag-blue.stl
+```
+
+Seeding from the constructor:
+
+=== "Python"
+
+```python
+from pythonscad import *
+
+red  = cube(10).color("red")
+blue = cube(10).color("blue").right(5)
+
+MultiToolExporter(
+    prefix="out/cube-",
+    suffix=".3mf",
+    mkdir=True,
+    items=[(red, "red"), (blue, "blue")],
+).export()
+```
+
+Previewing the same split inside the GUI without writing files:
+
+=== "Python"
+
+```python
+from pythonscad import *
+
+exporter = MultiToolExporter("ignored-", ".stl")
+exporter.append((red,  "red"))
+exporter.append((blue, "blue"))
+exporter.show()
+```

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -170,7 +170,8 @@ exporter.append(("red",  star))
 export(dict(exporter.parts()), "flag.3mf")
 ```
 
-The dict-form `export()` accepts only `.3mf` for two-or-more entries;
+The dict-form `export()` accepts only `.3mf` when, after silently
+dropping any non-solid values, two or more recognised solids remain;
 see [Multi-object 3MF export](display.md#multi-object-3mf-export) for
 the full constraints (insertion order, plain-dict requirement,
 silent-skip of non-solid values).

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -37,11 +37,12 @@ exported is
 self[i][0] − self[i+1][0] − self[i+2][0] − ... − self[-1][0]
 ```
 
-i.e. the first object's volume minus every later object's volume.
+i.e. each entry's volume minus every later entry's volume.
 This guarantees that overlapping regions are claimed by exactly one part:
-earlier entries "win", later parts only contain the volume not already
-claimed. The last entry is exported as-is (no degenerate one-child
-`difference` node).
+**later entries "win" over earlier ones**, so each part only keeps the
+volume not claimed by any subsequent part. The last entry is exported
+as-is (no degenerate one-child `difference` node) and therefore claims
+everything that overlaps with it.
 
 **Constructor:**
 
@@ -95,10 +96,10 @@ background = cube([200, 100, 1]).color("blue")
 star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
 
 exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
-exporter.append((star,       "red"))     # earlier wins
-exporter.append((background, "blue"))    # blue gets background minus star
+exporter.append((background, "blue"))    # blue: rectangle minus the star area
+exporter.append((star,       "red"))     # red: the star itself (later wins)
 exporter.export()
-# -> writes out/flag-red.stl and out/flag-blue.stl
+# -> writes out/flag-blue.stl and out/flag-red.stl
 ```
 
 Seeding from the constructor:

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -145,3 +145,32 @@ exporter.append(("red",  red))
 exporter.append(("blue", blue))
 exporter.show()
 ```
+
+### Combining with multi-object 3MF export
+
+`MultiToolExporter` writes one file per part. To combine its
+cumulative-difference split with the
+[multi-object 3MF form](display.md#multi-object-3mf-export) of
+`export()` (one 3MF file containing every part as a named object),
+run the parts through `parts()` and feed the result into a `dict`:
+
+=== "Python"
+
+```python
+from pythonscad import *
+
+background = cube([200, 100, 1]).color("blue")
+star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
+
+exporter = MultiToolExporter("", "")  # prefix/suffix unused for this path
+exporter.append(("blue", background))
+exporter.append(("red",  star))
+
+# Cumulative-difference split, then a single 3MF with two named parts.
+export(dict(exporter.parts()), "flag.3mf")
+```
+
+The dict-form `export()` accepts only `.3mf` for two-or-more entries;
+see [Multi-object 3MF export](display.md#multi-object-3mf-export) for
+the full constraints (insertion order, plain-dict requirement,
+silent-skip of non-solid values).

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -72,7 +72,8 @@ is created and no error is raised.
 | `append(item)`    | Append a single `(object, name)` 2-tuple. Validates the shape.                                                           |
 | `extend(items)`   | Append each `(object, name)` from an iterable.                                                                           |
 | `insert(i, item)` | Insert a single `(object, name)` 2-tuple at position `i`.                                                                |
-| `export()`        | Write each part to its file. Raises `ValueError` if any two items share the same name.                                  |
+| `parts()`         | Return the computed `(name, geometry)` pairs in declaration order. Used internally by `export`/`show` and as input for `dict(exporter.parts())` to feed multi-object 3MF export. |
+| `export()`        | Write each part to its file. Raises `ValueError` if any two items would write to the same output path.                  |
 | `show()`          | Render each part into the preview viewport (same cumulative-difference semantics as `export`).                           |
 
 **Validation:**

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -170,8 +170,12 @@ exporter.append(("red",  star))
 export(dict(exporter.parts()), "flag.3mf")
 ```
 
-The dict-form `export()` accepts only `.3mf` when, after silently
-dropping any non-solid values, two or more recognised solids remain;
-see [Multi-object 3MF export](display.md#multi-object-3mf-export) for
-the full constraints (insertion order, plain-dict requirement,
-silent-skip of non-solid values).
+The dict-form `export()` accepts only `.3mf` when, after filtering,
+two or more recognised values remain. The filter is *not* a uniform
+silent drop: `None` and `False` resolve to the built-in empty object
+and `True` to the full universe (they pass through as named parts),
+while truly unrelated values like numbers or strings are dropped, and
+if nothing converts at all you get `TypeError: Object not recognized`.
+Keys must be `str` (they become 3MF part names). See
+[Multi-object 3MF export](display.md#multi-object-3mf-export) for the
+full contract.

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -80,8 +80,16 @@ is created and no error is raised.
 * Every inserted item must be a 2-tuple of `(object, str)`. Anything else
   raises `TypeError`.
 * The `name` must be a non-empty string. Empty names raise `ValueError`.
-* At `export()` time, duplicate names raise `ValueError` rather than letting
-  later parts silently overwrite the files written by earlier parts.
+* At `export()` time, the full output filename
+  (`f"{prefix}{name}{suffix}"`) of every item is normalised with
+  `os.path.normcase(os.path.normpath(filename))` (plus an extra
+  `.casefold()` on macOS) and any collision raises `ValueError` rather
+  than letting later parts silently overwrite earlier ones. This rejects
+  raw duplicate names everywhere, plus path aliases like `"a/../b"` vs
+  `"b"`, plus case-only collisions like `"a.stl"` vs `"A.stl"` on
+  Windows and macOS (whose default filesystems are case-insensitive).
+  Linux treats such case-only pairs as distinct files and is left
+  alone.
 
 **Examples:**
 

--- a/web/docs/tutorial/python_new.md
+++ b/web/docs/tutorial/python_new.md
@@ -242,6 +242,35 @@ export( {
 
 ```
 
+## MultiToolExporter
+
+When working with multi-tool / multi-color 3D printers, a single model is
+often split into one part per filament. `MultiToolExporter` is a
+PythonSCAD-only `list` subclass that automates that split: it stores
+`(object, name)` pairs and, on export, writes each part as
+`f"{prefix}{name}{suffix}"`, where each part has all *later* objects
+subtracted from it. That cumulative-difference rule guarantees overlapping
+volume is claimed by exactly one part.
+
+```py
+from pythonscad import *
+
+# Two-color flag: red star punched out of a blue background.
+background = cube([200, 100, 1]).color("blue")
+star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
+
+exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
+exporter.append((star,       "red"))   # earlier wins
+exporter.append((background, "blue"))  # blue gets background minus star
+exporter.export()
+# writes out/flag-red.stl and out/flag-blue.stl
+```
+
+`exporter.show()` previews the same split inside the GUI without writing
+files, and items can also be seeded directly via the constructor's
+`items=[...]` argument. See
+[Multi-tool Export](../reference/multitool.md) for the full reference.
+
 ## spline
 
 Spline is like 'polygon'  just with the difference, that the resulting object is very round and will meet the given points

--- a/web/docs/tutorial/python_new.md
+++ b/web/docs/tutorial/python_new.md
@@ -260,10 +260,10 @@ background = cube([200, 100, 1]).color("blue")
 star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
 
 exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
-exporter.append((star,       "red"))   # earlier wins
-exporter.append((background, "blue"))  # blue gets background minus star
+exporter.append((background, "blue"))  # blue: rectangle minus the star area
+exporter.append((star,       "red"))   # red: the star itself (later wins)
 exporter.export()
-# writes out/flag-red.stl and out/flag-blue.stl
+# writes out/flag-blue.stl and out/flag-red.stl
 ```
 
 `exporter.show()` previews the same split inside the GUI without writing

--- a/web/docs/tutorial/python_new.md
+++ b/web/docs/tutorial/python_new.md
@@ -247,10 +247,10 @@ export( {
 When working with multi-tool / multi-color 3D printers, a single model is
 often split into one part per filament. `MultiToolExporter` is a
 PythonSCAD-only `list` subclass that automates that split: it stores
-`(object, name)` pairs and, on export, writes each part as
-`f"{prefix}{name}{suffix}"`, where each part has all *later* objects
-subtracted from it. That cumulative-difference rule guarantees overlapping
-volume is claimed by exactly one part.
+`(name, object)` pairs (the same shape as `dict.items()`) and, on export,
+writes each part as `f"{prefix}{name}{suffix}"`, where each part has all
+*later* objects subtracted from it. That cumulative-difference rule
+guarantees overlapping volume is claimed by exactly one part.
 
 ```py
 from pythonscad import *
@@ -260,8 +260,8 @@ background = cube([200, 100, 1]).color("blue")
 star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
 
 exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
-exporter.append((background, "blue"))  # blue: rectangle minus the star area
-exporter.append((star,       "red"))   # red: the star itself (later wins)
+exporter.append(("blue", background))  # blue: rectangle minus the star area
+exporter.append(("red",  star))        # red: the star itself (later wins)
 exporter.export()
 # writes out/flag-blue.stl and out/flag-red.stl
 ```

--- a/web/mkdocs.yml
+++ b/web/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - Object Properties: reference/properties.md
       - Object Model: reference/object_model.md
       - Display and Export: reference/display.md
+      - Multi-tool Export: reference/multitool.md
       - I/O and Integration: reference/io.md
       - Math Functions: reference/math.md
       - Special Variables: reference/variables.md


### PR DESCRIPTION
## Summary

Adds `MultiToolExporter`, a list-based PythonSCAD-only helper for splitting a single model into per-tool / per-color files. It stores `(name, object)` pairs (matching `dict.items()` and the multi-object form of `export()`) and, on `export()`, writes each part as `f"{prefix}{name}{suffix}"` with every later object subtracted from the current one - so overlapping volume is claimed by exactly one part: **later entries "win" over earlier ones**, and the last entry is exported as-is (no degenerate one-child `difference` node).

Lives in `libraries/python/pythonscad/__init__.py` so the C extension and the OpenSCAD-compatible `openscad` package are unaffected - only `from pythonscad import *` exposes it. No build-system or C++ changes required.

### Public API

- `MultiToolExporter(prefix, suffix, mkdir=False, items=())` - list-based constructor; `items=` accepts any iterable of `(name, object)` pairs (including `dict.items()`).
- `append`, `extend`, `insert`, `__setitem__` - validate every inserted item.
- `parts() -> list[tuple[str, Any]]` - return the computed cumulative-difference geometries as `(name, geometry)` pairs in declaration order. Used internally by `export()`/`show()` and as input for `dict(exporter.parts())` to feed the multi-object 3MF form of `export()`.
- `export()` - one file per part.
- `show()` - layered preview equivalent.

Items are `(name, object)` so a `MultiToolExporter` and a `dict` of parts are interchangeable:

- `MultiToolExporter(..., items=parts.items())` - seed from a `dict`.
- `dict(exporter.parts())` - feed straight into `export({...}, "out.3mf")` for one 3MF file with multiple named parts.

### Hardening over a naive implementation

- `os.makedirs(...)` is guarded against an empty directory component, so `mkdir=True` no longer crashes when the prefix has no directory part.
- Items are validated on every insertion path (constructor `items=...`, `append`, `extend`, `insert`, `__setitem__`); `extend` is atomic so a bad item in the middle of the iterable does not leave a half-applied state.
- Output paths must be unique per item: at `export()` time, every item's full filename is normalised with `os.path.normcase(os.path.normpath(filename))` (plus an extra `.casefold()` on macOS) and any collision raises `ValueError`. This rejects raw duplicate names everywhere, plus path aliases (`"a/../b"` vs `"b"`), plus case-only collisions (`"a.stl"` vs `"A.stl"`) on Windows and macOS where the destination filesystem is typically case-insensitive. Linux still treats case-only pairs as distinct files.

### Documentation

- New reference page `web/docs/reference/multitool.md`, linked from the mkdocs nav, with examples for one-file-per-part and the multi-object 3MF integration via `dict(exporter.parts())`.
- Expanded `## export` section in `web/docs/reference/display.md` documenting the `dict` form: 3MF-only constraint applied *after filtering*, plain-`dict` requirement, `str`-only keys, insertion-order semantics, and the value-conversion rules (`PyOpenSCADObject` / `list[...]` are exported, `None` and `False` resolve to the empty object, `True` resolves to the full universe, everything else is dropped, and an all-unrecognised dict raises `TypeError: Object not recognized`).
- Cheatsheet entries under "Display and Export" for both the basic exporter and the multi-object 3MF dict form.
- Tutorial section in `web/docs/tutorial/python_new.md`.
- Type stub in `libraries/python/stubs/pythonscad-stubs/__init__.pyi`.
- Import-aliasing convention comment in both `libraries/python/pythonscad/__init__.py` and the public stub: any non-public helper import must be aliased with a leading underscore (`import os as _os`) so it does not leak into `from pythonscad import *`, IDE auto-complete, or the public type-stub surface.

### Tests

- New `pythonscadecho_multitool-exporter` echo ctest covering all validation paths, the `_part(last)` shortcut, the new `parts()` shape, duplicate-name detection, the `mkdir=True` directory-less bug fix, and the end-to-end `export()` call sequence (with a monkey-patched `pythonscad.export` so output is deterministic and independent of the geometry backend).
- New `multitool-export_two-color-flag` on-disk export ctest that splits two overlapping cubes into `blue.stl` and `red.stl` and compares each against an ASCII-STL golden under `--enable=predictible-output`.
- Generic test infrastructure for future on-disk export regression tests (see #586): `tests/test_export_files.py` runs a fixture in a per-test scratch CWD and tree-diffs the rundir against `tests/regression/<testname>/<basename>/<rel-path>` — recursive (every file, every subdirectory), per-extension post-processing (`post_process_progname` for STL/SVG/OBJ, inner-XML extraction for 3MF), and `--suffix`-free, so a single fixture can mix formats freely.

## Test plan

- [x] `ctest -R pythonscadecho` - all tests pass locally, including the new `pythonscadecho_multitool-exporter`.
- [x] `ctest -R multitool-export` - the new on-disk export test passes (and correctly fails on missing/extra files when fixtures are perturbed).
- [x] Pre-commit hooks pass (markdownlint, ruff, mkdocs check, commitlint).
- [x] No linter regressions in `libraries/python/pythonscad/__init__.py` (only the 5 pre-existing `basedpyright` warnings about the runtime-resolved `openscad` C extension).
- [ ] CI green.
- [ ] Visual sanity-check of the new `web/docs/reference/multitool.md` page in the live mkdocs preview.

## Example

\`\`\`python
from pythonscad import *

background = cube([200, 100, 1]).color("blue")
star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")

exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
exporter.append(("blue", background))  # blue: rectangle minus the star area
exporter.append(("red",  star))        # red: the star itself (later wins)
exporter.export()
# -> writes out/flag-blue.stl and out/flag-red.stl

# Or: same split, single 3MF file with two named parts.
export(dict(exporter.parts()), "flag.3mf")
\`\`\`

Made with [Cursor](https://cursor.com)