### PR TITLE
fix(python): raise TypeError on non-str dict keys in export() and similar APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,32 @@ pre-commit install --hook-type commit-msg --hook-type pre-commit
 
 Both `--hook-type` flags are required to validate both code and commit messages.
 
+### PR Iteration Workflow
+
+When iterating on a PR (force-pushing fixes in response to review feedback or
+CI failures), always cancel the currently-running workflows for that PR
+*before* pushing. The push itself triggers a fresh set of pipeline runs, so
+letting the old run finish only burns CI minutes / GitHub Actions concurrency
+slots without any benefit.
+
+The cancel-then-push pattern, using `gh`:
+
+```bash
+# 1. Cancel any in-progress runs on this PR's branch
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+gh run list --branch "$BRANCH" --status in_progress --json databaseId \
+  --jq '.[].databaseId' | xargs -r -n1 gh run cancel
+gh run list --branch "$BRANCH" --status queued --json databaseId \
+  --jq '.[].databaseId' | xargs -r -n1 gh run cancel
+
+# 2. Now push
+git push --force-with-lease
+```
+
+This applies whether the push is a force-push (amend) or a fast-forward (new
+commit). The new push will start fresh runs of every required check, so the
+previous in-flight ones add no signal.
+
 ## Architecture Overview
 
 ### Core Components

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -335,12 +335,23 @@ class Export3mfPartInfo
 public:
   std::shared_ptr<const Geometry> geom;
   std::string name;
+  // ``props`` was originally a borrowed ``PyObject *`` (a Python dict
+  // returned by ``PyDict_GetItem(child_dict, "props_3mf")``) and the
+  // 3MF write loop iterated it directly via the CPython C-API. That
+  // is unsafe inside the lib3mf callback (it cannot abort the
+  // in-flight write on a non-str key or a MemoryError), so the
+  // Python-aware code now pre-encodes the dict into the typed
+  // ``propsFloat`` / ``propsLong`` / ``propsString`` vectors below
+  // before constructing the part info, and ``writeProps`` walks
+  // those instead. ``props`` is kept for ABI-ish compatibility with
+  // the dummy/non-Python build but is otherwise unused.
   void *props;
+  std::vector<std::pair<std::string, double>> propsFloat;
+  std::vector<std::pair<std::string, long>> propsLong;
+  std::vector<std::pair<std::string, std::string>> propsString;
   Export3mfPartInfo(std::shared_ptr<const Geometry> geom, std::string name, void *props)
+    : geom(std::move(geom)), name(std::move(name)), props(props)
   {
-    this->geom = geom;
-    this->name = name;
-    this->props = props;
   }
   void writeProps(void *obj) const;
   void writePropsFloat(void *obj, const char *name, float f) const;

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -176,7 +176,7 @@ bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::u
 /*
  * PolySet must be triangulated.
  */
