### PR TITLE
docs: use slices instead of fn for linear_extrude with python function

### DIFF
--- a/web/docs/reference/extrusions.md
+++ b/web/docs/reference/extrusions.md
@@ -45,7 +45,7 @@ def xsection(h):
     v = 5 + sin(h)
     return [[-v, -v], [v, -v], [v, v], [-v, v]]
 
-linear_extrude(xsection, height=10, fn=20).show()
+linear_extrude(xsection, height=10, slices=20).show()
 ```
 
 The `twist` parameter can also be a Python function:

--- a/web/docs/tutorial/python_new.md
+++ b/web/docs/tutorial/python_new.md
@@ -493,7 +493,7 @@ def xsection(h):
     v =5+sin(h)
     return [[-v,-v],[v,-v],[v,v],[-v,v]]
 
-prisma = linear_extrude(xsection, height=10,fn=20)
+prisma = linear_extrude(xsection, height=10, slices=20)
 prisma.show()
 ```
 <img src="../img/linext_xsect-expected.png" alt="Linear Extrude with custom xsection" width="200"/>


### PR DESCRIPTION
## Summary

Fixes #578.

The tutorial and extrusions reference both showed `fn=20` in the
`linear_extrude(<python function>, ...)` example. The `fn` keyword is
accepted (it feeds the curve discretizer used for 2D primitives inside
the shape) but has no effect on how many heights the user-provided
cross-section function is sampled at — that count is controlled by
`slices`. As a result, the rendered example was a flat-walled prism
instead of the wavy shape described by the surrounding text.

Per the maintainer's comment on the issue, the fix is documentation:
update both examples to `slices=20`.

- `web/docs/tutorial/python_new.md`: example under
  *linear_extrude can also extrude a python function*
- `web/docs/reference/extrusions.md`: example under
  `linear_extrude` → *PythonSCAD extensions*

## Test plan

- [x] `pre-commit` passes (`markdownlint-cli2`, `check-mkdocs`,
      `commitlint`, etc. run via the commit hook)
- [ ] After site rebuild, verify the rendered tutorial example produces
      a wavy-walled `prisma` matching `linext_xsect-expected.png`


Made with [Cursor](https://cursor.com)