### PR TITLE
docs: clarify osuse/osinclude usage and deprecation

### DIFF
--- a/web/docs/cheatsheet.md
+++ b/web/docs/cheatsheet.md
@@ -390,12 +390,12 @@
       <div><code>osimport("model.stl").show()</code></div>
 
       <div class="func"><code><a href="../reference/io/#osuse">osuse</a>(file)</code></div>
-      <div>Use an OpenSCAD library file (like <code>use &lt;...&gt;</code>)</div>
-      <div><code>osuse("library.scad")</code></div>
+      <div>Use an OpenSCAD library file (like <code>use &lt;...&gt;</code>); call modules/functions on the returned handle</div>
+      <div><code>lib = osuse("library.scad"); lib.my_module().show()</code></div>
 
       <div class="func"><code><a href="../reference/io/#osinclude">osinclude</a>(file)</code></div>
-      <div>Include an OpenSCAD file (like <code>include &lt;...&gt;</code>)</div>
-      <div><code>osinclude("config.scad")</code></div>
+      <div>Include an OpenSCAD file (like <code>include &lt;...&gt;</code>) — deprecated, use <code>osuse</code> instead</div>
+      <div><code>lib = osinclude("config.scad")</code></div>
 
       <div class="func"><code><a href="../reference/io/#scad">scad</a>(code)</code></div>
       <div>Execute inline OpenSCAD code from Python</div>

--- a/web/docs/reference/io.md
+++ b/web/docs/reference/io.md
@@ -53,14 +53,18 @@ drawing.linear_extrude(height=2).show()
 
 ## osuse
 
-Load an OpenSCAD library file, making its modules and functions available. Equivalent to OpenSCAD's `use <file.scad>`.
+Load an OpenSCAD library file and **return a handle object** whose attributes
+are the library's modules, functions, and top-level variables. Equivalent to
+OpenSCAD's `use <file.scad>`, but unlike OpenSCAD's `use`, the imported
+symbols are *not* injected into the global namespace — you must access them
+through the returned object.
 
 **Syntax:**
 
 === "Python"
 
 ```python
-osuse(file)
+lib = osuse(file)
 ```
 
 **Parameters:**
@@ -69,28 +73,78 @@ osuse(file)
 |-----------|------|-------------|
 | `file` | string | Path to the `.scad` file |
 
+**Returns:** an object exposing the imported library's contents:
+
+- **Modules** become methods that return geometry objects (e.g. `lib.gear(...)`).
+- **Functions** become methods that return values (e.g. `lib.calc_pitch(...)`).
+- **Top-level variables** are accessible via attribute access for plain names
+  (e.g. `lib.my_var`) and via item access for `$`-prefixed special variables
+  (e.g. `lib["$fn"]`).
+
+!!! note
+    Calling a module from the imported library produces a geometry object —
+    you still need to call `.show()` on it (or assign it to a variable that
+    you later `show()`) for it to appear in the output, just like any other
+    PythonSCAD geometry.
+
 **Examples:**
+
+Calling a module from an imported library:
 
 === "Python"
 
 ```python
 from openscad import *
 
-osuse("MCAD/gears.scad")
+mcad = osuse("MCAD/gears.scad")
+
+g = mcad.gear(
+    number_of_teeth=20,
+    circular_pitch=200,
+    pressure_angle=20,
+    clearance=0,
+    verbose=False,
+)
+g.show()
+```
+
+Calling a function and reading variables from an imported library:
+
+=== "Python"
+
+```python
+from openscad import *
+
+lib = osuse("mylib.scad")
+
+width = lib.get_width()
+radius = lib.calculate_radius(diameter=10)
+
+print(lib.my_constant)
+print(lib["$fn"])
 ```
 
 ---
 
 ## osinclude
 