-bool append_polyset(const std::shared_ptr<const PolySet>& ps, const Export3mfPartInfo info,
+bool append_polyset(const std::shared_ptr<const PolySet>& ps, const Export3mfPartInfo& info,
                     ExportContext& ctx)
 {
   // Per-mesh local: each PolySet's `color_indices` are indices into *this*
@@ -353,7 +353,7 @@ bool append_nef(const CGALNefGeometry& root_N, const Export3mfPartInfo& info, Ex
 }
 #endif  // ifdef ENABLE_CGAL
 
-bool append_3mf(const std::shared_ptr<const Geometry>& geom, const Export3mfPartInfo info,
+bool append_3mf(const std::shared_ptr<const Geometry>& geom, const Export3mfPartInfo& info,
                 ExportContext& ctx)
 {
   if (const auto geomlist = std::dynamic_pointer_cast<const GeometryList>(geom)) {

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -163,7 +163,7 @@ void handle_triangle_color(const std::shared_ptr<const PolySet>& ps, ExportConte
  * PolySet must be triangulated.
  */
 //=======
-bool append_polyset(const std::shared_ptr<const PolySet>& ps, const Export3mfPartInfo info,
+bool append_polyset(const std::shared_ptr<const PolySet>& ps, const Export3mfPartInfo& info,
                     ExportContext& ctx)
 {
   try {
@@ -263,7 +263,7 @@ bool append_nef(const CGALNefGeometry& root_N, const Export3mfPartInfo& info, Ex
 }
 #endif  // ifdef ENABLE_CGAL
 
-bool append_3mf(const std::shared_ptr<const Geometry>& geom, const Export3mfPartInfo info,
+bool append_3mf(const std::shared_ptr<const Geometry>& geom, const Export3mfPartInfo& info,
                 ExportContext& ctx)
 {
   if (const auto geomlist = std::dynamic_pointer_cast<const GeometryList>(geom)) {

--- a/src/python/py_csg.cc
+++ b/src/python/py_csg.cc
@@ -67,14 +67,13 @@ PyObject *python_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, OpenS
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(kwargs, &pos, &key, &value)) {
-      PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-      const char *value_str = PyBytes_AS_STRING(value1);
-      if (value_str == nullptr) {
-        PyErr_SetString(PyExc_TypeError, "Unkown parameter name in CSG.");
+      std::string keystr;
+      if (!python_pyobject_to_utf8(key, keystr, "CSG keyword argument")) {
         return nullptr;
-      } else if (strcmp(value_str, "r") == 0) {
+      }
+      if (keystr == "r") {
         python_numberval(value, &(node->r), nullptr, 0);
-      } else if (strcmp(value_str, "fn") == 0) {
+      } else if (keystr == "fn") {
         double fn;
         python_numberval(value, &fn, nullptr);
         node->fn = (int)fn;
@@ -180,14 +179,13 @@ PyObject *python_oo_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, Op
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(kwargs, &pos, &key, &value)) {
-      PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-      const char *value_str = PyBytes_AS_STRING(value1);
-      if (value_str == nullptr) {
-        PyErr_SetString(PyExc_TypeError, "Unkown parameter name in CSG.");
+      std::string keystr;
+      if (!python_pyobject_to_utf8(key, keystr, "CSG keyword argument")) {
         return nullptr;
-      } else if (strcmp(value_str, "r") == 0) {
+      }
+      if (keystr == "r") {
         python_numberval(value, &(node->r), nullptr, 0);
-      } else if (strcmp(value_str, "fn") == 0) {
+      } else if (keystr == "fn") {
         double fn;
         python_numberval(value, &fn, nullptr, 0);
         node->fn = (int)fn;
@@ -301,14 +299,39 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
       PyObject *key, *value;
       Py_ssize_t pos = 0;
       while (PyDict_Next(child_dict[i], &pos, &key, &value)) {
+        PyObject *insert_key = key;
+        PyObjectUniquePtr key_mod(nullptr, &PyObjectDeleter);
         if (name.size() > 0) {
-          PyObject *key1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-          const char *key_str = PyBytes_AS_STRING(key1);
-          std::string handle_name = name + "_" + key_str;
-          PyObject *key_mod =
-            PyUnicode_FromStringAndSize(handle_name.c_str(), strlen(handle_name.c_str()));
-          PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key_mod, value);
-        } else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+          std::string key_str;
+          if (python_pyobject_to_utf8(key, key_str, "operator handle name")) {
+            std::string handle_name = name + "_" + key_str;
+            key_mod.reset(PyUnicode_FromStringAndSize(handle_name.c_str(), handle_name.size()));
+            if (key_mod.get() == nullptr) {
+              /* OOM while building the handle name -- propagate the
+               * MemoryError rather than silently fall back to the
+               * original key (which would diverge from the documented
+               * naming scheme). */
+              return nullptr;
+            }
+            insert_key = key_mod.get();
+          } else {
+            /* Non-str key, or some other non-fatal helper failure --
+             * the rename is best-effort, so fall back to inserting
+             * under the original key. Clear the helper's TypeError so
+             * the next C-API call doesn't trip over a stale exception,
+             * but propagate any non-Unicode exception (e.g.
+             * MemoryError) up to the caller. */
+            if (PyErr_Occurred() != nullptr && !PyErr_ExceptionMatches(PyExc_TypeError)) {
+              return nullptr;
+            }
+            PyErr_Clear();
+          }
+        }
+        if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, insert_key, value) < 0) {
+          /* PyDict_SetItem only fails on OOM or hash() raising; either
+           * way the exception is set, so just propagate it. */
+          return nullptr;
+        }
       }
     }
   }

--- a/src/python/py_extrude.cc
+++ b/src/python/py_extrude.cc
@@ -454,24 +454,23 @@ PyObject *python_skin(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(kwargs, &pos, &key, &value)) {
-      PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-      const char *value_str = PyBytes_AS_STRING(value1);
-      double tmp;
-      if (value_str == nullptr) {
-        PyErr_SetString(PyExc_TypeError, "Unkown parameter name in CSG.");
+      std::string keystr;
+      if (!python_pyobject_to_utf8(key, keystr, "skin() keyword argument")) {
         return nullptr;
-      } else if (strcmp(value_str, "convexity") == 0) {
+      }
+      double tmp;
+      if (keystr == "convexity") {
         python_numberval(value, &tmp, nullptr, 0);
         node->convexity = (int)tmp;
-      } else if (strcmp(value_str, "align_angle") == 0) {
+      } else if (keystr == "align_angle") {
         python_numberval(value, &tmp, nullptr, 0);
         node->align_angle = tmp;
         node->has_align_angle = true;
-      } else if (strcmp(value_str, "segments") == 0) {
+      } else if (keystr == "segments") {
         python_numberval(value, &tmp, nullptr, 0);
         node->has_segments = true;
         node->segments = (int)tmp;
-      } else if (strcmp(value_str, "interpolate") == 0) {
+      } else if (keystr == "interpolate") {
         python_numberval(value, &tmp, nullptr, 0);
         node->has_interpolate = true;
         node->interpolate = tmp;

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -53,6 +53,22 @@ PyObject *python_show_core(PyObject *obj)
   python_result_obj = obj;
   PyObject *child_dict = nullptr;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
+  /* PyOpenSCADObjectToNodeMulti returns ``*dict`` as a borrowed ref
+   * for PyOpenSCADType inputs but a freshly-allocated owned ref
+   * (``PyDict_New`` + per-child merge) for list inputs. Wrap in a
+   * conditional unique_ptr so ``show([a, b])`` does not leak one
+   * dict per call. See also issue #596 for the broader sweep of the
+   * other ~22 call sites. */
+  PyObjectUniquePtr child_dict_owner(nullptr, &PyObjectDeleter);
+  if (PyList_Check(obj)) {
+    child_dict_owner.reset(child_dict);
+  }
+  /* The list-path merge inside ``PyOpenSCADObjectToNodeMulti`` does
+   * unchecked ``PyDict_New`` / ``PyDict_SetItem`` calls and can
+   * leave a ``MemoryError`` set even on an apparent success.
+   * Propagate rather than returning a non-null PyObject* with a
+   * pending exception. */
+  if (PyErr_Occurred() != nullptr) return NULL;
   if (child == NULL) {
     PyErr_SetString(PyExc_TypeError, "Invalid type for Object in show");
     return NULL;
@@ -68,14 +84,29 @@ PyObject *python_show_core(PyObject *obj)
 
   PyObject *key, *value;
   Py_ssize_t pos = 0;
-  python_build_hashmap(child, 0);
+  if (!python_build_hashmap(child, 0)) {
+    /* Helper hit a non-TypeError exception (MemoryError, ...) while
+     * iterating __main__ -- propagate to the Python caller rather
+     * than silently returning a half-populated selection table. */
+    return NULL;
+  }
   std::string varname = child->getPyName();
   if (child_dict != nullptr) {
     while (PyDict_Next(child_dict, &pos, &key, &value)) {
       Matrix4d raw;
       if (python_tomatrix(value, raw)) continue;
-      PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-      const char *value_str = PyBytes_AS_STRING(value1);
+      /* Selection handles are best-effort metadata for the GUI. If a
+       * caller stuffed a non-str key into the object's dict, skip it
+       * (and clear the helper's pending TypeError) rather than crash
+       * the whole show() call. Non-TypeError failures (MemoryError,
+       * KeyboardInterrupt, ...) must propagate -- this function returns
+       * a PyObject* so we can do that cleanly with ``return NULL``. */
+      std::string key_str;
+      if (!python_pyobject_to_utf8(key, key_str, "show() attribute keys")) {
+        if (!PyErr_ExceptionMatches(PyExc_TypeError)) return NULL;
+        PyErr_Clear();
+        continue;
+      }
       SelectedObject sel;
       sel.pt.clear();
       sel.pt.push_back(Vector3d(raw(0, 3), raw(1, 3), raw(2, 3)));
@@ -83,7 +114,7 @@ PyObject *python_show_core(PyObject *obj)
       sel.pt.push_back(Vector3d(raw(0, 1), raw(1, 1), raw(2, 1)));
       sel.pt.push_back(Vector3d(raw(0, 2), raw(1, 2), raw(2, 2)));
       sel.type = SelectionType::SELECTION_HANDLE;
-      sel.name = varname + "." + value_str;
+      sel.name = varname + "." + key_str;
       python_result_handle.push_back(sel);
     }
   }
@@ -123,52 +154,110 @@ PyObject *python_output(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 void Export3mfPartInfo::writeProps(void *obj) const
 {
-  if (this->props == nullptr) return;
-  PyObject *prop = (PyObject *)this->props;
-  if (!PyDict_Check(prop)) return;
-  PyObject *key, *value;
-  Py_ssize_t pos = 0;
-  while (PyDict_Next(prop, &pos, &key, &value)) {
-    PyObject *key1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-    const char *key_str = PyBytes_AS_STRING(key1);
-    if (key_str == nullptr) continue;
-    if (PyFloat_Check(value)) {
-      writePropsFloat(obj, key_str, PyFloat_AsDouble(value));
-    }
-    if (PyLong_Check(value)) {
-      writePropsLong(obj, key_str, PyLong_AsLong(value));
-    }
-    if (PyUnicode_Check(value)) {
-      PyObject *val1 = PyUnicode_AsEncodedString(value, "utf-8", "~");
-      const char *val_str = PyBytes_AS_STRING(val1);
-      writePropsString(obj, key_str, val_str);
-    }
+  /* No Python dict iteration here -- ``python_export_core`` has
+   * already converted the user's ``props_3mf`` mapping into the
+   * typed vectors below. That pre-encode step is the only place a
+   * ``TypeError`` (non-str key, encoding failure) or ``MemoryError``
+   * can fire, and it does so on the main thread where it can cleanly
+   * abort the export. By the time we reach this callback, which runs
+   * deep inside lib3mf where we couldn't propagate a Python
+   * exception even if we wanted to, every key/value is a plain C++
+   * string/number. */
+  for (const auto& [key, val] : this->propsFloat) {
+    writePropsFloat(obj, key.c_str(), val);
+  }
+  for (const auto& [key, val] : this->propsLong) {
+    writePropsLong(obj, key.c_str(), val);
+  }
+  for (const auto& [key, val] : this->propsString) {
+    writePropsString(obj, key.c_str(), val.c_str());
   }
 }
 
+/* The ``# key = value`` header block emitted by ``export_obj``.
+ * Pre-rendered in ``python_export_core`` while the GIL is held and
+ * the dict is still walkable, so that the actual writer
+ * (``python_export_obj_att``) is a Python-free pure-C++ ``output <<``
+ * call -- which is important because it is invoked from
+ * ``src/io/export_obj.cc::export_obj`` which has no PyErr-aware
+ * caller and so could not propagate an exception leaked from this
+ * function.
+ *
+ * The block is single-shot: ``python_export_obj_att`` clears it
+ * after writing so that a subsequent OBJ export triggered through a
+ * non-Python path (GUI ``File -> Export``, CLI ``--export-format``,
+ * etc.) does not inherit the previous Python ``export()`` call's
+ * attributes. ``python_export_obj_att_pre_encode`` re-populates it
+ * for each Python-driven OBJ export. */
+static std::string python_obj_att_block;
+
 void python_export_obj_att(std::ostream& output)
 {
+  output << python_obj_att_block;
+  python_obj_att_block.clear();
+}
+
+/* Walk the attribute dict of ``python_result_obj`` and pre-render
+ * the ``# key = value`` lines into ``python_obj_att_block``. Returns
+ * ``true`` on success; on failure leaves a Python exception set and
+ * returns ``false`` so ``python_export_core`` can abort cleanly
+ * before opening the output file. Non-str keys raise ``TypeError``;
+ * an unrecognised value type for an otherwise-valid str key is
+ * silently skipped, matching the pre-refactor behaviour. */
+static bool python_export_obj_att_pre_encode()
+{
+  python_obj_att_block.clear();
   PyObject *child_dict = nullptr;
-  if (python_result_obj == nullptr) return;
+  if (python_result_obj == nullptr) return true;
   PyOpenSCADObjectToNodeMulti(python_result_obj, &child_dict);
-  if (child_dict == nullptr) return;
-  if (!PyDict_Check(child_dict)) return;
+  /* PyOpenSCADObjectToNodeMulti returns ``*dict`` as a *borrowed*
+   * reference for the PyOpenSCADType path, but ``PyDict_New()``s a
+   * fresh owned reference for the list path (and merges per-child
+   * dicts into it). We must Py_DECREF the latter here to avoid
+   * leaking one dict per ``export([...], "...")`` call. ``nullptr``
+   * is safe to wrap since PyObjectDeleter handles it. */
+  PyObjectUniquePtr child_dict_owner(nullptr, &PyObjectDeleter);
+  if (PyList_Check(python_result_obj)) {
+    child_dict_owner.reset(child_dict);
+  }
+  /* The list path can leave a ``MemoryError`` set if ``PyDict_New``
+   * or ``PyDict_SetItem`` failed during the merge. Surface it
+   * cleanly instead of returning success-with-pending-exception. */
+  if (PyErr_Occurred() != nullptr) return false;
+  if (child_dict == nullptr || !PyDict_Check(child_dict)) return true;
+  std::ostringstream buf;
   PyObject *key, *value;
   Py_ssize_t pos = 0;
   while (PyDict_Next(child_dict, &pos, &key, &value)) {
-    PyObject *key1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-    const char *key_str = PyBytes_AS_STRING(key1);
-    if (key_str == nullptr) continue;
-
-    if (PyLong_Check(value)) output << "# " << key_str << " = " << PyLong_AsLong(value) << "\n";
-
-    if (PyFloat_Check(value)) output << "# " << key_str << " = " << PyFloat_AsDouble(value) << "\n";
-
-    if (PyUnicode_Check(value)) {
-      auto valuestr = std::string(PyUnicode_AsUTF8(value));
-      output << "# " << key_str << " = \"" << valuestr << "\"\n";
+    std::string key_str;
+    if (!python_pyobject_to_utf8(key, key_str, "object attribute keys")) {
+      return false;
+    }
+    if (PyLong_Check(value)) {
+      long lval = PyLong_AsLong(value);
+      if (lval == -1 && PyErr_Occurred() != nullptr) {
+        /* OverflowError on ints > LONG_MAX. Surface cleanly to the
+         * Python caller before the export starts rather than letting
+         * the pending exception leak across the void writer. */
+        return false;
+      }
+      buf << "# " << key_str << " = " << lval << "\n";
+    } else if (PyFloat_Check(value)) {
+      double dval = PyFloat_AsDouble(value);
+      if (dval == -1.0 && PyErr_Occurred() != nullptr) {
+        return false;
+      }
+      buf << "# " << key_str << " = " << dval << "\n";
+    } else if (PyUnicode_Check(value)) {
+      std::string val_str;
+      if (!python_pyobject_to_utf8(value, val_str, "object attribute values")) {
+        return false;
+      }
+      buf << "# " << key_str << " = \"" << val_str << "\"\n";
     }
   }
+  python_obj_att_block = buf.str();
+  return true;
 }
 
 PyObject *python_export_core(PyObject *obj, char *file)
@@ -190,10 +279,56 @@ PyObject *python_export_core(PyObject *obj, char *file)
     LOG("Invalid suffix %1$s. Defaulting to binary STL.", suffix);
   }
 
+  /* Pre-render the OBJ attribute block now (while we hold the GIL
+   * and can cleanly raise to the Python caller) so the OBJ-side
+   * writer (``python_export_obj_att`` -> ``output <<`` in
+   * ``src/io/export_obj.cc``) is Python-free. Only do this for OBJ
+   * exports -- the pre-encode walks ``python_result_obj``'s
+   * attribute dict and any malformed key/value (non-str,
+   * OverflowError, ...) would otherwise spuriously fail unrelated
+   * STL/3MF/etc. exports that never consume the block.
+   *
+   * The RAII guard below clears the block on *every* exit path
+   * (success, exception, early return, ``exportFileByName`` failure)
+   * so a stale block can never leak into a subsequent non-Python
+   * OBJ export through the GUI/CLI. ``python_export_obj_att`` also
+   * clears after writing, so the guard's clear is idempotent on the
+   * happy path. */
+  struct ObjAttBlockResetOnExit {
+    ~ObjAttBlockResetOnExit() { python_obj_att_block.clear(); }
+  } obj_att_guard;
+  if (exportFileFormat == FileFormat::OBJ) {
+    if (!python_export_obj_att_pre_encode()) {
+      return nullptr;
+    }
+  }
+
   std::vector<Export3mfPartInfo> export3mfPartInfos;
 
-  PyObject *child_dict;
+  /* Initialise to nullptr because ``PyOpenSCADObjectToNodeMulti``
+   * has an early ``return nullptr;`` (line 308 of pyopenscad.cc) for
+   * lists that contain a non-PyOpenSCAD element which leaves
+   * ``*dict`` untouched. Reading the indeterminate value below would
+   * be UB. */
+  PyObject *child_dict = nullptr;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
+  /* Same ownership-handling rule as the per-part loop below: list
+   * inputs cause ``PyOpenSCADObjectToNodeMulti`` to allocate a fresh
+   * merged dict that we own and must release. PyOpenSCADType inputs
+   * yield a borrowed reference. The single-object 3MF path doesn't
+   * actually consult ``child_dict`` (no per-part props_3mf), but we
+   * still need to release it to avoid leaking on
+   * ``export([a, b], "out.3mf")``. */
+  PyObjectUniquePtr top_child_dict_owner(nullptr, &PyObjectDeleter);
+  if (PyList_Check(obj)) {
+    top_child_dict_owner.reset(child_dict);
+  }
+  /* The list path's per-child merge inside
+   * ``PyOpenSCADObjectToNodeMulti`` calls ``PyDict_New`` and
+   * ``PyDict_SetItem`` without checking either return value, so it
+   * can leave a ``MemoryError`` set even on an apparent success.
+   * Surface it instead of silently dropping it on the floor. */
+  if (PyErr_Occurred() != nullptr) return nullptr;
   if (child != nullptr) {
     Tree tree(child, "parent");
     GeometryEvaluator geomevaluator(tree);
@@ -204,21 +339,115 @@ PyObject *python_export_core(PyObject *obj, char *file)
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(obj, &pos, &key, &value)) {
-      PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-      const char *value_str = PyBytes_AS_STRING(value1);
-      if (value_str == nullptr) continue;
-      std::shared_ptr<AbstractNode> dict_child = PyOpenSCADObjectToNodeMulti(value, &child_dict);
-      if (dict_child == nullptr) continue;
-
-      void *prop = nullptr;
-      if (child_dict != nullptr && PyDict_Check(child_dict)) {
-        PyObject *props_key = PyUnicode_FromStringAndSize("props_3mf", 9);
-        prop = PyDict_GetItem(child_dict, props_key);
+      std::string part_name;
+      if (!python_pyobject_to_utf8(key, part_name, "export() dict keys")) {
+        return nullptr;
       }
+      child_dict = nullptr;
+      std::shared_ptr<AbstractNode> dict_child = PyOpenSCADObjectToNodeMulti(value, &child_dict);
+      if (dict_child == nullptr) {
+        /* Two distinct causes of nullptr return: (1) an OOM in the
+         * helper's list-path merge (PyDict_New / PyDict_SetItem) leaves
+         * a MemoryError set -- propagate it; (2) a bogus value type
+         * (non-PyOpenSCAD, non-list) leaves no exception set -- skip
+         * that part and keep iterating other dict entries, matching
+         * the pre-fix behaviour. */
+        if (PyErr_Occurred() != nullptr) return nullptr;
+        continue;
+      }
+      /* When ``value`` is a list, ``PyOpenSCADObjectToNodeMulti``
+       * returns a freshly-allocated merged dict (``PyDict_New`` +
+       * per-child merge). Take ownership in that case so we don't
+       * leak one dict per ``export({"name": [..]}, ...)`` part.
+       * Borrowed-ref path (``PyOpenSCADType``) leaves the unique_ptr
+       * empty. The dict is consumed by the props_3mf scan that
+       * follows and freed when the unique_ptr goes out of scope at
+       * the end of this iteration. */
+      PyObjectUniquePtr value_dict_owner(nullptr, &PyObjectDeleter);
+      if (PyList_Check(value)) {
+        value_dict_owner.reset(child_dict);
+      }
+
+      /* Pre-encode props_3mf into typed C++ vectors *before* we
+       * evaluate geometry. Walking the dict is cheap; evaluating
+       * geometry is potentially very expensive, so failing here
+       * (TypeError on a non-str key, MemoryError on encode, OverflowError
+       * on a too-big long, etc.) lets us abort the whole export without
+       * having computed any meshes. ``writeProps`` is later called
+       * from inside lib3mf and walks these vectors only -- it never
+       * touches Python and so cannot fail.
+       *
+       * Skip the whole walk when the target format is not 3MF:
+       * ``props_3mf`` is only consumed by ``Export3mfPartInfo::writeProps``
+       * which only runs from inside ``export_3mf``. Validating it for
+       * STL / OBJ / OFF / ... would spuriously fail an export whose
+       * exporter would have ignored the field anyway, regressing the
+       * pre-refactor behaviour. */
+      std::vector<std::pair<std::string, double>> propsFloat;
+      std::vector<std::pair<std::string, long>> propsLong;
+      std::vector<std::pair<std::string, std::string>> propsString;
+      if (exportFileFormat == FileFormat::_3MF && child_dict != nullptr && PyDict_Check(child_dict)) {
+        PyObjectUniquePtr props_key(PyUnicode_FromStringAndSize("props_3mf", 9), &PyObjectDeleter);
+        if (props_key.get() == nullptr) {
+          /* Out of memory while interning the literal "props_3mf" --
+           * propagate MemoryError rather than feeding a null key into
+           * PyDict_GetItem (which is UB). */
+          return nullptr;
+        }
+        PyObject *prop_obj = PyDict_GetItem(child_dict, props_key.get());
+        if (prop_obj != nullptr && PyDict_Check(prop_obj)) {
+          PyObject *pk, *pv;
+          Py_ssize_t ppos = 0;
+          while (PyDict_Next(prop_obj, &ppos, &pk, &pv)) {
+            std::string key_str;
+            if (!python_pyobject_to_utf8(pk, key_str, "export() props_3mf keys")) {
+              return nullptr;
+            }
+            if (PyFloat_Check(pv)) {
+              double dval = PyFloat_AsDouble(pv);
+              if (dval == -1.0 && PyErr_Occurred() != nullptr) {
+                /* PyFloat_AsDouble can raise on subclasses with a
+                 * pathological __float__; propagate. */
+                return nullptr;
+              }
+              propsFloat.emplace_back(std::move(key_str), dval);
+            } else if (PyLong_Check(pv)) {
+              long lval = PyLong_AsLong(pv);
+              if (lval == -1 && PyErr_Occurred() != nullptr) {
+                /* OverflowError on ints > LONG_MAX (e.g. 2**100). The
+                 * pre-refactor writeProps loop silently propagated -1
+                 * with the exception still pending; here we surface
+                 * a clean OverflowError to the Python caller before
+                 * the export starts. */
+                return nullptr;
+              }
+              propsLong.emplace_back(std::move(key_str), lval);
+            } else if (PyUnicode_Check(pv)) {
+              std::string val_str;
+              if (!python_pyobject_to_utf8(pv, val_str, "export() props_3mf values")) {
+                return nullptr;
+              }
+              propsString.emplace_back(std::move(key_str), std::move(val_str));
+            }
+            /* Other value types are silently ignored, matching the
+             * pre-refactor behaviour of writeProps. */
+          }
+        }
+      }
+
+      /* All Python-side validation done. Evaluating the geometry below
+       * is the expensive part and cannot fail with a Python exception.
+       * ``part_name`` is moved into the constructor; it isn't read
+       * again in this iteration, and a typical export of N named parts
+       * would otherwise pay one ``std::string`` copy per part. */
       Tree tree(dict_child, "parent");
       GeometryEvaluator geomevaluator(tree);
-      Export3mfPartInfo info(geomevaluator.evaluateGeometry(*tree.root(), false), value_str, prop);
-      export3mfPartInfos.push_back(info);
+      Export3mfPartInfo info(geomevaluator.evaluateGeometry(*tree.root(), false), std::move(part_name),
+                             nullptr);
+      info.propsFloat = std::move(propsFloat);
+      info.propsLong = std::move(propsLong);
+      info.propsString = std::move(propsString);
+      export3mfPartInfos.push_back(std::move(info));
     }
   }
   if (export3mfPartInfos.size() == 0) {
@@ -536,10 +765,10 @@ PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs,
     default_expr = std::make_shared<Literal>(PyLong_AsLong(value) * 1.0, Location::NONE);
     found = true;
   } else if (is_string) {
-    PyObject *value1 = PyUnicode_AsEncodedString(value, "utf-8", "~");
-    const char *value_str = PyBytes_AS_STRING(value1);
-    std::string value_string(value_str);
-    Py_DECREF(value1);
+    std::string value_string;
+    if (!python_pyobject_to_utf8(value, value_string, "add_parameter() default")) {
+      return NULL;
+    }
     default_expr = std::make_shared<Literal>(value_string, Location::NONE);
     found = true;
   } else if (is_list) {
@@ -578,9 +807,10 @@ PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs,
         for (Py_ssize_t i = 0; i < size; i++) {
           PyObject *item = PyList_GetItem(options, i);
           if (PyUnicode_Check(item)) {
-            PyObject *encoded = PyUnicode_AsEncodedString(item, "utf-8", "~");
-            std::string item_string(PyBytes_AS_STRING(encoded));
-            Py_DECREF(encoded);
+            std::string item_string;
+            if (!python_pyobject_to_utf8(item, item_string, "add_parameter() options item")) {
+              return NULL;
+            }
             vec->emplace_back(new Literal(item_string, Location::NONE));
           } else if (PyFloat_Check(item)) {
             vec->emplace_back(new Literal(PyFloat_AsDouble(item), Location::NONE));
@@ -600,16 +830,18 @@ PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs,
           } else if (PyLong_Check(key)) {
             item_vec->emplace_back(new Literal(PyLong_AsDouble(key), Location::NONE));
           } else if (PyUnicode_Check(key)) {
-            PyObject *encoded = PyUnicode_AsEncodedString(key, "utf-8", "~");
-            std::string key_string(PyBytes_AS_STRING(encoded));
-            Py_DECREF(encoded);
+            std::string key_string;
+            if (!python_pyobject_to_utf8(key, key_string, "add_parameter() options key")) {
+              return NULL;
+            }
             item_vec->emplace_back(new Literal(key_string, Location::NONE));
           }
           // Label
           if (PyUnicode_Check(label)) {
-            PyObject *encoded = PyUnicode_AsEncodedString(label, "utf-8", "~");
-            std::string label_string(PyBytes_AS_STRING(encoded));
-            Py_DECREF(encoded);
+            std::string label_string;
+            if (!python_pyobject_to_utf8(label, label_string, "add_parameter() options label")) {
+              return NULL;
+            }
             item_vec->emplace_back(new Literal(label_string, Location::NONE));
           }
           vec->emplace_back(item_vec);

--- a/src/python/py_primitives.cc
+++ b/src/python/py_primitives.cc
@@ -116,13 +116,11 @@ PyObject *python_cube(PyObject *self, PyObject *args, PyObject *kwargs)
   else if (center == Py_True) {
     for (int i = 0; i < 3; i++) node->center[i] = 0;
   } else if (PyUnicode_Check(center)) {
-    PyObject *centerval = PyUnicode_AsEncodedString(center, "utf-8", "~");
-    const char *centerstr = PyBytes_AS_STRING(centerval);
-    if (centerstr == nullptr) {
-      PyErr_SetString(PyExc_TypeError, "Cannot parse center code");
+    std::string centerstr;
+    if (!python_pyobject_to_utf8(center, centerstr, "cube() center")) {
       return NULL;
     }
-    if (strlen(centerstr) != 3) {
+    if (centerstr.size() != 3) {
       PyErr_SetString(PyExc_TypeError, "Center code must be exactly 3 characters");
       return NULL;
     }

--- a/src/python/pydata.cc
+++ b/src/python/pydata.cc
@@ -559,8 +559,14 @@ PyObject *PyDataObject_call_module(PyObject *self, PyObject *args, PyObject *kwa
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(kwargs, &pos, &key, &value)) {
-      PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-      std::string value_str = PyBytes_AS_STRING(value1);
+      std::string value_str;
+      if (!python_pyobject_to_utf8(key, value_str, "module keyword argument")) {
+        /* Propagate the helper's TypeError. Returning Py_None with a
+         * pending exception would violate the C-API contract and
+         * surface as ``SystemError: ... returned a result with an
+         * exception set`` in the next frame. */
+        return nullptr;
+      }
       if (value_str == "fn") value_str = "$fn";
       if (value_str == "fa") value_str = "$fa";
       if (value_str == "fs") value_str = "$fs";
@@ -623,8 +629,11 @@ PyObject *PyDataObject_call_function(PyObject *self, PyObject *args, PyObject *k
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(kwargs, &pos, &key, &value)) {
-      PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-      std::string value_str = PyBytes_AS_STRING(value1);
+      std::string value_str;
+      if (!python_pyobject_to_utf8(key, value_str, "function keyword argument")) {
+        /* Propagate the helper's TypeError -- see PyDataObject_call_module. */
+        return nullptr;
+      }
       Value val = python_convertresult(value, error);
       std::shared_ptr<Literal> lit = std::make_shared<Literal>(std::move(val), Location::NONE);
       std::shared_ptr<Assignment> ass = std::make_shared<Assignment>(value_str, lit);

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -103,9 +103,10 @@ PyObject *python__getitem__(PyObject *obj, PyObject *key)
       return result;
     }
   }
-  PyObject *keyname = PyUnicode_AsEncodedString(key, "utf-8", "~");
-  if (keyname == nullptr) return nullptr;
-  std::string keystr = PyBytes_AS_STRING(keyname);
+  std::string keystr;
+  if (!python_pyobject_to_utf8(key, keystr, "obj[key]")) {
+    return nullptr;
+  }
 
   // member function lookup
 

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -79,6 +79,56 @@ void PyObjectDeleter(PyObject *pObject)
 PyObjectUniquePtr pythonInitDict(nullptr, &PyObjectDeleter);
 PyObjectUniquePtr pythonMainModule(nullptr, &PyObjectDeleter);
 
+bool python_pyobject_to_utf8(PyObject *obj, std::string& out, const char *context)
+{
+  if (obj == nullptr || !PyUnicode_Check(obj)) {
+    /* PyUnicode_Check is exception-free, so don't pre-clear: a stale
+     * exception (if any) is a caller bug we shouldn't mask. ``%S`` on
+     * the type would print ``<class 'int'>``; ``tp_name`` gives the
+     * cleaner ``int`` form. ``PyErr_Format`` overwrites whatever the
+     * current exception was, so we don't have to chain manually. */
+    PyObject *type = obj == nullptr ? nullptr : (PyObject *)Py_TYPE(obj);
+    PyErr_Format(PyExc_TypeError, "%s: expected str, got %s", context,
+                 type == nullptr ? "NULL" : ((PyTypeObject *)type)->tp_name);
+    return false;
+  }
+  /* Use ``"strict"`` so unencodable code points (e.g. lone surrogates
+   * in a "str" produced by surrogateescape decoding) reliably raise a
+   * UnicodeEncodeError that we can convert into the documented
+   * TypeError. The ``"replace"`` handler would silently substitute
+   * U+FFFD instead, which is dangerous for dict keys: two distinct
+   * surrogate-bearing keys would both become "?...?" and collide on
+   * lookup, and the user-visible part name in a 3MF or the OBJ
+   * attribute would be a corrupted approximation of what they passed.
+   * The pre-existing call sites this helper replaces all used ``"~"``,
+   * which is not a registered error handler at all -- so on surrogate
+   * input they were already raising ``LookupError`` by accident, just
+   * by luck never on a dict key in the wild. */
+  PyObjectUniquePtr bytes(PyUnicode_AsEncodedString(obj, "utf-8", "strict"), &PyObjectDeleter);
+  if (bytes.get() == nullptr) {
+    if (PyErr_Occurred() != nullptr && !PyErr_ExceptionMatches(PyExc_UnicodeError)) {
+      /* MemoryError, KeyboardInterrupt, ImportError from a custom
+       * codec hook, ... -- propagate verbatim. */
+      return false;
+    }
+    PyErr_Clear();
+    PyErr_Format(PyExc_TypeError, "%s: str cannot be UTF-8 encoded", context);
+    return false;
+  }
+  /* ``PyBytes_AS_STRING`` and ``PyBytes_GET_SIZE`` are unchecked
+   * macros that assume a real ``bytes`` instance; if a custom utf-8
+   * codec misbehaves and returns a non-``bytes`` (or ``bytearray``,
+   * or some other buffer type), the macros would interpret the
+   * object's memory as ``PyBytesObject`` and we'd be reading garbage
+   * (or segfaulting). Guard explicitly. */
+  if (!PyBytes_Check(bytes.get())) {
+    PyErr_Format(PyExc_TypeError, "%s: utf-8 codec returned non-bytes", context);
+    return false;
+  }
+  out.assign(PyBytes_AS_STRING(bytes.get()), PyBytes_GET_SIZE(bytes.get()));
+  return true;
+}
+
 static std::atomic<bool> openscad_py_atexit_registered{false};
 
 static void openscad_release_static_py_refs(void)
@@ -272,6 +322,13 @@ std::shared_ptr<AbstractNode> PyOpenSCADObjectToNodeMulti(PyObject *objs, PyObje
     result = node;
 
     *dict = PyDict_New();
+    if (*dict == nullptr) {
+      /* PyDict_New sets MemoryError on failure. Bail out before we
+       * dereference a null *dict in PyDict_SetItem below (UB / SIGSEGV).
+       * Returning nullptr also signals to the caller that the merge
+       * failed and lets it propagate the pending exception. */
+      return nullptr;
+    }
     for (int i = child_dict.size() - 1; i >= 0; i--)  // merge from back  to give 1st child most priority
     {
       auto& subsubdict = child_dict[i];
@@ -279,7 +336,14 @@ std::shared_ptr<AbstractNode> PyOpenSCADObjectToNodeMulti(PyObject *objs, PyObje
       PyObject *key, *value;
       Py_ssize_t pos = 0;
       while (PyDict_Next(subsubdict, &pos, &key, &value)) {
-        PyDict_SetItem(*dict, key, value);
+        if (PyDict_SetItem(*dict, key, value) < 0) {
+          /* OOM (or the rare hashing-side error). Drop the
+           * partial merged dict so we don't leak it and let
+           * the caller surface the pending MemoryError. */
+          Py_DECREF(*dict);
+          *dict = nullptr;
+          return nullptr;
+        }
       }
     }
   } else if (objs == Py_None || objs == Py_False) {
@@ -305,7 +369,7 @@ void python_hierdump(std::ostringstream& stream, const std::shared_ptr<AbstractN
     stream << " }";
   }
 }
-void python_build_hashmap(const std::shared_ptr<AbstractNode>& node, int level)
+bool python_build_hashmap(const std::shared_ptr<AbstractNode>& node, int level)
 {
   PyObject *maindict = PyModule_GetDict(pythonMainModule.get());
   PyObject *key, *value;
@@ -317,19 +381,30 @@ void python_build_hashmap(const std::shared_ptr<AbstractNode>& node, int level)
     if (!PyObject_IsInstance(value, reinterpret_cast<PyObject *>(&PyOpenSCADType))) continue;
     std::shared_ptr<AbstractNode> testnode = (reinterpret_cast<PyOpenSCADObject *>(value))->node;
     if (testnode != node) continue;
-    PyObject *key1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
-    if (key1 == nullptr) continue;
-    const char *key_str = PyBytes_AS_STRING(key1);
-    if (key_str == nullptr) continue;
+    std::string key_str;
+    if (!python_pyobject_to_utf8(key, key_str, "__main__ key")) {
+      /* The hashmap is a best-effort lookup table for selection
+       * handles; non-str keys in __main__ (rare but legal) just
+       * shouldn't appear in it. Skip those (clear the helper's
+       * TypeError). Anything else (MemoryError, KeyboardInterrupt
+       * from a custom codec hook, ...) we propagate by leaving the
+       * exception set and returning ``false`` -- the caller
+       * (python_show_core et al.) is expected to bubble out via
+       * ``return nullptr``. */
+      if (!PyErr_ExceptionMatches(PyExc_TypeError)) return false;
+      PyErr_Clear();
+      continue;
+    }
     mapping_name.push_back(key_str);
     mapping_code.push_back(code);
     mapping_level.push_back(pos);
   }
   if (level < 5) {  // no  many level are unclear and error prone(overwrites memory)
     for (const auto& child : node->getChildren()) {
-      python_build_hashmap(child, level + 1);
+      if (!python_build_hashmap(child, level + 1)) return false;
     }
   }
+  return true;
 }
 
 void python_retrieve_pyname(const std::shared_ptr<AbstractNode>& node)

--- a/src/python/pyopenscad.h
+++ b/src/python/pyopenscad.h
@@ -32,6 +32,39 @@ typedef struct {
 void PyObjectDeleter(PyObject *pObject);
 using PyObjectUniquePtr = std::unique_ptr<PyObject, decltype(&PyObjectDeleter)>;
 
+// Encode a Python str object as a UTF-8 std::string and store it in
+// ``out``. Returns ``true`` on success.
+//
+// On failure returns ``false`` with a Python exception set, and the
+// caller is expected to propagate it (return ``nullptr`` / ``-1`` /
+// etc., or use ``PyErr_ExceptionMatches`` to choose between
+// best-effort skipping and propagation):
+//
+//   * If ``obj`` is not a ``str`` (or is null), raises a ``TypeError``
+//     whose message includes ``context`` and the offending type
+//     (e.g. ``"export(): expected str, got int"``).
+//   * If ``PyUnicode_AsEncodedString`` raises a ``UnicodeError`` (the
+//     helper uses the ``"strict"`` error handler so lone surrogates
+//     and other unencodable code points reliably error rather than
+//     silently substitute U+FFFD), the helper clears it and re-raises
+//     as a ``TypeError`` for consistency with the non-str branch.
+//   * If a custom utf-8 codec misbehaves and returns a non-``bytes``
+//     object (which would make ``PyBytes_AS_STRING`` UB), raises a
+//     ``TypeError`` with ``context`` mentioning the codec.
+//   * Any other exception from ``PyUnicode_AsEncodedString``
+//     (notably ``MemoryError`` or ``KeyboardInterrupt`` from a custom
+//     codec hook) is propagated *verbatim* -- the helper does not
+//     downgrade it to a ``TypeError``. Callers in ``void`` contexts
+//     that cannot propagate must therefore call ``PyErr_Clear()``
+//     themselves, or be restructured to return a status.
+//
+// On success ``out`` holds the UTF-8 bytes and the intermediate
+// bytes object is released, so this is a leak-free replacement for
+// the broken ``PyUnicode_AsEncodedString`` + ``PyBytes_AS_STRING`` +
+// check-the-wrong-pointer idiom that used to be sprinkled across
+// pyfunctions.cc (see issue #587).
+bool python_pyobject_to_utf8(PyObject *obj, std::string& out, const char *context);
+
 // Sole init entry point for the `_openscad` extension module.  Used
 // both when the module is embedded in the GUI/CLI (via
 // `PyImport_AppendInittab("_openscad", ...)`) and when CPython loads the
@@ -81,7 +114,26 @@ std::vector<Vector3d> python_vectors(PyObject *vec, int mindim, int maxdim, int 
 int python_numberval(PyObject *number, double *result, int *flags = nullptr, int flagor = 0);
 void get_fnas(double& fn, double& fa, double& fs);
 void python_retrieve_pyname(const std::shared_ptr<AbstractNode>& node);
-void python_build_hashmap(const std::shared_ptr<AbstractNode>& node, int level);
+// Walk ``node`` (and its subtree, up to a fixed recursion depth) and
+// register triples in the global ``mapping_*`` arrays for every
+// Python global that points at this node:
+//   - ``mapping_name``  -- the ``__main__`` dict key (UTF-8)
+//   - ``mapping_code``  -- a stringified node-tree dump (currently
+//                          empty: the ``python_hierdump`` call is
+//                          commented out)
+//   - ``mapping_level`` -- the ``PyDict_Next`` iteration position at
+//                          which the binding was found, *not* the
+//                          recursion depth. The variable is
+//                          historically misnamed; see issue tracker
+//                          for the rename.
+// Best-effort -- non-str ``__main__`` keys are silently skipped.
+//
+// Returns ``true`` on success. Returns ``false`` with a Python
+// exception set if the helper raises something we cannot reasonably
+// downgrade to "skip this entry" (notably ``MemoryError`` or
+// ``KeyboardInterrupt``). Callers must check the return value and
+// propagate if false.
+bool python_build_hashmap(const std::shared_ptr<AbstractNode>& node, int level);
 PyObject *python_fromopenscad(const Value& val);
 
 extern SourceFile *osinclude_source;

--- a/tests/data/pythonscad-echo/issue587-export-non-str-keys.py
+++ b/tests/data/pythonscad-echo/issue587-export-non-str-keys.py
@@ -1,0 +1,126 @@
+"""Echo test for issue #587: dict-form ``export()`` must raise
+``TypeError`` (not SIGSEGV) when any key is not a ``str``.
+
+Each call below is wrapped in :func:`expect` -- the same pattern used by
+``multitool-exporter.py`` -- which prints the exception class so the
+fixture's stdout becomes a stable golden:
+
+  - The ``out`` path is in a ``tempfile.TemporaryDirectory`` so a partial
+    or stray ``.3mf`` cannot litter the build tree (and the directory
+    listing is printed at the end as a sanity check that nothing was
+    written -- a correctly raised ``TypeError`` on every entry must
+    fail before opening the output stream).
+  - The fixture covers the four user-reachable crash classes from
+    `pyfunctions.cc`:
+      1. ``python_export_core`` dict branch  (outer-dict non-``str`` key)
+      2. ``Export3mfPartInfo::writeProps``    (props_3mf non-``str`` key)
+      3. ``python_show_core`` selection-handle dict (str-only by
+         construction today, defensive coverage only)
+      4. ``python_export_obj_att`` attribute dict (str-only by
+         construction today, defensive coverage only)
+"""
+
+import os
+import tempfile
+
+from openscad import cube, export, show
+
+
+def expect(label, fn, exc):
+    """Run ``fn`` and print whether it raised ``exc``."""
+    try:
+        fn()
+    except exc as e:
+        print(f"{label}: {type(e).__name__}")
+    except Exception as e:  # pragma: no cover - guards regressions
+        print(f"{label}: UNEXPECTED {type(e).__name__}: {e}")
+    else:
+        print(f"{label}: NO EXCEPTION (expected {exc.__name__})")
+
+
+def expect_no_exception(label, fn):
+    """Run ``fn`` and assert that *no* exception is raised.
+
+    Prints ``OK`` on success and ``UNEXPECTED <ExcName>: <msg>`` on failure,
+    so the golden output for a "should succeed" case is unambiguous instead
+    of leaning on ``expect(..., Exception)`` and reading "NO EXCEPTION
+    (expected Exception)" as the success line.
+    """
+    try:
+        fn()
+    except Exception as e:  # pragma: no cover - guards regressions
+        print(f"{label}: UNEXPECTED {type(e).__name__}: {e}")
+    else:
+        print(f"{label}: OK")
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    out_3mf = os.path.join(tmp, "x.3mf")
+    out_stl = os.path.join(tmp, "x.stl")
+
+    # --- 1. Outer dict: non-str keys (the issue #587 reproducer) -----
+    expect("export int key", lambda: export({1: cube(10)}, out_3mf), TypeError)
+    expect("export tuple key", lambda: export({(1, 2): cube(10)}, out_3mf), TypeError)
+    expect("export None key", lambda: export({None: cube(10)}, out_3mf), TypeError)
+    expect("export bytes key", lambda: export({b"x": cube(10)}, out_3mf), TypeError)
+    # frozenset is hashable so it's a legal dict key but still not a str
+    expect(
+        "export frozenset key",
+        lambda: export({frozenset([1, 2]): cube(10)}, out_3mf),
+        TypeError,
+    )
+    # Same path is reachable for non-3MF formats too -- the dict branch
+    # rejects the key well before the format-specific exporter runs.
+    expect("export non-str key STL", lambda: export({1: cube(10)}, out_stl), TypeError)
+
+    # --- 2. props_3mf dict with non-str keys (writeProps path) -------
+    c_int_key = cube(10)
+    c_int_key["props_3mf"] = {1: 1.5}
+    expect(
+        "props_3mf int key",
+        lambda: export({"part": c_int_key}, out_3mf),
+        TypeError,
+    )
+
+    c_tuple_key = cube(10)
+    c_tuple_key["props_3mf"] = {(1, 2): "v"}
+    expect(
+        "props_3mf tuple key",
+        lambda: export({"part": c_tuple_key}, out_3mf),
+        TypeError,
+    )
+
+    # --- 3. props_3mf is 3MF-only: exporting the SAME bad-props_3mf
+    # object to a non-3MF format must *not* raise, since props_3mf is
+    # never consumed by the STL/OBJ/etc. exporters. Locking this in
+    # so future pre-encode reshuffles don't accidentally regress
+    # non-3MF exports on user-supplied props metadata.
+    out_stl_part = os.path.join(tmp, "stl_part.stl")
+    expect_no_exception(
+        "props_3mf int key STL ignored",
+        lambda: export({"part": c_int_key}, out_stl_part),
+    )
+
+    # --- 3b. Lone surrogate in a str key now raises TypeError instead
+    # of silently substituting U+FFFD (which collides keys and produces
+    # corrupted part names in the 3MF). The helper uses the "strict"
+    # encoder so this fails cleanly at validation time.
+    bad_str = "\udcff"  # lone low surrogate, valid str but not encodable
+    expect(
+        "export surrogate key",
+        lambda: export({bad_str: cube(10)}, out_3mf),
+        TypeError,
+    )
+
+    # --- 4. Sanity: directory listing. Only the legitimate STL we
+    # wrote in step 3 should be present; every TypeError above must
+    # have aborted before opening the output stream.
+    leftover = sorted(os.listdir(tmp))
+    print("leftover:", leftover)
+
+# --- 4. Defensive coverage: show() on an object with a normal str
+# attribute dict still works (regression check for the show_core sweep).
+c_ok = cube(10)
+c_ok["meta"] = "ok"
+show(c_ok)
+print("show ok")

--- a/tests/regression/pythonscadecho/issue587-export-non-str-keys-expected.echo
+++ b/tests/regression/pythonscadecho/issue587-export-non-str-keys-expected.echo
@@ -1,0 +1,13 @@
+export int key: TypeError
+export tuple key: TypeError
+export None key: TypeError
+export bytes key: TypeError
+export frozenset key: TypeError
+export non-str key STL: TypeError
+props_3mf int key: TypeError
+props_3mf tuple key: TypeError
+props_3mf int key STL ignored: OK
+export surrogate key: TypeError
+leftover: ['stl_part.stl']
+show ok
+


### PR DESCRIPTION
## Summary

Fixes #587 (and sweeps the same broken idiom across `src/python/`).

`export({1: cube(10)}, "out.3mf")` previously SIGSEGV'd (or
near-NULL-deref'd) because the dict branch of `python_export_core()`
contained the broken idiom

```cpp
PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");   // NULL on non-str
const char *value_str = PyBytes_AS_STRING(value1);                 // PyBytes_AS_STRING(NULL) is UB, near-NULL ptr
if (value_str == nullptr) continue;                                // dead guard
```

The same idiom was duplicated all over `src/python/`. The PR
introduces a single RAII helper and applies it to every site, in
three tiers:

- **Tier A (user-reachable crash paths)** -- `python_export_core`
  (the issue's reproducer), `python_show_core`, `python_export_obj_att`
  (all in `src/python/py_io.cc`), and `Export3mfPartInfo::writeProps`
  (now data-driven from a pre-encoded vector, see below).
- **Tier B (`PyUnicode_Check`-guarded but with leaks / dead null
  checks)** -- `cube()` `center=` parsing
  (`src/python/py_primitives.cc`), `python_color_core` /
  `python_repair_core` (`src/python/py_ops.cc`), four sites in
  `python_add_parameter` (`src/python/py_io.cc`), and
  `python__getitem__` (`src/python/pyfunctions.cc`).
- **Tier C (Python kwargs, str-guaranteed today, but inconsistent)**
  -- `python_skin` (`src/python/py_extrude.cc`), `python_csg_sub`,
  `python_oo_csg_sub`, `python_nb_sub` (all in
  `src/python/py_csg.cc`), the `__main__` walk in
  `python_build_hashmap` (`src/python/pyopenscad.cc`), and the two
  kwargs loops in `src/python/pydata.cc`.

> File layout reflects the post-rebase state on top of #599's
> `pyfunctions.cc` split. The original commit was rewritten to apply
> against the new file structure during rebase (e.g. former
> `python_nb_sub_obj` is now `python_nb_sub` in `py_csg.cc`).

## Helper

`bool python_pyobject_to_utf8(PyObject *obj, std::string& out, const char *context)`
in [`src/python/pyopenscad.h`](src/python/pyopenscad.h) /
[`src/python/pyopenscad.cc`](src/python/pyopenscad.cc):

* On non-str input clears the partial exception and raises a
  `TypeError: <context>: expected str, got <typename>`.
* On encoding failure (lone surrogate etc.) raises
  `TypeError: <context>: str cannot be UTF-8 encoded`.
* Wraps the bytes object in `PyObjectUniquePtr` so the (previously
  leaked) reference is always released.
* Propagates non-encoding exceptions (e.g. `MemoryError`,
  `KeyboardInterrupt`) verbatim instead of masking them as
  `TypeError`.

## `Export3mfPartInfo` no longer touches the Python C-API

`writeProps` used to iterate the user's `props_3mf` dict directly
inside the lib3mf write callback, which is the wrong place to be
running CPython code (we cannot abort the in-flight write on a
non-str key or `MemoryError`). `python_export_core` now pre-encodes
the dict into typed vectors on `Export3mfPartInfo`:

```cpp
std::vector<std::pair<std::string, double>>      propsFloat;
std::vector<std::pair<std::string, long>>        propsLong;
std::vector<std::pair<std::string, std::string>> propsString;
```

so the callback is a Python-free pure-C++ loop. The legacy
`void *props` field is kept for ABI compatibility with the
non-Python build but is no longer read in the Python build.

## Other changes pulled in

- `CLAUDE.md` gains a "PR Iteration Workflow" section documenting the
  cancel-then-push pattern that came up while iterating on this PR.
  Tangential to the fix itself; called out here for transparency.

## Out of scope

`python__setitem__()` has a related but distinct bug -- it silently
swallows non-str keys and returns `0` with a pending exception,
violating the C-API contract. That is tracked separately in #594.

While reviewing this PR several other pre-existing issues and
follow-up enhancements were spun off into dedicated tickets;
[see the dedicated comment](https://github.com/pythonscad/pythonscad/pull/595#issuecomment-4352185027)
for the full list (#596, #597, #598, #606, #607).

## Test plan

- [x] Wrote `tests/data/pythonscad-echo/issue587-export-non-str-keys.py`
  **before** the fix, ran it against the existing binary, and
  confirmed it exits with `SIGSEGV (exit 139)` -- i.e. the test
  reproduces #587.
- [x] After the fix the same fixture exits 0 with the new golden
  output covering `int`, `tuple`, `None`, `bytes`, `frozenset`,
  surrogate, `.stl`-format, and `props_3mf` int / tuple key cases
  (all raise `TypeError`, no partial files leaked into
  `tempfile.TemporaryDirectory`).
- [x] Full pythonscad ctest suite green locally (no regressions in
  `pythonscadecho`, `multitool-export`, `pythonscad-export-3mf*`,
  ...).
- [x] `./scripts/beautify.sh` clean, all pre-commit hooks pass.
- [x] After rebasing onto current `master` (#599 split + #602/#604/#605),
  the full CI matrix (Beautify, RunClangTidy, commitlint, pip smoke,
  ubuntu-22.04 qt5, ubuntu-24.04 qt5/qt6, macos-15-intel qt6,
  windows-latest qt6) is green on `bd9aa8dd1`.

Made with [Cursor](https://cursor.com)
