### PR TITLE
fix(3mf): scope per-mesh material IDs to append_polyset (lib3mf v1)

### DIFF
--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -91,7 +91,6 @@ struct ExportContext {
   int modelcount = 0;
   Color4f defaultColor;
   DWORD defaultColorId = 0;
-  std::vector<DWORD> materialids;
   const ExportInfo& info;
   const std::shared_ptr<const Export3mfOptions> options;
 };
@@ -140,7 +139,8 @@ int count_mesh_objects(PLib3MFModel *& model)
 }
 
 bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::unique_ptr<PolySet>& ps,
-                           int triangle_index, int color_index, ExportContext& ctx)
+                           int triangle_index, int color_index, const std::vector<DWORD>& materialids,
+                           ExportContext& ctx)
 {
   if (color_index < 0) {
     return true;
@@ -157,7 +157,7 @@ bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::u
 
   if (ctx.basematerial) {
     if (lib3mf_propertyhandler_setbasematerial(propertyhandler, triangle_index, ctx.basematerialid,
-                                               ctx.materialids[color_index]) != LIB3MF_OK) {
+                                               materialids[color_index]) != LIB3MF_OK) {
       export_3mf_error("Can't set triangle base material.", ctx.model);
       return false;
     }
@@ -179,6 +179,14 @@ bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::u
 bool append_polyset(const std::shared_ptr<const PolySet>& ps, const Export3mfPartInfo info,
                     ExportContext& ctx)
 {
+  // Per-mesh local: each PolySet's `color_indices` are indices into *this*
+  // mesh's `colors`, so the lib3mf-side material IDs registered for those
+  // colors must also be looked up per-mesh. Keeping this in `ctx` (as was
+  // done previously) caused the second mesh's `color_index=0` to resolve
+  // to the FIRST mesh's material ID, silently painting all subsequent
+  // meshes with the first one's color. See pythonscad/pythonscad#591.
+  std::vector<DWORD> materialids;
+
   PLib3MFModelMeshObject *mesh = nullptr;
   if (lib3mf_model_addmeshobject(ctx.model, &mesh) != LIB3MF_OK) {
     export_3mf_error("Can't add mesh to 3MF model.", ctx.model);
@@ -266,9 +274,9 @@ bool append_polyset(const std::shared_ptr<const PolySet>& ps, const Export3mfPar
       }
     }
 
-    ctx.materialids.reserve(sorted_ps->colors.size());
+    materialids.reserve(sorted_ps->colors.size());
     for (size_t i = 0; i < sorted_ps->colors.size(); i++) {
-      ctx.materialids.push_back(materialFunc(materials + i, sorted_ps->colors[i]));
+      materialids.push_back(materialFunc(materials + i, sorted_ps->colors[i]));
     }
   }
 
@@ -280,7 +288,7 @@ bool append_polyset(const std::shared_ptr<const PolySet>& ps, const Export3mfPar
 
   for (size_t i = 0; i < sorted_ps->color_indices.size(); ++i) {
     const int32_t idx = sorted_ps->color_indices[i];
-    if (!handle_triangle_color(propertyhandler, sorted_ps, i, idx, ctx)) {
+    if (!handle_triangle_color(propertyhandler, sorted_ps, i, idx, materialids, ctx)) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Closes #591.

Multi-part / multi-color 3MF export through `export(dict, ...)` silently painted every mesh after the first with the FIRST mesh's color on builds against **lib3mf 1.x** (the Linux qt5/qt6 CI configurations and most Linux distro packages). The user-visible bug:

```python
export({\"red\":  cube(...).color(\"red\"),
        \"blue\": cube(...).color(\"blue\")},
       \"two-color.3mf\")
```

produced a 3MF whose `<basematerials>` palette was correct (Default, Color 1 = red, Color 2 = blue) but whose blue object's triangles all referenced `p1=\"1\"` (red), so both meshes rendered red.

## Root cause

`src/io/export_3mf_v1.cc::ExportContext` carried a single `std::vector<DWORD> materialids` shared across **all** meshes in an export. `append_polyset` `push_back`-ed each new mesh's color IDs into it without ever clearing, while `handle_triangle_color` indexed it with `color_index` -- which is **per-mesh-relative** (an index into *this* PolySet's `->colors`). After the first mesh seeded `materialids = [red_id]`, the second mesh -- whose own `colors` array has one entry, so its triangles all carry `color_index=0` -- looked up `materialids[0]` and got the **first** mesh's red ID instead of its own newly-registered blue one.

Walked through with debug prints to confirm:

```
[3mf-dbg] append_polyset ENTER: name='red'  ps->colors=1 ctx.materialids.size=0 (BEFORE)
[3mf-dbg]   ps->colors[0] = rgba(1.000,0.000,0.000,1.000)
[3mf-dbg]   AFTER push_back loop ctx.materialids.size=1
[3mf-dbg]     ctx.materialids[0]=1
[3mf-dbg] handle_triangle_color: color_index=0 -> ctx.materialids[0]=1   (red, OK)

[3mf-dbg] append_polyset ENTER: name='blue' ps->colors=1 ctx.materialids.size=1 (BEFORE)
[3mf-dbg]   ps->colors[0] = rgba(0.000,0.000,1.000,1.000)
[3mf-dbg]   AFTER push_back loop ctx.materialids.size=2
[3mf-dbg]     ctx.materialids[0]=1
[3mf-dbg]     ctx.materialids[1]=2
[3mf-dbg] handle_triangle_color: color_index=0 -> ctx.materialids[0]=1   (red, WRONG: should be 2/blue)
```

The lib3mf v2 path (`src/io/export_3mf_v2.cc`) was already immune because it keys per-color material registration off `ctx.colors` (a `Color4f -> idx` map) instead of a vector indexed by `color_index`. That's why macOS-15-intel qt6 and windows-latest qt6 (which build against lib3mf >= 2) have been producing the obviously-correct output (second mesh's triangles reference `p1=\"2\"` for blue) all along, while Ubuntu 22.04 qt5, Ubuntu 24.04 qt5, and Ubuntu 24.04 qt6 (which build against lib3mf 1.x) produced wrong output.

## Fix

`materialids` is only ever pushed to and read from within a single `append_polyset` call, so move it from `ExportContext` to a local in `append_polyset` and thread it to `handle_triangle_color` as a parameter. Each mesh now starts with an empty `materialids` so its own `color_index=0` resolves to its own first material ID.

Diff is small and surgical:

- `ExportContext::materialids` field removed.
- `append_polyset` declares a local `std::vector<DWORD> materialids` per call.
- `handle_triangle_color` takes `const std::vector<DWORD>& materialids` as a parameter.

## Test plan

- [x] Reproduce on Linux locally with the two-color fixture from #590; confirm second object's triangles reference `p1=\"1\"` (wrong) before the fix.
- [x] Apply the fix; rebuild; rerun. Second object's triangles now reference `p1=\"2\"` (= Color 2 = blue), matching the macOS / Windows output.
- [x] Three-mesh stress (red, blue, red again): each object correctly references its own color slot (`p1=1`, `p1=2`, `p1=3`).
- [x] Single-color export through the same code path is unaffected (no triangle-level properties when no `.color()` is set).
- [ ] CI matrix passes across all five configurations (ubuntu-22.04 qt5, ubuntu-24.04 qt5, ubuntu-24.04 qt6, macos-15-intel qt6, windows-latest qt6).
- [ ] Unblocks the `pythonscad-export-3mf_multi-color` regression test in #590 once that PR is rebased on master.

## Notes

- v1 of the lib3mf-side ``displaycolor`` attributes still serializes alpha as `00` rather than `FF` because `lib3mf_basematerial_addmaterialutf8` on lib3mf 1.x doesn't take an alpha argument; that's a pre-existing, separate issue and out of scope for this fix.
- v2 path is *not* changed (the corresponding `ctx.colors` Color4f map is correct as-is).


Made with [Cursor](https://cursor.com)