-Include an OpenSCAD file, executing its top-level code. Equivalent to OpenSCAD's `include <file.scad>`.
+!!! warning "Deprecated"
+    `osinclude` is deprecated — use [`osuse`](#osuse) instead. Both functions
+    return the same handle object; `osinclude` exists only for backwards
+    compatibility with early PythonSCAD scripts and emits a deprecation
+    warning when called.
+
+Include an OpenSCAD file, executing its top-level code. Equivalent to
+OpenSCAD's `include <file.scad>`. Returns the same kind of handle object as
+[`osuse`](#osuse); see that section for how to access the imported modules,
+functions, and variables.
 
 **Syntax:**
 
 === "Python"
 
 ```python
-osinclude(file)
+lib = osinclude(file)
 ```
 
 **Parameters:**
@@ -106,7 +160,8 @@ osinclude(file)
 ```python
 from openscad import *
 
-osinclude("config.scad")
+lib = osinclude("config.scad")
+print(lib.default_radius)
 ```
 
 ---

--- a/web/docs/reference/io.md
+++ b/web/docs/reference/io.md
@@ -54,10 +54,13 @@ drawing.linear_extrude(height=2).show()
 ## osuse
 
 Load an OpenSCAD library file and **return a handle object** whose attributes
-are the library's modules, functions, and top-level variables. Equivalent to
-OpenSCAD's `use <file.scad>`, but unlike OpenSCAD's `use`, the imported
-symbols are *not* injected into the global namespace — you must access them
-through the returned object.
+are the library's modules, functions, and top-level variables. PythonSCAD's
+analog of OpenSCAD's `use <file.scad>`, with two semantic differences:
+
+- The imported symbols are *not* injected into the global namespace — you
+  must access them through the returned handle.
+- The handle also exposes top-level variable assignments, which OpenSCAD's
+  `use` does not import.
 
 **Syntax:**
 
@@ -83,9 +86,9 @@ lib = osuse(file)
 
 !!! note
     Calling a module from the imported library produces a geometry object —
-    you still need to call `.show()` on it (or assign it to a variable that
-    you later `show()`) for it to appear in the output, just like any other
-    PythonSCAD geometry.
+    you still need to call `.show()` on it (or assign it to a variable and
+    call `.show()` on that variable later) for it to appear in the output,
+    just like any other PythonSCAD geometry.
 
 **Examples:**
 
@@ -129,15 +132,29 @@ print(lib["$fn"])
 ## osinclude
 
 !!! warning "Deprecated"
-    `osinclude` is deprecated — use [`osuse`](#osuse) instead. Both functions
-    return the same handle object; `osinclude` exists only for backwards
-    compatibility with early PythonSCAD scripts and emits a deprecation
-    warning when called.
+    `osinclude` is deprecated — use [`osuse`](#osuse) for new code. Calling
+    `osinclude` logs a deprecation message to the PythonSCAD console (it does
+    not raise a Python `DeprecationWarning`).
 
-Include an OpenSCAD file, executing its top-level code. Equivalent to
-OpenSCAD's `include <file.scad>`. Returns the same kind of handle object as
-[`osuse`](#osuse); see that section for how to access the imported modules,
-functions, and variables.
+PythonSCAD's analog of OpenSCAD's `include <file.scad>`. The returned handle
+exposes the imported modules, functions, and top-level variables exactly the
+same way as [`osuse`](#osuse) — see that section for usage examples.
+
+`osuse` and `osinclude` differ in whether they evaluate the imported
+file's top-level *module instantiations* — in OpenSCAD that category covers
+calls like `cube()`, `echo()`, and `assert()`, which are syntactically
+module calls. `osinclude` evaluates them, `osuse` suppresses them. Output
+or errors from those top-level calls therefore only surface with
+`osinclude`.
+
+Top-level *variable assignments* (e.g. `x = 10;`) are always evaluated by
+both functions — they are needed to populate the returned handle, so any
+errors in their expressions will propagate from either call.
+
+In both cases, any geometry produced by top-level module instantiations is
+discarded — neither `osuse` nor `osinclude` exposes top-level geometry on
+the returned handle. To use geometry from an OpenSCAD file, call its
+modules explicitly via the handle (e.g. `lib.my_module().show()`).
 
 **Syntax:**
 

--- a/web/mkdocs.yml
+++ b/web/mkdocs.yml
@@ -95,5 +95,4 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
   - attr_list

--- a/web/mkdocs.yml
+++ b/web/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - Contact: contact.md
 
 markdown_extensions:
+  - admonition
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
## Summary

Fixes #584 — the reference docs for `osuse()` showed loading an OpenSCAD
library but never explained how to actually call modules or functions from
it. As reported in the issue, this led users to (reasonably) assume that the
imported symbols would be available globally, which is not the case.

- Document that `osuse()` returns a handle object whose attributes are the
  library's modules, functions, and top-level variables.
- Add concrete examples for calling modules (incl. the exact `MCAD/gears.scad`
  case from the issue), calling functions, and reading both regular and
  `$`-prefixed variables.
- Flag `osinclude()` as deprecated in the reference (matches the runtime
  `LOG(message_group::Deprecated, ...)` already emitted by the implementation
  in `src/python/pyfunctions.cc`).
- Enable the `admonition` markdown extension in `web/mkdocs.yml` so the new
  `!!! note` / `!!! warning` callouts render correctly under Material for
  MkDocs.

Docs-only change — no behavior changes, no new code.

## Test plan

- [x] `pre-commit` runs cleanly (`markdownlint`, `check-mkdocs`, `commitlint` all pass).
- [ ] Build the docs locally (`mkdocs build` / `mkdocs serve` from `web/`) and
      visually verify the `osuse` and `osinclude` sections render properly,
      including the admonition callouts.

Made with [Cursor](https://cursor.com)