### PR TITLE
fix(python): guard PyDict_SetDefaultRef polyfill behind PY_VERSION_HEX

### DIFF
--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -315,11 +315,38 @@ PyObject *python_oo__repr_mimebundle_(PyObject *self, PyObject *args, PyObject *
   return bundle;
 }
 
+#if PY_VERSION_HEX < 0x030D0000
+// Fallback for CPython < 3.13 where this API does not exist. CPython >= 3.13
+// ships the real implementation in libpython, so we MUST NOT redefine it: the
+// dynamic linker resolves _asyncio.so's reference to the main executable's
+// copy first, and a broken polyfill silently corrupts asyncio internals
+// (e.g. enter_task() does Py_DECREF(*result) on the stack slot we never
+// wrote, crashing on the first await).
 int PyDict_SetDefaultRef(PyObject *d, PyObject *key, PyObject *default_value, PyObject **result)
 {
-  PyDict_SetDefault(d, key, default_value);
+  PyObject *existing = PyDict_GetItemWithError(d, key);
+  if (existing != NULL) {
+    if (result != NULL) {
+      Py_INCREF(existing);
+      *result = existing;
+    }
+    return 1;
+  }
+  if (PyErr_Occurred()) {
+    if (result != NULL) *result = NULL;
+    return -1;
+  }
+  if (PyDict_SetItem(d, key, default_value) < 0) {
+    if (result != NULL) *result = NULL;
+    return -1;
+  }
+  if (result != NULL) {
+    Py_INCREF(default_value);
+    *result = default_value;
+  }
   return 0;
 }
+#endif
 
 int type_add_method(PyTypeObject *type, PyMethodDef *meth)  // from typeobject.c
 {

--- a/tests/data/pythonscad-echo/asyncio-regression.py
+++ b/tests/data/pythonscad-echo/asyncio-regression.py
@@ -1,0 +1,22 @@
+"""
+Regression test for issue #601: asyncio segfault in embedded Python.
+
+Before the fix, running any asyncio coroutine inside PythonSCAD's embedded
+interpreter would SIGSEGV on the first `await`, because pyfunctions.cc
+defined an unconditional polyfill for `PyDict_SetDefaultRef` that never
+populated *result. The dynamic linker resolved _asyncio.so's reference to
+that broken polyfill (RTLD prefers the main executable), so enter_task()
+ended up doing Py_DECREF on uninitialized stack memory.
+
+This test runs a tiny asyncio coroutine and prints a deterministic message.
+It SIGSEGVs on the unfixed binary and prints "asyncio_ok" on the fixed one.
+"""
+import asyncio
+
+
+async def _main():
+    await asyncio.sleep(0)
+    return "asyncio_ok"
+
+
+print(asyncio.run(_main()))

--- a/tests/regression/pythonscadecho/asyncio-regression-expected.echo
+++ b/tests/regression/pythonscadecho/asyncio-regression-expected.echo
@@ -1,0 +1,1 @@
+asyncio_ok


### PR DESCRIPTION
## Summary

Fixes #601 — a hard `SIGSEGV` on the first `await` in any code that runs inside the embedded Python interpreter (`--ipython`, `--repl`, or any `--trust-python` script that uses `asyncio` directly or transitively).

## Root cause

`src/python/pyfunctions.cc` defined an unconditional polyfill for `PyDict_SetDefaultRef`. Two bugs combined:

1. **Symbol shadowing.** The polyfill was compiled even on Python ≥ 3.13 where the API exists in `libpython3.13.so`. Because the symbol lived in the main executable, the dynamic linker resolved `_asyncio.so`'s reference to **our** copy first (RTLD prefers the main executable). Confirmed via `nm -D --defined-only build/pythonscad | grep PyDict_SetDefaultRef` — present before fix, absent after.
2. **Polyfill never wrote `*result`.** `_asyncio.enter_task()` does `Py_DECREF(*result)` immediately after the call. The stack slot we never wrote contained whatever was there before — most often a code address (e.g. `_PyType_LookupRef+33`) — which crashed on the first dereference.

```c++
// before (broken, unconditional)
int PyDict_SetDefaultRef(PyObject *d, PyObject *key, PyObject *def, PyObject **result)
{
  PyDict_SetDefault(d, key, def);
  return 0;        // *result is left uninitialised!
}
```

## Fix

* Wrap the polyfill in `#if PY_VERSION_HEX < 0x030D0000` so it is only emitted on the CPython versions that actually need it. On 3.13+ the linker now resolves to libpython's correct implementation.
* Rewrite the polyfill body to populate `*result` correctly, so users on older CPython are not bitten by the same write-nothing bug.

## Verification

* `nm -D --defined-only build/pythonscad | grep PyDict_SetDefaultRef` is empty after the fix (was present before).
* `build/pythonscad --ipython` exits cleanly on EOF (was `SIGSEGV`).
* `asyncio.run(asyncio.sleep(0))` inside a `--trust-python` script now succeeds (was `SIGSEGV`).
* New regression test `tests/data/pythonscad-echo/asyncio-regression.py` runs an asyncio coroutine and prints `asyncio_ok`. Verified locally with `ctest -R asyncio-regression`.

## Test plan

- [x] Build with `cmake --build build -j` succeeds.
- [x] `nm` shows the symbol no longer leaks from the executable.
- [x] `ctest -R asyncio-regression` passes.
- [x] `build/pythonscad --ipython` exits cleanly.
- [x] STL export of a Python script that imports asyncio runs to completion.


Made with [Cursor](https://cursor.com)