### PR TITLE
fix(python): plug PyOpenSCADObjectToNodeMulti dict leak (#596)

### DIFF
--- a/src/python/py_analysis.cc
+++ b/src/python/py_analysis.cc
@@ -36,12 +36,10 @@
 
 PyObject *python_mesh_core(PyObject *obj, bool tessellate, bool color)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in mesh \n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in mesh \n");
   Tree tree(child, "");
   GeometryEvaluator geomevaluator(tree);
   std::shared_ptr<const Geometry> geom = geomevaluator.evaluateGeometry(*tree.root(), true);
@@ -134,9 +132,10 @@ PyObject *python_oo_mesh(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_inside_core(PyObject *pyobj, PyObject *pypoint)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   Vector3d vec3;
   std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNode(pyobj, &dummydict);
+  auto dummydict_owner = py_owned(dummydict);
   if (node == nullptr) {
     PyErr_SetString(PyExc_TypeError, "Object must be a solid\n");
     return nullptr;
@@ -274,9 +273,11 @@ PyObject *python_oo_bbox(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_size_core(PyObject *obj)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
+  auto dummydict_owner = py_owned(dummydict);
   if (child == NULL) {
+    if (PyErr_Occurred()) return NULL;
     Py_RETURN_NONE;
   }
   Tree tree(child, "");
@@ -316,9 +317,11 @@ PyObject *python_size_core(PyObject *obj)
 
 PyObject *python_position_core(PyObject *obj)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
+  auto dummydict_owner = py_owned(dummydict);
   if (child == NULL) {
+    if (PyErr_Occurred()) return NULL;
     Py_RETURN_NONE;
   }
   Tree tree(child, "");
@@ -375,13 +378,11 @@ PyObject *python_position(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_separate_core(PyObject *obj)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in separate \n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in separate \n");
   Tree tree(child, "");
   GeometryEvaluator geomevaluator(tree);
   std::shared_ptr<const Geometry> geom = geomevaluator.evaluateGeometry(*tree.root(), true);
@@ -480,13 +481,11 @@ PyObject *python_oo_separate(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_edges_core(PyObject *obj)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in faces \n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in faces \n");
 
   Tree tree(child, "");
   GeometryEvaluator geomevaluator(tree);
@@ -564,13 +563,11 @@ PyObject *python_oo_edges(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_faces_core(PyObject *obj, bool tessellate)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in faces \n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in faces \n");
 
   Tree tree(child, "");
   GeometryEvaluator geomevaluator(tree);
@@ -723,8 +720,9 @@ PyObject *python_oo_faces(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_children_core(PyObject *obj)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   auto solid = PyOpenSCADObjectToNode(obj, &dummydict);
+  auto dummydict_owner = py_owned(dummydict);
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   if (solid == nullptr) {
     PyErr_SetString(PyExc_TypeError, "not a solid\n");

--- a/src/python/py_csg.cc
+++ b/src/python/py_csg.cc
@@ -61,7 +61,10 @@ PyObject *python_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, OpenS
   node->r = 0;
   node->fn = 1;
   PyObject *obj;
-  std::vector<PyObject *> child_dict;
+  // child_dict owns one strong dict ref per accepted arg; destructor
+  // releases all of them on every exit path (including the early
+  // `return nullptr` on parsing errors below).
+  std::vector<PyObjectUniquePtr> child_dict;
   std::shared_ptr<AbstractNode> child;
   if (kwargs != nullptr) {
     PyObject *key, *value;
@@ -78,7 +81,7 @@ PyObject *python_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, OpenS
         python_numberval(value, &fn, nullptr);
         node->fn = (int)fn;
       } else {
-        PyErr_SetString(PyExc_TypeError, "Unkown parameter name in CSG.");
+        PyErr_SetString(PyExc_TypeError, "Unknown parameter name in CSG.");
         return nullptr;
       }
     }
@@ -88,12 +91,16 @@ PyObject *python_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, OpenS
     obj = PyTuple_GetItem(args, i);
     PyObject *dict = nullptr;
     child = PyOpenSCADObjectToNodeMulti(obj, &dict);
-    if (dict != nullptr) {
-      child_dict.push_back(dict);
-    }
+    auto owned_dict = py_owned(dict);
     if (child != NULL) {
       child_solid.push_back(child);
+      if (dict != nullptr) child_dict.push_back(std::move(owned_dict));
     } else {
+      // Since round 1 of #596, PyOpenSCADObjectToNodeMulti can return
+      // nullptr with a Python exception already set (e.g. MemoryError
+      // from the dict-merge path). Synthesizing a new TypeError here
+      // would overwrite the original; propagate it instead.
+      if (PyErr_Occurred()) return nullptr;
       switch (mode) {
       case OpenSCADOperator::UNION:
         PyErr_SetString(PyExc_TypeError,
@@ -126,14 +133,24 @@ PyObject *python_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, OpenS
   }
   PyObject *pyresult = python_csg_core(node, child_solid);
 
-  for (int i = child_dict.size() - 1; i >= 0; i--)  // merge from back  to give 1st child most priority
-  {
-    auto& dict = child_dict[i];
+  // Reverse-iterate so the 1st child wins on conflicting keys (later
+  // writes overwrite earlier ones). Use the `i-- > 0` pattern so the
+  // loop is well-defined when child_dict is empty -- python_csg_sub
+  // can be called with zero variadic args (e.g. union()).
+  for (size_t i = child_dict.size(); i-- > 0;) {
+    PyObject *dict = child_dict[i].get();
     if (dict == nullptr) continue;
     PyObject *key, *value;
     Py_ssize_t pos = 0;
     while (PyDict_Next(dict, &pos, &key, &value)) {
-      PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+      // PyDict_SetItem can fail (e.g. MemoryError on dict resize);
+      // ignoring the return would leave a pending Python exception
+      // while we hand `pyresult` back to the caller, which the
+      // C-API contract forbids. Drop our reference and propagate.
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;
@@ -164,15 +181,19 @@ PyObject *python_oo_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, Op
   node->fn = 1;
 
   PyObject *obj;
-  std::vector<PyObject *> child_dict;
+  // Owns one strong dict ref per accepted arg (self plus tuple args).
+  // Destructor releases everything on early returns and at end-of-scope.
+  std::vector<PyObjectUniquePtr> child_dict;
   std::shared_ptr<AbstractNode> child;
-  PyObject *dict;
+  PyObject *dict = nullptr;
 
-  dict = nullptr;
   child = PyOpenSCADObjectToNodeMulti(self, &dict);
-  if (child != NULL) {
-    node->children.push_back(child);
-    child_dict.push_back(dict);
+  {
+    auto owned_self_dict = py_owned(dict);
+    if (child != NULL) {
+      node->children.push_back(child);
+      child_dict.push_back(std::move(owned_self_dict));
+    }
   }
 
   if (kwargs != nullptr) {
@@ -190,7 +211,7 @@ PyObject *python_oo_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, Op
         python_numberval(value, &fn, nullptr, 0);
         node->fn = (int)fn;
       } else {
-        PyErr_SetString(PyExc_TypeError, "Unkown parameter name in CSG.");
+        PyErr_SetString(PyExc_TypeError, "Unknown parameter name in CSG.");
         return nullptr;
       }
     }
@@ -199,10 +220,15 @@ PyObject *python_oo_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, Op
   for (i = 0; i < PyTuple_Size(args); i++) {
     obj = PyTuple_GetItem(args, i);
     child = PyOpenSCADObjectToNodeMulti(obj, &dict);
-    child_dict.push_back(dict);
+    auto owned_arg_dict = py_owned(dict);
     if (child != NULL) {
       child_solid.push_back(child);
+      child_dict.push_back(std::move(owned_arg_dict));
     } else {
+      // See python_csg_sub above: propagate any pending exception
+      // from PyOpenSCADObjectToNodeMulti rather than overwriting it
+      // with a generic TypeError.
+      if (PyErr_Occurred()) return nullptr;
       switch (mode) {
       case OpenSCADOperator::UNION:
         PyErr_SetString(PyExc_TypeError,
@@ -231,14 +257,23 @@ PyObject *python_oo_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, Op
   }
 
   PyObject *pyresult = python_csg_core(node, child_solid);
-  for (int i = child_dict.size() - 1; i >= 0; i--)  // merge from back  to give 1st child most priority
-  {
-    auto& dict = child_dict[i];
-    if (dict == nullptr) continue;
+  // See python_csg_sub above for the rationale: 1st-child-wins reverse
+  // merge with a size_t / `i-- > 0` loop so an empty child_dict (0-arg
+  // method call) does not trigger implementation-defined size_t-to-int
+  // conversion.
+  for (size_t i = child_dict.size(); i-- > 0;) {
+    PyObject *dict_item = child_dict[i].get();
+    if (dict_item == nullptr) continue;
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(dict, &pos, &key, &value)) {
-      PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(dict_item, &pos, &key, &value)) {
+      // Same propagation rule as in python_csg_sub: a PyDict_SetItem
+      // failure leaves an exception pending, so propagate it instead
+      // of returning pyresult while one is in flight.
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;
@@ -263,7 +298,7 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
 {
   DECLARE_INSTANCE();
   std::vector<std::shared_ptr<AbstractNode>> child;
-  std::vector<PyObject *> child_dict;
+  std::vector<PyObjectUniquePtr> child_dict;
 
   if (arg1 == Py_None && mode == OpenSCADOperator::UNION) {
     Py_INCREF(arg2);
@@ -279,10 +314,9 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
   }
 
   for (int i = 0; i < 2; i++) {
-    PyObject *dict;
-    dict = nullptr;
+    PyObject *dict = nullptr;
     auto solid = PyOpenSCADObjectToNodeMulti(i == 1 ? arg2 : arg1, &dict);
-    child_dict.push_back(dict);
+    child_dict.push_back(py_owned(dict));
     if (solid != nullptr) child.push_back(solid);
     else {
       PyErr_SetString(PyExc_TypeError, "invalid argument left to operator");
@@ -294,11 +328,12 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
 
   python_retrieve_pyname(node);
   for (int i = 1; i >= 0; i--) {
-    if (child_dict[i] != nullptr) {
+    PyObject *dict_item = child_dict[i].get();
+    if (dict_item != nullptr) {
       std::string name = child[i]->getPyName();
       PyObject *key, *value;
       Py_ssize_t pos = 0;
-      while (PyDict_Next(child_dict[i], &pos, &key, &value)) {
+      while (PyDict_Next(dict_item, &pos, &key, &value)) {
         PyObject *insert_key = key;
         PyObjectUniquePtr key_mod(nullptr, &PyObjectDeleter);
         if (name.size() > 0) {
@@ -310,7 +345,9 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
               /* OOM while building the handle name -- propagate the
                * MemoryError rather than silently fall back to the
                * original key (which would diverge from the documented
-               * naming scheme). */
+               * naming scheme). Drop our strong ref to pyresult on the
+               * way out so we don't leak it. */
+              Py_DECREF(pyresult);
               return nullptr;
             }
             insert_key = key_mod.get();
@@ -322,6 +359,7 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
              * but propagate any non-Unicode exception (e.g.
              * MemoryError) up to the caller. */
             if (PyErr_Occurred() != nullptr && !PyErr_ExceptionMatches(PyExc_TypeError)) {
+              Py_DECREF(pyresult);
               return nullptr;
             }
             PyErr_Clear();
@@ -329,7 +367,9 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
         }
         if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, insert_key, value) < 0) {
           /* PyDict_SetItem only fails on OOM or hash() raising; either
-           * way the exception is set, so just propagate it. */
+           * way the exception is set, so just propagate it. Drop our
+           * strong ref to pyresult on the way out so we don't leak it. */
+          Py_DECREF(pyresult);
           return nullptr;
         }
       }
@@ -343,11 +383,23 @@ PyObject *python_nb_sub_vec3(PyObject *arg1, PyObject *arg2,
 {
   DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
-  PyObject *child_dict;
+  PyObject *child_dict_raw = nullptr;
 
   PyTypeObject *type = PyOpenSCADObjectType(arg1);
-  child = PyOpenSCADObjectToNodeMulti(arg1, &child_dict);
-  if (arg2 == nullptr) return PyOpenSCADObjectFromNode(type, child);
+  child = PyOpenSCADObjectToNodeMulti(arg1, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (child == nullptr && PyErr_Occurred()) return NULL;
+  if (arg2 == nullptr) {
+    // arg2 == nullptr means "wrap arg1 in a fresh PyOpenSCADObject"
+    // (used by the unary fall-through callers in pyfunctions.cc).
+    // PyOpenSCADObjectFromNode dereferences `child`, so a soft-fail
+    // null here would build a broken object; raise a clear TypeError
+    // instead. The matrix-arithmetic branch further down explicitly
+    // tolerates a null `child` (it operates on `arg1` directly via
+    // python_number_trans), so don't gate it on `child` here.
+    if (child == nullptr) return propagate_or_typeerror("Invalid type for Object in translate/scale");
+    return PyOpenSCADObjectFromNode(type, child);
+  }
   std::vector<Vector3d> vecs;
   int dragflags = 0;
   if (mode == 3) {
@@ -417,13 +469,29 @@ PyObject *python_nb_sub_vec3(PyObject *arg1, PyObject *arg2,
     if (nodes.size() == 1) {
       nodes[0]->dragflags = dragflags;
       PyObject *pyresult = PyOpenSCADObjectFromNode(type, nodes[0]);
-      if (child_dict != nullptr) {
+      if (child_dict.get() != nullptr) {
         PyObject *key, *value;
         Py_ssize_t pos = 0;
-        while (PyDict_Next(child_dict, &pos, &key, &value)) {
-          PyObject *value1 = python_number_trans(value, vecs[0], 4);
-          if (value1 != nullptr) PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value1);
-          else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+        while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+          // Same pattern as the python_*_sub merge loops in
+          // py_transform.cc: python_number_trans returns a NEW
+          // reference, so wrap it in py_owned() to avoid leaking
+          // one object per dict entry, and propagate any
+          // PyDict_SetItem failure to the caller. python_number_trans
+          // returning nullptr can mean either "value is not numeric,
+          // fall back" (no exception) or "hard failure" (exception
+          // set, e.g. allocation failure inside python_fromvector);
+          // disambiguate via PyErr_Occurred().
+          auto value1 = py_owned(python_number_trans(value, vecs[0], 4));
+          if (value1.get() == nullptr && PyErr_Occurred()) {
+            Py_DECREF(pyresult);
+            return nullptr;
+          }
+          PyObject *to_insert = value1.get() != nullptr ? value1.get() : value;
+          if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, to_insert) < 0) {
+            Py_DECREF(pyresult);
+            return nullptr;
+          }
         }
       }
       return pyresult;
@@ -445,10 +513,13 @@ PyObject *python_nb_add(PyObject *arg1, PyObject *arg2)
 
 PyObject *python_nb_xor(PyObject *arg1, PyObject *arg2)
 {
-  PyObject *dummy_dict;
   if (PyObject_IsInstance(arg2, reinterpret_cast<PyObject *>(&PyOpenSCADType))) {
-    auto node1 = PyOpenSCADObjectToNode(arg1, &dummy_dict);
-    auto node2 = PyOpenSCADObjectToNode(arg2, &dummy_dict);
+    PyObject *dict1_raw = nullptr;
+    PyObject *dict2_raw = nullptr;
+    auto node1 = PyOpenSCADObjectToNode(arg1, &dict1_raw);
+    auto node2 = PyOpenSCADObjectToNode(arg2, &dict2_raw);
+    auto dict1 = py_owned(dict1_raw);
+    auto dict2 = py_owned(dict2_raw);
     if (node1 == nullptr || node2 == nullptr) {
       PyErr_SetString(PyExc_TypeError, "Error during parsing hull. arguments must be solids.");
       return nullptr;
@@ -465,9 +536,12 @@ PyObject *python_nb_xor(PyObject *arg1, PyObject *arg2)
 PyObject *python_nb_remainder(PyObject *arg1, PyObject *arg2)
 {
   if (PyObject_IsInstance(arg2, reinterpret_cast<PyObject *>(&PyOpenSCADType))) {
-    PyObject *dummy_dict;
-    auto node1 = PyOpenSCADObjectToNode(arg1, &dummy_dict);
-    auto node2 = PyOpenSCADObjectToNode(arg2, &dummy_dict);
+    PyObject *dict1_raw = nullptr;
+    PyObject *dict2_raw = nullptr;
+    auto node1 = PyOpenSCADObjectToNode(arg1, &dict1_raw);
+    auto node2 = PyOpenSCADObjectToNode(arg2, &dict2_raw);
+    auto dict1 = py_owned(dict1_raw);
+    auto dict2 = py_owned(dict2_raw);
     if (node1 == nullptr || node2 == nullptr) {
       PyErr_SetString(PyExc_TypeError, "Error during parsing hull. arguments must be solids.");
       return nullptr;
@@ -525,17 +599,22 @@ PyObject *python_csg_adv_sub(PyObject *self, PyObject *args, PyObject *kwargs, C
   std::shared_ptr<AbstractNode> child;
   PyTypeObject *type = &PyOpenSCADType;
   int i;
-  PyObject *dummydict;
 
   auto node = std::make_shared<CgalAdvNode>(instance, mode);
   PyObject *obj;
   for (i = 0; i < PyTuple_Size(args); i++) {
     obj = PyTuple_GetItem(args, i);
     type = PyOpenSCADObjectType(obj);
-    child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
+    PyObject *dummydict_raw = nullptr;
+    child = PyOpenSCADObjectToNodeMulti(obj, &dummydict_raw);
+    auto dummydict = py_owned(dummydict_raw);
     if (child != NULL) {
       node->children.push_back(child);
     } else {
+      // See python_csg_sub for rationale: propagate any pre-set
+      // exception from PyOpenSCADObjectToNodeMulti instead of
+      // overwriting it with a synthesized TypeError.
+      if (PyErr_Occurred()) return NULL;
       switch (mode) {
       case CgalAdvType::HULL:
         PyErr_SetString(PyExc_TypeError,
@@ -564,17 +643,26 @@ PyObject *python_minkowski(PyObject *self, PyObject *args, PyObject *kwargs)
   auto node = std::make_shared<CgalAdvNode>(instance, CgalAdvType::MINKOWSKI);
   char *kwlist[] = {"obj1", "obj2", "convexity", NULL};
   PyObject *obj1, *obj2;
-  PyObject *dummydict;
 
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|i", kwlist, &obj1, &obj2, &convexity)) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing minkowski(object1, object2[, convexity])");
     return NULL;
   }
   PyTypeObject *type = PyOpenSCADObjectType(obj1);
-  child = PyOpenSCADObjectToNodeMulti(obj1, &dummydict);
+  PyObject *dict1_raw = nullptr;
+  PyObject *dict2_raw = nullptr;
+  // Validate both conversions before pushing into node->children:
+  // PyOpenSCADObjectToNodeMulti can return nullptr with a Python
+  // exception already set, and pushing a null shared_ptr would
+  // build an invalid node and crash later in evaluation.
+  child = PyOpenSCADObjectToNodeMulti(obj1, &dict1_raw);
+  auto dict1 = py_owned(dict1_raw);
+  if (child == nullptr) return propagate_or_typeerror("Invalid type for first object in minkowski");
   node->children.push_back(child);
 
-  child = PyOpenSCADObjectToNodeMulti(obj2, &dummydict);
+  child = PyOpenSCADObjectToNodeMulti(obj2, &dict2_raw);
+  auto dict2 = py_owned(dict2_raw);
+  if (child == nullptr) return propagate_or_typeerror("Invalid type for second object in minkowski");
   node->children.push_back(child);
 
   node->convexity = convexity;
@@ -598,13 +686,11 @@ PyObject *python_resize_core(PyObject *obj, PyObject *newsize, PyObject *autosiz
   std::shared_ptr<AbstractNode> child;
 
   auto node = std::make_shared<CgalAdvNode>(instance, CgalAdvType::RESIZE);
-  PyObject *child_dict;
+  PyObject *child_dict_raw = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
-  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in resize");
-    return NULL;
-  }
+  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in resize");
 
   node->autosize << false, false, false;
   if (newsize != NULL) {
@@ -633,11 +719,18 @@ PyObject *python_resize_core(PyObject *obj, PyObject *newsize, PyObject *autosiz
   node->convexity = convexity;
 
   auto pyresult = PyOpenSCADObjectFromNode(type, node);
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
-      PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+      // Same propagation rule as python_csg_sub et al.: a
+      // PyDict_SetItem failure leaves an exception pending, so
+      // surface it instead of returning pyresult with a stale
+      // exception in flight.
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;

--- a/src/python/py_extrude.cc
+++ b/src/python/py_extrude.cc
@@ -57,13 +57,11 @@ PyObject *rotate_extrude_core(PyObject *obj, int convexity, double scale, double
     auto dummy_node = std::make_shared<SquareNode>(instance);
     node->children.push_back(dummy_node);
   } else {
-    PyObject *dummydict;
+    PyObject *dummydict = nullptr;
     type = PyOpenSCADObjectType(obj);
     child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-    if (child == NULL) {
-      PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in rotate_extrude\n");
-      return NULL;
-    }
+    auto dummydict_owner = py_owned(dummydict);
+    if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in rotate_extrude\n");
     node->children.push_back(child);
   }
 
@@ -161,13 +159,11 @@ PyObject *linear_extrude_core(PyObject *obj, PyObject *height, int convexity, Py
     auto dummy_node = std::make_shared<SquareNode>(instance);
     node->children.push_back(dummy_node);
   } else {
-    PyObject *dummydict;
+    PyObject *dummydict = nullptr;
     type = PyOpenSCADObjectType(obj);
     child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-    if (child == NULL) {
-      PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in linear_extrude\n");
-      return NULL;
-    }
+    auto dummydict_owner = py_owned(dummydict);
+    if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in linear_extrude\n");
     node->children.push_back(child);
   }
 
@@ -287,13 +283,11 @@ PyObject *path_extrude_core(PyObject *obj, PyObject *path, PyObject *xdir, int c
     auto dummy_node = std::make_shared<SquareNode>(instance);
     node->children.push_back(dummy_node);
   } else {
-    PyObject *dummydict;
+    PyObject *dummydict = nullptr;
     type = PyOpenSCADObjectType(obj);
     child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-    if (child == NULL) {
-      PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in path_extrude\n");
-      return NULL;
-    }
+    auto dummydict_owner = py_owned(dummydict);
+    if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in path_extrude\n");
     node->children.push_back(child);
   }
   if (path != NULL && PyList_Check(path)) {
@@ -447,8 +441,17 @@ PyObject *python_skin(PyObject *self, PyObject *args, PyObject *kwargs)
   auto node = std::make_shared<SkinNode>(instance);
   PyTypeObject *type = &PyOpenSCADType;
   PyObject *obj;
-  PyObject *child_dict = nullptr;
-  PyObject *dummy_dict = nullptr;
+  // child_dict holds the strong ref returned by the FIRST positional
+  // arg's PyOpenSCADObjectToNodeMulti call. Declared up here so any
+  // early `return nullptr` from later iterations still releases it
+  // via RAII (previously it was stored in a raw `child_dict_raw` and
+  // only wrapped in py_owned() AFTER the loop, so a failure on arg 2
+  // leaked the dict from arg 1).
+  auto child_dict = py_owned();
+  // dummy_dict_owner reset()s on every iter to release the previous
+  // strong ref before installing the next; final value (last arg) is
+  // released at end-of-scope.
+  auto dummy_dict_owner = py_owned();
   std::shared_ptr<AbstractNode> child;
   if (kwargs != nullptr) {
     PyObject *key, *value;
@@ -475,7 +478,7 @@ PyObject *python_skin(PyObject *self, PyObject *args, PyObject *kwargs)
         node->has_interpolate = true;
         node->interpolate = tmp;
       } else {
-        PyErr_SetString(PyExc_TypeError, "Unkown parameter name in skin.");
+        PyErr_SetString(PyExc_TypeError, "Unknown parameter name in skin.");
         return nullptr;
       }
     }
@@ -484,22 +487,38 @@ PyObject *python_skin(PyObject *self, PyObject *args, PyObject *kwargs)
     obj = PyTuple_GetItem(args, i);
     if (i == 0) {
       type = PyOpenSCADObjectType(obj);
-      child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-    } else child = PyOpenSCADObjectToNodeMulti(obj, &dummy_dict);
+      PyObject *first_dict_raw = nullptr;
+      child = PyOpenSCADObjectToNodeMulti(obj, &first_dict_raw);
+      child_dict.reset(first_dict_raw);
+    } else {
+      PyObject *dummy_dict_raw = nullptr;
+      child = PyOpenSCADObjectToNodeMulti(obj, &dummy_dict_raw);
+      dummy_dict_owner.reset(dummy_dict_raw);
+    }
     if (child != NULL) {
       node->children.push_back(child);
     } else {
+      // See py_csg.cc python_csg_sub: propagate any pre-set Python
+      // exception from PyOpenSCADObjectToNodeMulti instead of
+      // overwriting it with a generic TypeError.
+      if (PyErr_Occurred()) return nullptr;
       PyErr_SetString(PyExc_TypeError, "Error during skin. arguments must be solids or arrays.");
       return nullptr;
     }
   }
 
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, node);
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
-      PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+      // Same propagation rule as the merge loops in py_csg.cc /
+      // py_ops.cc: a PyDict_SetItem failure leaves an exception
+      // pending, so propagate it instead of returning pyresult.
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -51,28 +51,14 @@ PyObject *python_show_core(PyObject *obj)
     return obj;
   }
   python_result_obj = obj;
-  PyObject *child_dict = nullptr;
-  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-  /* PyOpenSCADObjectToNodeMulti returns ``*dict`` as a borrowed ref
-   * for PyOpenSCADType inputs but a freshly-allocated owned ref
-   * (``PyDict_New`` + per-child merge) for list inputs. Wrap in a
-   * conditional unique_ptr so ``show([a, b])`` does not leak one
-   * dict per call. See also issue #596 for the broader sweep of the
-   * other ~22 call sites. */
-  PyObjectUniquePtr child_dict_owner(nullptr, &PyObjectDeleter);
-  if (PyList_Check(obj)) {
-    child_dict_owner.reset(child_dict);
-  }
-  /* The list-path merge inside ``PyOpenSCADObjectToNodeMulti`` does
-   * unchecked ``PyDict_New`` / ``PyDict_SetItem`` calls and can
-   * leave a ``MemoryError`` set even on an apparent success.
-   * Propagate rather than returning a non-null PyObject* with a
-   * pending exception. */
-  if (PyErr_Occurred() != nullptr) return NULL;
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in show");
-    return NULL;
-  }
+  PyObject *child_dict_raw = nullptr;
+  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  /* PyOpenSCADObjectToNodeMulti now always hands back either nullptr
+   * or a fresh strong reference (see issue #596 for the historical
+   * borrow-vs-own asymmetry); wrap it so the dict from a list input
+   * (``show([a, b])``) is released at end of scope. */
+  auto child_dict = py_owned(child_dict_raw);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in show");
   if (child == void_node) {
     Py_RETURN_NONE;
   }
@@ -91,8 +77,8 @@ PyObject *python_show_core(PyObject *obj)
     return NULL;
   }
   std::string varname = child->getPyName();
-  if (child_dict != nullptr) {
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
+  if (child_dict.get() != nullptr) {
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
       Matrix4d raw;
       if (python_tomatrix(value, raw)) continue;
       /* Selection handles are best-effort metadata for the GUI. If a
@@ -207,28 +193,23 @@ void python_export_obj_att(std::ostream& output)
 static bool python_export_obj_att_pre_encode()
 {
   python_obj_att_block.clear();
-  PyObject *child_dict = nullptr;
   if (python_result_obj == nullptr) return true;
-  PyOpenSCADObjectToNodeMulti(python_result_obj, &child_dict);
-  /* PyOpenSCADObjectToNodeMulti returns ``*dict`` as a *borrowed*
-   * reference for the PyOpenSCADType path, but ``PyDict_New()``s a
-   * fresh owned reference for the list path (and merges per-child
-   * dicts into it). We must Py_DECREF the latter here to avoid
-   * leaking one dict per ``export([...], "...")`` call. ``nullptr``
-   * is safe to wrap since PyObjectDeleter handles it. */
-  PyObjectUniquePtr child_dict_owner(nullptr, &PyObjectDeleter);
-  if (PyList_Check(python_result_obj)) {
-    child_dict_owner.reset(child_dict);
-  }
-  /* The list path can leave a ``MemoryError`` set if ``PyDict_New``
-   * or ``PyDict_SetItem`` failed during the merge. Surface it
-   * cleanly instead of returning success-with-pending-exception. */
+  PyObject *child_dict_raw = nullptr;
+  PyOpenSCADObjectToNodeMulti(python_result_obj, &child_dict_raw);
+  /* PyOpenSCADObjectToNodeMulti now always hands back either nullptr
+   * or a fresh strong reference (see issue #596); wrap so the dict
+   * from a list input is released at end of scope. */
+  auto child_dict = py_owned(child_dict_raw);
+  /* The list path's per-child merge inside
+   * ``PyOpenSCADObjectToNodeMulti`` can now propagate a MemoryError
+   * via PyDict_New / PyDict_SetItem failure (round 1 of #596).
+   * Surface it instead of silently dropping it on the floor. */
   if (PyErr_Occurred() != nullptr) return false;
-  if (child_dict == nullptr || !PyDict_Check(child_dict)) return true;
+  if (child_dict.get() == nullptr || !PyDict_Check(child_dict.get())) return true;
   std::ostringstream buf;
   PyObject *key, *value;
   Py_ssize_t pos = 0;
-  while (PyDict_Next(child_dict, &pos, &key, &value)) {
+  while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
     std::string key_str;
     if (!python_pyobject_to_utf8(key, key_str, "object attribute keys")) {
       return false;
@@ -305,30 +286,21 @@ PyObject *python_export_core(PyObject *obj, char *file)
 
   std::vector<Export3mfPartInfo> export3mfPartInfos;
 
-  /* Initialise to nullptr because ``PyOpenSCADObjectToNodeMulti``
-   * has an early ``return nullptr;`` (line 308 of pyopenscad.cc) for
-   * lists that contain a non-PyOpenSCAD element which leaves
-   * ``*dict`` untouched. Reading the indeterminate value below would
-   * be UB. */
-  PyObject *child_dict = nullptr;
-  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-  /* Same ownership-handling rule as the per-part loop below: list
-   * inputs cause ``PyOpenSCADObjectToNodeMulti`` to allocate a fresh
-   * merged dict that we own and must release. PyOpenSCADType inputs
-   * yield a borrowed reference. The single-object 3MF path doesn't
-   * actually consult ``child_dict`` (no per-part props_3mf), but we
-   * still need to release it to avoid leaking on
-   * ``export([a, b], "out.3mf")``. */
-  PyObjectUniquePtr top_child_dict_owner(nullptr, &PyObjectDeleter);
-  if (PyList_Check(obj)) {
-    top_child_dict_owner.reset(child_dict);
-  }
-  /* The list path's per-child merge inside
-   * ``PyOpenSCADObjectToNodeMulti`` calls ``PyDict_New`` and
-   * ``PyDict_SetItem`` without checking either return value, so it
-   * can leave a ``MemoryError`` set even on an apparent success.
-   * Surface it instead of silently dropping it on the floor. */
+  /* PyOpenSCADObjectToNodeMulti now always hands back either nullptr
+   * or a fresh strong reference (issue #596 contract). Wrap the
+   * outer dict in a PyObjectUniquePtr so it is released at end of
+   * scope; ``child_dict.reset()`` below will release it before
+   * installing each per-part dict. */
+  PyObject *child_dict_raw = nullptr;
+  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  /* The list path's per-child merge inside PyOpenSCADObjectToNodeMulti
+   * can propagate a MemoryError via PyDict_New / PyDict_SetItem failure
+   * (round 1 of #596). Surface it directly instead of letting it fall
+   * through into the "Object not recognized" TypeError below, which
+   * would overwrite the original exception. */
   if (PyErr_Occurred() != nullptr) return nullptr;
+
   if (child != nullptr) {
     Tree tree(child, "parent");
     GeometryEvaluator geomevaluator(tree);
@@ -343,8 +315,15 @@ PyObject *python_export_core(PyObject *obj, char *file)
       if (!python_pyobject_to_utf8(key, part_name, "export() dict keys")) {
         return nullptr;
       }
-      child_dict = nullptr;
-      std::shared_ptr<AbstractNode> dict_child = PyOpenSCADObjectToNodeMulti(value, &child_dict);
+      /* Per-iteration dict from PyOpenSCADObjectToNodeMulti -- it
+       * is now always a strong reference (or nullptr), so reset()
+       * the outer unique_ptr to release the previous part's dict
+       * before installing the new one. The dict is consumed by the
+       * props_3mf scan below and freed when reset() runs in the next
+       * iteration (or at end of scope on the final iteration). */
+      PyObject *iter_dict_raw = nullptr;
+      std::shared_ptr<AbstractNode> dict_child = PyOpenSCADObjectToNodeMulti(value, &iter_dict_raw);
+      child_dict.reset(iter_dict_raw);
       if (dict_child == nullptr) {
         /* Two distinct causes of nullptr return: (1) an OOM in the
          * helper's list-path merge (PyDict_New / PyDict_SetItem) leaves
@@ -354,18 +333,6 @@ PyObject *python_export_core(PyObject *obj, char *file)
          * the pre-fix behaviour. */
         if (PyErr_Occurred() != nullptr) return nullptr;
         continue;
-      }
-      /* When ``value`` is a list, ``PyOpenSCADObjectToNodeMulti``
-       * returns a freshly-allocated merged dict (``PyDict_New`` +
-       * per-child merge). Take ownership in that case so we don't
-       * leak one dict per ``export({"name": [..]}, ...)`` part.
-       * Borrowed-ref path (``PyOpenSCADType``) leaves the unique_ptr
-       * empty. The dict is consumed by the props_3mf scan that
-       * follows and freed when the unique_ptr goes out of scope at
-       * the end of this iteration. */
-      PyObjectUniquePtr value_dict_owner(nullptr, &PyObjectDeleter);
-      if (PyList_Check(value)) {
-        value_dict_owner.reset(child_dict);
       }
 
       /* Pre-encode props_3mf into typed C++ vectors *before* we
@@ -386,7 +353,8 @@ PyObject *python_export_core(PyObject *obj, char *file)
       std::vector<std::pair<std::string, double>> propsFloat;
       std::vector<std::pair<std::string, long>> propsLong;
       std::vector<std::pair<std::string, std::string>> propsString;
-      if (exportFileFormat == FileFormat::_3MF && child_dict != nullptr && PyDict_Check(child_dict)) {
+      if (exportFileFormat == FileFormat::_3MF && child_dict.get() != nullptr &&
+          PyDict_Check(child_dict.get())) {
         PyObjectUniquePtr props_key(PyUnicode_FromStringAndSize("props_3mf", 9), &PyObjectDeleter);
         if (props_key.get() == nullptr) {
           /* Out of memory while interning the literal "props_3mf" --
@@ -394,7 +362,7 @@ PyObject *python_export_core(PyObject *obj, char *file)
            * PyDict_GetItem (which is UB). */
           return nullptr;
         }
-        PyObject *prop_obj = PyDict_GetItem(child_dict, props_key.get());
+        PyObject *prop_obj = PyDict_GetItem(child_dict.get(), props_key.get());
         if (prop_obj != nullptr && PyDict_Check(prop_obj)) {
           PyObject *pk, *pv;
           Py_ssize_t ppos = 0;
@@ -651,8 +619,9 @@ void python_str_sub(std::ostringstream& stream, const std::shared_ptr<AbstractNo
 PyObject *python_str(PyObject *self)
 {
   std::ostringstream stream;
-  PyObject *dummydict;
-  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNode(self, &dummydict);
+  PyObject *dummydict_raw = nullptr;
+  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNode(self, &dummydict_raw);
+  auto dummydict = py_owned(dummydict_raw);
   if (node != nullptr) python_str_sub(stream, node, 0);
   else stream << "Invalid OpenSCAD Object";
 
@@ -832,6 +801,10 @@ PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs,
           } else if (PyUnicode_Check(key)) {
             std::string key_string;
             if (!python_pyobject_to_utf8(key, key_string, "add_parameter() options key")) {
+              /* item_vec is a raw `new` allocation; clean up before
+               * propagating the helper's TypeError so we don't leak
+               * one Vector per malformed enum-options entry. */
+              delete item_vec;
               return NULL;
             }
             item_vec->emplace_back(new Literal(key_string, Location::NONE));
@@ -840,6 +813,9 @@ PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs,
           if (PyUnicode_Check(label)) {
             std::string label_string;
             if (!python_pyobject_to_utf8(label, label_string, "add_parameter() options label")) {
+              /* Same leak as the key branch above: clean up the raw
+               * Vector allocation before propagating the TypeError. */
+              delete item_vec;
               return NULL;
             }
             item_vec->emplace_back(new Literal(label_string, Location::NONE));

--- a/src/python/py_ops.cc
+++ b/src/python/py_ops.cc
@@ -620,6 +620,13 @@ PyObject *python_render_core(PyObject *obj, int convexity)
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNode(obj, &dummydict);
   auto dummydict_owner = py_owned(dummydict);
+  /* PyOpenSCADObjectToNode can return nullptr for a user-constructed
+   * PyOpenSCADType whose `tp_init` did not populate `self->node`, or
+   * with an exception already set (e.g. MemoryError from the
+   * dict-merge path). Pushing a null shared_ptr into
+   * `node->children` would build an invalid graph that crashes
+   * during geometry evaluation; surface a clean TypeError now. */
+  if (child == nullptr) return propagate_or_typeerror("Invalid type for Object in render");
   node->convexity = convexity;
   node->children.push_back(child);
   return PyOpenSCADObjectFromNode(type, node);
@@ -769,6 +776,11 @@ PyObject *python_group(PyObject *self, PyObject *args, PyObject *kwargs)
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   child = PyOpenSCADObjectToNode(obj, &dummydict);
   auto dummydict_owner = py_owned(dummydict);
+  /* See `python_render_core` above: a null `child` from
+   * PyOpenSCADObjectToNode would build an invalid GroupNode that
+   * crashes during evaluation. Propagate any pending exception or
+   * raise a clean TypeError. */
+  if (child == nullptr) return propagate_or_typeerror("Invalid type for Object in group");
 
   node->children.push_back(child);
   return PyOpenSCADObjectFromNode(type, node);
@@ -885,6 +897,11 @@ PyObject *python_debug_modifier(PyObject *arg, int mode)
   PyTypeObject *type = PyOpenSCADObjectType(arg);
   auto child = PyOpenSCADObjectToNode(arg, &dummydict);
   auto dummydict_owner = py_owned(dummydict);
+  /* See `python_render_core` / `python_group` above: a null `child`
+   * would build a CsgOpNode with a null child that crashes during
+   * geometry evaluation. Surface a clean TypeError (or propagate an
+   * already-pending exception) before constructing the node. */
+  if (child == nullptr) return propagate_or_typeerror("Invalid type for Object in modifier");
   switch (mode) {
   case 0: instance->tag_highlight = true; break;   // #
   case 1: instance->tag_background = true; break;  // %

--- a/src/python/py_ops.cc
+++ b/src/python/py_ops.cc
@@ -54,13 +54,11 @@ PyObject *python_offset_core(PyObject *obj, double r, double delta, PyObject *ch
   DECLARE_INSTANCE();
   auto node = std::make_shared<OffsetNode>(instance, discretizer);
 
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in offset");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in offset");
 
   node->delta = 1;
   node->chamfer = false;
@@ -114,13 +112,11 @@ PyObject *python_pull_core(PyObject *obj, PyObject *anchor, PyObject *dir)
 {
   DECLARE_INSTANCE();
   auto node = std::make_shared<PullNode>(instance);
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in translate\n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in pull");
 
   double x = 0, y = 0, z = 0;
   if (python_vectorval(anchor, 3, 3, &x, &y, &z)) {
@@ -170,13 +166,11 @@ PyObject *python_wrap_core(PyObject *obj, PyObject *target, double r, double d, 
   DECLARE_INSTANCE();
   auto node = std::make_shared<WrapNode>(instance);
 
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in Wrap\n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in Wrap\n");
 
   if (!python_numberval(target, &node->r, nullptr, 0)) {
     node->shape = nullptr;
@@ -236,14 +230,12 @@ PyObject *python_oo_wrap(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_color_core(PyObject *obj, PyObject *color, double alpha)
 {
-  PyObject *child_dict;
+  PyObject *child_dict_raw = nullptr;
   std::shared_ptr<AbstractNode> child;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
-  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in color");
-    return NULL;
-  }
+  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in color");
   DECLARE_INSTANCE();
   auto node = std::make_shared<ColorNode>(instance);
 
@@ -251,8 +243,9 @@ PyObject *python_color_core(PyObject *obj, PyObject *color, double alpha)
   if (!python_vectorval(color, 3, 4, &col[0], &col[1], &col[2], &col[3])) {
     node->color.setRgba(float(col[0]), float(col[1]), float(col[2]), float(col[3]));
   } else if (PyUnicode_Check(color)) {
-    PyObject *value = PyUnicode_AsEncodedString(color, "utf-8", "~");
-    char *colorname = PyBytes_AS_STRING(value);
+    auto value = py_owned(PyUnicode_AsEncodedString(color, "utf-8", "~"));
+    if (value.get() == nullptr) return NULL;
+    char *colorname = PyBytes_AS_STRING(value.get());
     const auto parsed_color = OpenSCAD::parse_color(colorname);
     if (parsed_color) {
       node->color = *parsed_color;
@@ -269,11 +262,18 @@ PyObject *python_color_core(PyObject *obj, PyObject *color, double alpha)
   node->children.push_back(child);
 
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, node);
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
-      PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+      // PyDict_SetItem can fail (MemoryError, unhashable key, ...);
+      // ignoring the return would leave a pending exception while
+      // we hand `pyresult` back to the caller, which the C-API
+      // contract forbids. Drop our reference and propagate.
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;
@@ -307,13 +307,11 @@ PyObject *python_oo_color(PyObject *obj, PyObject *args, PyObject *kwargs)
 PyObject *python_oversample_core(PyObject *obj, double size, const char *texture, const char *projection,
                                  double texturewidth, double textureheight, double texturedepth)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in oversample \n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in oversample \n");
 
   DECLARE_INSTANCE();
   auto node = std::make_shared<OversampleNode>(instance);
@@ -385,13 +383,11 @@ PyObject *python_oo_oversample(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_debug_core(PyObject *obj, PyObject *faces)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in debug \n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in debug \n");
 
   DECLARE_INSTANCE();
   auto node = std::make_shared<DebugNode>(instance);
@@ -428,13 +424,11 @@ PyObject *python_oo_debug(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_repair_core(PyObject *obj, PyObject *color)
 {
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNode(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in repair \n");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for  Object in repair \n");
 
   DECLARE_INSTANCE();
   auto node = std::make_shared<RepairNode>(instance);
@@ -444,8 +438,9 @@ PyObject *python_repair_core(PyObject *obj, PyObject *color)
     if (!python_vectorval(color, 3, 4, &col[0], &col[1], &col[2], &col[3])) {
       node->color.setRgba(float(col[0]), float(col[1]), float(col[2]), float(col[3]));
     } else if (PyUnicode_Check(color)) {
-      PyObject *value = PyUnicode_AsEncodedString(color, "utf-8", "~");
-      char *colorname = PyBytes_AS_STRING(value);
+      auto value = py_owned(PyUnicode_AsEncodedString(color, "utf-8", "~"));
+      if (value.get() == nullptr) return nullptr;
+      const char *colorname = PyBytes_AS_STRING(value.get());
       const auto parsed_color = OpenSCAD::parse_color(colorname);
       if (parsed_color) {
         node->color = *parsed_color;
@@ -487,16 +482,25 @@ PyObject *python_oo_repair(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_fillet_core(PyObject *obj, double r, int fn, PyObject *sel, double minang)
 {
-  PyObject *dummydict;
   DECLARE_INSTANCE();
   auto node = std::make_shared<FilletNode>(instance);
   PyTypeObject *type = &PyOpenSCADType;
   node->r = r;
   node->fn = fn;
   node->minang = minang;
+  PyObject *obj_dict_raw = nullptr;
+  PyObject *sel_dict_raw = nullptr;
   if (obj != nullptr) {
     type = PyOpenSCADObjectType(obj);
-    node->children.push_back(PyOpenSCADObjectToNodeMulti(obj, &dummydict));
+    auto child = PyOpenSCADObjectToNodeMulti(obj, &obj_dict_raw);
+    auto obj_dict = py_owned(obj_dict_raw);
+    // Check the conversion before pushing a potentially-null child
+    // into the node tree. Now that PyOpenSCADObjectToNodeMulti can
+    // return nullptr with a Python exception already set (see round 1
+    // of #596), propagate that exception; only synthesize a TypeError
+    // when no exception is pending.
+    if (child == nullptr) return propagate_or_typeerror("Invalid type for Object in fillet");
+    node->children.push_back(child);
   } else {
     PyErr_SetString(PyExc_TypeError, "Invalid type for  Object in fillet \n");
     return NULL;
@@ -504,8 +508,15 @@ PyObject *python_fillet_core(PyObject *obj, double r, int fn, PyObject *sel, dou
 
   if (sel != nullptr) {
     type = PyOpenSCADObjectType(sel);
-    auto child = PyOpenSCADObjectToNodeMulti(sel, &dummydict);
-    if (child != nullptr) node->children.push_back(child);
+    auto child = PyOpenSCADObjectToNodeMulti(sel, &sel_dict_raw);
+    auto sel_dict = py_owned(sel_dict_raw);
+    if (child == nullptr) {
+      // Same reasoning as above for the optional `sel` argument.
+      if (PyErr_Occurred()) return NULL;
+      // Non-exceptional: just skip pushing a missing/invalid sel.
+    } else {
+      node->children.push_back(child);
+    }
   }
 
   return PyOpenSCADObjectFromNode(type, node);
@@ -547,13 +558,11 @@ PyObject *python_roof_core(PyObject *obj, const char *method, int convexity,
   DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   auto node = std::make_shared<RoofNode>(instance, discretizer);
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in roof");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in roof");
 
   if (method == NULL) {
     node->method = "voronoi";
@@ -607,9 +616,10 @@ PyObject *python_render_core(PyObject *obj, int convexity)
   DECLARE_INSTANCE();
   auto node = std::make_shared<RenderNode>(instance);
 
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNode(obj, &dummydict);
+  auto dummydict_owner = py_owned(dummydict);
   node->convexity = convexity;
   node->children.push_back(child);
   return PyOpenSCADObjectFromNode(type, node);
@@ -699,13 +709,11 @@ PyObject *python_projection_core(PyObject *obj, PyObject *cut, int convexity)
 {
   DECLARE_INSTANCE();
   auto node = std::make_shared<ProjectionNode>(instance);
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in projection");
-    return NULL;
-  }
+  auto dummydict_owner = py_owned(dummydict);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in projection");
   node->convexity = convexity;
   node->cut_mode = 0;
   if (cut == Py_True) node->cut_mode = 1;
@@ -753,13 +761,14 @@ PyObject *python_group(PyObject *self, PyObject *args, PyObject *kwargs)
 
   char *kwlist[] = {"obj", NULL};
   PyObject *obj = NULL;
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!", kwlist, &PyOpenSCADType, &obj)) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing group(group)");
     return NULL;
   }
   PyTypeObject *type = PyOpenSCADObjectType(obj);
   child = PyOpenSCADObjectToNode(obj, &dummydict);
+  auto dummydict_owner = py_owned(dummydict);
 
   node->children.push_back(child);
   return PyOpenSCADObjectFromNode(type, node);
@@ -771,13 +780,11 @@ PyObject *python_align_core(PyObject *obj, PyObject *pyrefmat, PyObject *pydstma
     PyErr_SetString(PyExc_TypeError, "Must specify Object as 1st parameter");
     return nullptr;
   }
-  PyObject *child_dict = nullptr;
+  PyObject *child_dict_raw = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
-  std::shared_ptr<AbstractNode> dstnode = PyOpenSCADObjectToNode(obj, &child_dict);
-  if (dstnode == nullptr) {
-    PyErr_SetString(PyExc_TypeError, "Invalid align object");
-    Py_RETURN_NONE;
-  }
+  std::shared_ptr<AbstractNode> dstnode = PyOpenSCADObjectToNode(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (dstnode == nullptr) return propagate_or_typeerror("Invalid align object");
   DECLARE_INSTANCE();
   auto multmatnode = std::make_shared<TransformNode>(instance, "align");
   multmatnode->children.push_back(dstnode);
@@ -797,10 +804,10 @@ PyObject *python_align_core(PyObject *obj, PyObject *pyrefmat, PyObject *pydstma
   multmatnode->setPyName(dstnode->getPyName());
 
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, multmatnode);
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
       //       PyObject* value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
       //       const char *value_str =  PyBytes_AS_STRING(value1);
       if (!python_tomatrix(value, mat)) {
@@ -841,7 +848,7 @@ PyObject *python_oo_align(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_oo_clone(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  PyObject *dict;
+  PyObject *dict_raw = nullptr;
   PyObject *obj = NULL;
   char *kwlist[] = {"obj", NULL};
 
@@ -849,15 +856,23 @@ PyObject *python_oo_clone(PyObject *self, PyObject *args, PyObject *kwargs)
     PyErr_SetString(PyExc_TypeError, "Error during clone");
     return NULL;
   }
-  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNodeMulti(obj, &dict);
+  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNodeMulti(obj, &dict_raw);
+  auto dict = py_owned(dict_raw);
+  if (node == nullptr) return propagate_or_typeerror("Invalid type for Object in clone");
   if (node.use_count() > 1) ((PyOpenSCADObject *)self)->node = node->clone();
   else ((PyOpenSCADObject *)self)->node = node;
 
-  if (dict != nullptr) {
+  if (dict_raw != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(dict, &pos, &key, &value)) {
-      PyDict_SetItem(((PyOpenSCADObject *)self)->dict, key, value);
+    while (PyDict_Next(dict_raw, &pos, &key, &value)) {
+      // Same propagation rule as in python_color_core et al.: a
+      // PyDict_SetItem failure leaves an exception pending, so let
+      // it surface instead of returning None. self->dict is owned
+      // by `self` (the caller), so no extra DECREF needed here.
+      if (PyDict_SetItem(((PyOpenSCADObject *)self)->dict, key, value) < 0) {
+        return nullptr;
+      }
     }
   }
   Py_RETURN_NONE;
@@ -866,9 +881,10 @@ PyObject *python_oo_clone(PyObject *self, PyObject *args, PyObject *kwargs)
 PyObject *python_debug_modifier(PyObject *arg, int mode)
 {
   DECLARE_INSTANCE();
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(arg);
   auto child = PyOpenSCADObjectToNode(arg, &dummydict);
+  auto dummydict_owner = py_owned(dummydict);
   switch (mode) {
   case 0: instance->tag_highlight = true; break;   // #
   case 1: instance->tag_background = true; break;  // %

--- a/src/python/py_primitives.cc
+++ b/src/python/py_primitives.cc
@@ -753,7 +753,7 @@ PyObject *python_ifrep(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   DECLARE_INSTANCE();
   PyObject *object = NULL;
-  PyObject *dummydict;
+  PyObject *dummydict = nullptr;
 
   char *kwlist[] = {"obj", nullptr};
   std::shared_ptr<AbstractNode> child;
@@ -761,7 +761,26 @@ PyObject *python_ifrep(PyObject *self, PyObject *args, PyObject *kwargs)
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!", kwlist, &PyOpenSCADType, &object)) return NULL;
 
   child = PyOpenSCADObjectToNodeMulti(object, &dummydict);
-  LeafNode *node = (LeafNode *)child.get();
+  auto dummydict_owner = py_owned(dummydict);
+  // Two failure modes the original C-style cast quietly missed:
+  //   1) child == nullptr (PyOpenSCADObjectToNodeMulti failed,
+  //      possibly with a Python exception already set);
+  //   2) child is non-null but not actually a LeafNode -- e.g. the
+  //      caller passed a CSG operation like `union(a, b)` whose
+  //      runtime type is CsgOpNode. The C-style cast would happily
+  //      pretend the bytes are a LeafNode and the subsequent
+  //      `createGeometry()` call would walk uninitialized vtable
+  //      slots, i.e. undefined behaviour.
+  // Validate both with a dynamic_cast (AbstractNode is polymorphic
+  // via BaseVisitable) and surface a Python-visible error instead.
+  if (child == nullptr) return propagate_or_typeerror("Invalid type for Object in ifrep");
+  LeafNode *node = dynamic_cast<LeafNode *>(child.get());
+  if (node == nullptr) {
+    PyErr_SetString(PyExc_TypeError,
+                    "ifrep() expects a primitive object (cube, sphere, polyhedron, ...); "
+                    "for CSG combinations use frep() with an explicit expression");
+    return nullptr;
+  }
   const std::shared_ptr<const Geometry> geom = node->createGeometry();
   const std::shared_ptr<const PolySet> ps = std::dynamic_pointer_cast<const PolySet>(geom);
 

--- a/src/python/py_transform.cc
+++ b/src/python/py_transform.cc
@@ -65,24 +65,29 @@ PyObject *python_scale_sub(PyObject *obj, Vector3d scalevec)
   DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   auto node = std::make_shared<TransformNode>(instance, "scale");
-  PyObject *child_dict;
+  PyObject *child_dict_raw = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
-  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in scale");
-    return NULL;
-  }
+  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in scale");
   node->matrix.scale(scalevec);
   node->setPyName(child->getPyName());
   node->children.push_back(child);
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, node);
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
-      PyObject *value1 = python_number_scale(value, scalevec, 4);
-      if (value1 != nullptr) PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value1);
-      else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+      auto value1 = py_owned(python_number_scale(value, scalevec, 4));
+      if (value1.get() == nullptr && PyErr_Occurred()) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
+      PyObject *to_insert = value1.get() != nullptr ? value1.get() : value;
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, to_insert) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;
@@ -200,13 +205,11 @@ PyObject *python_rotate_sub(PyObject *obj, Vector3d vec3, double angle, PyObject
   auto node = std::make_shared<TransformNode>(instance, "rotate");
   node->dragflags = dragflags;
 
-  PyObject *child_dict;
-  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
+  PyObject *child_dict_raw = nullptr;
+  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
   PyTypeObject *type = PyOpenSCADObjectType(obj);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in rotate");
-    return NULL;
-  }
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in rotate");
   node->matrix.rotate(M);
   node->setPyName(child->getPyName());
 
@@ -234,13 +237,20 @@ PyObject *python_rotate_sub(PyObject *obj, Vector3d vec3, double angle, PyObject
     postnode->children.push_back(node);
     pyresult = PyOpenSCADObjectFromNode(type, postnode);
   }
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
-      PyObject *value1 = python_number_rot(value, M, 4);
-      if (value1 != nullptr) PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value1);
-      else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+      auto value1 = py_owned(python_number_rot(value, M, 4));
+      if (value1.get() == nullptr && PyErr_Occurred()) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
+      PyObject *to_insert = value1.get() != nullptr ? value1.get() : value;
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, to_insert) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;
@@ -313,23 +323,28 @@ PyObject *python_mirror_sub(PyObject *obj, Matrix4d& m)
   DECLARE_INSTANCE();
   auto node = std::make_shared<TransformNode>(instance, "mirror");
   node->matrix = m;
-  PyObject *child_dict;
+  PyObject *child_dict_raw = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
-  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in mirror");
-    return NULL;
-  }
+  std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in mirror");
   node->children.push_back(child);
   node->setPyName(child->getPyName());
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, node);
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
-      PyObject *value1 = python_number_mirror(value, m, 4);
-      if (value1 != nullptr) PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value1);
-      else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+      auto value1 = py_owned(python_number_mirror(value, m, 4));
+      if (value1.get() == nullptr && PyErr_Occurred()) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
+      PyObject *to_insert = value1.get() != nullptr ? value1.get() : value;
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, to_insert) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;
@@ -402,7 +417,7 @@ PyObject *python_number_trans(PyObject *pynum, Vector3d transvec, int vecs)
 
 PyObject *python_translate_sub(PyObject *obj, Vector3d translatevec, int dragflags)
 {
-  PyObject *child_dict;
+  PyObject *child_dict_raw = nullptr;
   PyObject *mat = python_number_trans(obj, translatevec, 4);
   if (mat != nullptr) return mat;
 
@@ -410,24 +425,29 @@ PyObject *python_translate_sub(PyObject *obj, Vector3d translatevec, int dragfla
   auto node = std::make_shared<TransformNode>(instance, "translate");
   std::shared_ptr<AbstractNode> child;
   PyTypeObject *type = PyOpenSCADObjectType(obj);
-  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict);
-  if (child == NULL) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in translate");
-    return NULL;
-  }
+  child = PyOpenSCADObjectToNodeMulti(obj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (child == NULL) return propagate_or_typeerror("Invalid type for Object in translate");
   node->setPyName(child->getPyName());
   node->dragflags = dragflags;
   node->matrix.translate(translatevec);
 
   node->children.push_back(child);
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, node);
-  if (child_dict != nullptr) {  // TODO dies ueberall
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
-      PyObject *value1 = python_number_trans(value, translatevec, 4);
-      if (value1 != nullptr) PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value1);
-      else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
+      auto value1 = py_owned(python_number_trans(value, translatevec, 4));
+      if (value1.get() == nullptr && PyErr_Occurred()) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
+      PyObject *to_insert = value1.get() != nullptr ? value1.get() : value;
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, to_insert) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;
@@ -491,22 +511,20 @@ PyObject *python_multmatrix_sub(PyObject *pyobj, PyObject *pymat, int div)
   DECLARE_INSTANCE();
   auto node = std::make_shared<TransformNode>(instance, "multmatrix");
   std::shared_ptr<AbstractNode> child;
-  PyObject *child_dict;
+  PyObject *child_dict_raw = nullptr;
   PyTypeObject *type = PyOpenSCADObjectType(pyobj);
-  child = PyOpenSCADObjectToNodeMulti(pyobj, &child_dict);
-  if (!child) {
-    PyErr_SetString(PyExc_TypeError, "Invalid type for Object in multmatrix");
-    return NULL;
-  }
+  child = PyOpenSCADObjectToNodeMulti(pyobj, &child_dict_raw);
+  auto child_dict = py_owned(child_dict_raw);
+  if (!child) return propagate_or_typeerror("Invalid type for Object in multmatrix");
   node->setPyName(child->getPyName());
 
   node->matrix = mat;
   node->children.push_back(child);
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, node);
-  if (child_dict != nullptr) {
+  if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;
-    while (PyDict_Next(child_dict, &pos, &key, &value)) {
+    while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
       Matrix4d raw;
       if (python_tomatrix(value, raw)) return nullptr;
       PyObject *value1 = python_frommatrix(node->matrix * raw);

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -122,8 +122,9 @@ PyObject *python__getitem__(PyObject *obj, PyObject *key)
     return (PyObject *)bm;
   }
 
-  PyObject *dummy_dict;
-  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNode(obj, &dummy_dict);
+  PyObject *dummy_dict_raw = nullptr;
+  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNode(obj, &dummy_dict_raw);
+  auto dummy_dict = py_owned(dummy_dict_raw);
   if (node != nullptr) {
     result = python__getsetitem_hier(node, keystr, nullptr, 0);
     if (result != nullptr) return result;
@@ -142,23 +143,45 @@ PyObject *python__getitem__(PyObject *obj, PyObject *key)
 
 int python__setitem__(PyObject *obj, PyObject *key, PyObject *v)
 {
-  PyObject *keyname = PyUnicode_AsEncodedString(key, "utf-8", "~");
-  if (keyname == nullptr) return 0;
-  std::string keystr = PyBytes_AS_STRING(keyname);
+  // PyUnicode_AsEncodedString returns a NEW reference; without
+  // py_owned() this leaks one bytes object per __setitem__ call.
+  // The keystr std::string copy below outlives keyname, so we can
+  // release the bytes immediately after building keystr.
+  auto keyname = py_owned(PyUnicode_AsEncodedString(key, "utf-8", "~"));
+  // mp_ass_subscript convention: 0 == success, -1 == failure with
+  // exception set. Encoding failure already left an exception
+  // pending (e.g. on a non-text key); surface it by returning -1
+  // instead of silently reporting success to the caller.
+  if (keyname.get() == nullptr) return -1;
+  std::string keystr = PyBytes_AS_STRING(keyname.get());
 
   PyOpenSCADObject *self = (PyOpenSCADObject *)obj;
 
-  PyObject *dummy_dict;
-  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNode(obj, &dummy_dict);
-  if (node != nullptr) {
+  PyObject *dummy_dict_raw = nullptr;
+  std::shared_ptr<AbstractNode> node = PyOpenSCADObjectToNode(obj, &dummy_dict_raw);
+  auto dummy_dict = py_owned(dummy_dict_raw);
+  // mp_ass_subscript reuses this slot for `del obj[key]`, in which
+  // case CPython passes v == NULL. The hier setter only makes sense
+  // for assignment, so skip it on deletion.
+  if (node != nullptr && v != nullptr) {
     python__getsetitem_hier(node, keystr, v, 2);
   }
 
   if (self->dict == NULL) {
     return 0;
   }
-  Py_INCREF(v);
-  PyDict_SetItem(self->dict, key, v);
+  // Route the deletion case through PyDict_DelItem; without this guard
+  // the Py_INCREF / PyDict_SetItem path below would crash on a NULL v.
+  if (v == nullptr) {
+    if (PyDict_DelItem(self->dict, key) < 0) return -1;
+    return 0;
+  }
+  // PyDict_SetItem already increments the value's refcount on success
+  // and leaves it untouched on failure, so no manual Py_INCREF is
+  // required. The previous unconditional incref leaked one reference
+  // per __setitem__ call (and also doubled the leak when SetItem
+  // failed, since the dict never absorbed the extra ref).
+  if (PyDict_SetItem(self->dict, key, v) < 0) return -1;
   return 0;
 }
 
@@ -199,7 +222,6 @@ PyObject *python_osversion_num(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_oo_hasattr(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  PyObject *dict;
   char *keyword = NULL;
   char *kwlist[] = {"keyword", NULL};
 
@@ -207,15 +229,36 @@ PyObject *python_oo_hasattr(PyObject *self, PyObject *args, PyObject *kwargs)
     PyErr_SetString(PyExc_TypeError, "Error during hasattr");
     return NULL;
   }
-  PyObject *pykeyword = PyUnicode_FromString(keyword);
-  PyOpenSCADObjectToNodeMulti(self, &dict);
-  if (PyDict_Contains(dict, pykeyword)) Py_RETURN_TRUE;
-  else Py_RETURN_FALSE;
+  auto pykeyword = py_owned(PyUnicode_FromString(keyword));
+  // PyUnicode_FromString already raised the relevant exception (typically
+  // MemoryError or UnicodeDecodeError) on failure; just propagate it.
+  if (pykeyword.get() == nullptr) return NULL;
+
+  PyObject *dict_raw = nullptr;
+  PyOpenSCADObjectToNodeMulti(self, &dict_raw);
+  auto dict = py_owned(dict_raw);
+  if (dict_raw == nullptr) {
+    // PyOpenSCADObjectToNodeMulti can fail with a Python exception
+    // already set (e.g. MemoryError from the dict-merge path); the
+    // C-API contract forbids returning a value while an exception is
+    // pending. Surface the error; only treat the no-dict case as
+    // "not present" when no exception is in flight.
+    if (PyErr_Occurred()) return NULL;
+    Py_RETURN_FALSE;
+  }
+
+  // PyDict_Contains returns -1 with an exception set on error. Treating
+  // that as truthy and returning Py_True would silently swallow the
+  // error AND hand the caller a return value while an exception is
+  // pending, which the C API contract forbids.
+  int contains = PyDict_Contains(dict_raw, pykeyword.get());
+  if (contains < 0) return NULL;
+  if (contains) Py_RETURN_TRUE;
+  Py_RETURN_FALSE;
 }
 
 PyObject *python_oo_getattr(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  PyObject *dict;
   char *keyword = NULL;
   char *kwlist[] = {"keyword", NULL};
 
@@ -223,16 +266,35 @@ PyObject *python_oo_getattr(PyObject *self, PyObject *args, PyObject *kwargs)
     PyErr_SetString(PyExc_TypeError, "Error during getattr");
     return NULL;
   }
-  PyObject *pykeyword = PyUnicode_FromString(keyword);
-  PyOpenSCADObjectToNodeMulti(self, &dict);
-  PyObject *prop = PyDict_GetItem(dict, pykeyword);
+  auto pykeyword = py_owned(PyUnicode_FromString(keyword));
+  if (pykeyword.get() == nullptr) return NULL;
+
+  PyObject *dict_raw = nullptr;
+  PyOpenSCADObjectToNodeMulti(self, &dict_raw);
+  auto dict = py_owned(dict_raw);
+  if (dict_raw == nullptr) {
+    // Same propagation rule as in python_oo_hasattr: a pending
+    // exception from PyOpenSCADObjectToNodeMulti must surface
+    // through to Python; only the non-exceptional "no dict for
+    // this input" case should resolve to None.
+    if (PyErr_Occurred()) return NULL;
+    Py_RETURN_NONE;
+  }
+
+  // PyDict_GetItem returns NULL for "missing key" WITHOUT setting an
+  // exception, so we cannot distinguish that from a hard error by the
+  // return value alone. Returning NULL to Python in the missing-key
+  // case is incorrect (Python would surface a SystemError because no
+  // exception is set). Surface the missing-key case as Py_None to
+  // match the most common "attribute lookup with default" idiom.
+  PyObject *prop = PyDict_GetItem(dict_raw, pykeyword.get());
+  if (prop == nullptr) Py_RETURN_NONE;
   Py_INCREF(prop);
   return prop;
 }
 
 PyObject *python_oo_setattr(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  PyObject *dict;
   char *keyword = NULL;
   PyObject *setvalue;
   char *kwlist[] = {"keyword", "setvalue", NULL};
@@ -241,9 +303,25 @@ PyObject *python_oo_setattr(PyObject *self, PyObject *args, PyObject *kwargs)
     PyErr_SetString(PyExc_TypeError, "Error during setattr");
     return NULL;
   }
-  PyObject *pykeyword = PyUnicode_FromString(keyword);
-  PyOpenSCADObjectToNodeMulti(self, &dict);
-  PyDict_SetItem(dict, pykeyword, setvalue);
+  auto pykeyword = py_owned(PyUnicode_FromString(keyword));
+  if (pykeyword.get() == nullptr) return NULL;
+
+  PyObject *dict_raw = nullptr;
+  PyOpenSCADObjectToNodeMulti(self, &dict_raw);
+  auto dict = py_owned(dict_raw);
+  if (dict_raw == nullptr) {
+    // Same propagation rule as in python_oo_hasattr/getattr: a
+    // pending exception from PyOpenSCADObjectToNodeMulti must
+    // surface through to Python; only the non-exceptional "no
+    // dict for this input" case should resolve to None.
+    if (PyErr_Occurred()) return NULL;
+    Py_RETURN_NONE;
+  }
+
+  // PyDict_SetItem returns -1 with an exception set on failure (e.g.
+  // unhashable key, MemoryError on resize). Propagate that instead of
+  // silently swallowing it.
+  if (PyDict_SetItem(dict_raw, pykeyword.get(), setvalue) < 0) return NULL;
   Py_RETURN_NONE;
 }
 

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1425,7 +1425,15 @@ PyObject *PyOpenSCAD_sq_item(PyOpenSCADObject *self, Py_ssize_t i)
   std::shared_ptr<AbstractNode> node =
     PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self), &dummydict_raw);
   auto dummydict = py_owned(dummydict_raw);
-  if (i < 0 || i >= node->children.size()) {
+  /* `PyOpenSCADObjectToNode` returns nullptr for a user-constructed
+   * `PyOpenSCADType` instance whose `tp_init` did not populate
+   * `self->node` (e.g. ``Openscad()`` then ``obj[0]``). Dereferencing
+   * `node->children` in that case would segfault. Surface a clean
+   * `TypeError` instead. `propagate_or_typeerror` preserves any
+   * pre-existing pending exception (e.g. MemoryError from the
+   * dict-merge path) verbatim. */
+  if (node == nullptr) return propagate_or_typeerror("PyOpenSCAD object has no node");
+  if (i < 0 || i >= (Py_ssize_t)node->children.size()) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return nullptr;
   }
@@ -1438,6 +1446,14 @@ Py_ssize_t PyOpenSCAD_sq_length(PyOpenSCADObject *self)
   std::shared_ptr<AbstractNode> node =
     PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self), &dummydict_raw);
   auto dummydict = py_owned(dummydict_raw);
+  /* See PyOpenSCAD_sq_item above for the null-`node` motivation.
+   * `sq_length` returns Py_ssize_t -- the C-API convention for an
+   * exceptional case is to return -1 with a Python exception set,
+   * which CPython will then surface to the caller of `len(obj)`. */
+  if (node == nullptr) {
+    propagate_or_typeerror("PyOpenSCAD object has no node");
+    return -1;
+  }
   return node->children.size();
 }
 

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -233,21 +233,29 @@ void python_unlock(void)
  *  extracts Absrtract Node from PyOpenSCAD Object
  */
 
+// `*dict` ownership contract (post-fix):
+//
+// On every return path (success or failure, every input shape) `*dict`
+// is set to either `nullptr` or a NEW STRONG REFERENCE that the caller
+// owns and MUST `Py_XDECREF` (or hand to a `PyObjectUniquePtr`) when
+// done. The borrow-vs-own asymmetry that historically existed -- a
+// borrowed ref to `obj->dict` for instance inputs but a freshly-
+// allocated dict for list inputs -- silently leaked one dict per
+// list-input call (see issue #596). Standardising on "always strong"
+// makes the contract uniform; the per-input-shape leak goes away
+// automatically once every call site decrefs.
 std::shared_ptr<AbstractNode> PyOpenSCADObjectToNode(PyObject *obj, PyObject **dict)
 {
-  // Check for special Python objects BEFORE casting to PyOpenSCADObject
+  *dict = nullptr;
+
   if (obj == Py_None || obj == Py_False) {
-    *dict = nullptr;
     return void_node;
   }
   if (obj == Py_True) {
-    *dict = nullptr;
     return full_node;
   }
 
-  // Verify obj is actually a PyOpenSCADType before casting
   if (!PyObject_IsInstance(obj, reinterpret_cast<PyObject *>(&PyOpenSCADType))) {
-    *dict = nullptr;
     return void_node;
   }
 
@@ -256,7 +264,9 @@ std::shared_ptr<AbstractNode> PyOpenSCADObjectToNode(PyObject *obj, PyObject **d
     if (result.use_count() > 2 && result != void_node && result != full_node) {
       result = result->clone();
     }
-    *dict = (reinterpret_cast<PyOpenSCADObject *>(obj))->dict;
+    PyObject *instance_dict = (reinterpret_cast<PyOpenSCADObject *>(obj))->dict;
+    Py_XINCREF(instance_dict);
+    *dict = instance_dict;
   } else {
     result = nullptr;
   }
@@ -294,65 +304,91 @@ PyTypeObject *PyOpenSCADObjectType(PyObject *objs)
  * same as  python_more_obj but always returns only one AbstractNode by creating an UNION operation
  */
 
+// `*dict` ownership contract: same as PyOpenSCADObjectToNode -- always
+// `nullptr` or a NEW STRONG REFERENCE the caller must `Py_XDECREF`.
+// See the comment on PyOpenSCADObjectToNode above for the rationale
+// and the pre-fix leak behavior (issue #596).
 std::shared_ptr<AbstractNode> PyOpenSCADObjectToNodeMulti(PyObject *objs, PyObject **dict)
 {
+  *dict = nullptr;
   std::shared_ptr<AbstractNode> result = nullptr;
   if (PyObject_IsInstance(objs, reinterpret_cast<PyObject *>(&PyOpenSCADType))) {
     result = (reinterpret_cast<PyOpenSCADObject *>(objs))->node;
     if (result.use_count() > 2 && result != void_node && result != full_node) {
       result = result->clone();
     }
-    *dict = (reinterpret_cast<PyOpenSCADObject *>(objs))->dict;
+    PyObject *instance_dict = (reinterpret_cast<PyOpenSCADObject *>(objs))->dict;
+    Py_XINCREF(instance_dict);
+    *dict = instance_dict;
   } else if (PyList_Check(objs)) {
     DECLARE_INSTANCE();
     auto node = std::make_shared<CsgOpNode>(instance, OpenSCADOperator::UNION);
 
     int n = PyList_Size(objs);
-    std::vector<PyObject *> child_dict;
-    PyObject *subdict;
+    // Each entry is a STRONG ref returned by PyOpenSCADObjectToNode;
+    // we must Py_XDECREF every entry on every exit path. Wrapping in
+    // PyObjectUniquePtr so this is impossible to forget regardless of
+    // which return path is taken (early `return nullptr` on a
+    // non-PyOpenSCAD list element, or the merge fall-through below).
+    std::vector<PyObjectUniquePtr> child_dict;
+    child_dict.reserve(n);
     for (int i = 0; i < n; i++) {
       PyObject *obj = PyList_GetItem(objs, i);
       if (PyObject_IsInstance(obj, reinterpret_cast<PyObject *>(&PyOpenSCADType))) {
+        PyObject *subdict = nullptr;
         std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNode(obj, &subdict);
+        auto owned_subdict = py_owned(subdict);
         if (child == nullptr) continue;
         node->children.push_back(child);
-        child_dict.push_back(subdict);
-      } else return nullptr;
+        child_dict.push_back(std::move(owned_subdict));
+      } else {
+        // Early return: child_dict's destructor decrements every
+        // strong ref accumulated so far, so no leak on this path.
+        return nullptr;
+      }
     }
     result = node;
 
-    *dict = PyDict_New();
-    if (*dict == nullptr) {
-      /* PyDict_New sets MemoryError on failure. Bail out before we
-       * dereference a null *dict in PyDict_SetItem below (UB / SIGSEGV).
-       * Returning nullptr also signals to the caller that the merge
-       * failed and lets it propagate the pending exception. */
+    PyObject *merged = PyDict_New();
+    if (merged == nullptr) {
+      // PyDict_New sets a Python exception (typically MemoryError) on
+      // failure. Returning a valid node here would leave the exception
+      // pending and surface as a SystemError later. Returning nullptr
+      // -- with *dict already nullptr -- propagates the exception
+      // cleanly; child_dict cleans up its accumulated strong refs on
+      // scope exit.
       return nullptr;
     }
-    for (int i = child_dict.size() - 1; i >= 0; i--)  // merge from back  to give 1st child most priority
-    {
-      auto& subsubdict = child_dict[i];
+    // Reverse-iterate: 1st child wins (later writes overwrite earlier
+    // ones). Use the `i-- > 0` pattern with size_t to avoid the
+    // implementation-defined size_t-to-int conversion that the prior
+    // `int i = child_dict.size() - 1` formulation triggered when
+    // child_dict was empty.
+    for (size_t i = child_dict.size(); i-- > 0;) {
+      PyObject *subsubdict = child_dict[i].get();
       if (subsubdict == nullptr) continue;
       PyObject *key, *value;
       Py_ssize_t pos = 0;
       while (PyDict_Next(subsubdict, &pos, &key, &value)) {
-        if (PyDict_SetItem(*dict, key, value) < 0) {
-          /* OOM (or the rare hashing-side error). Drop the
-           * partial merged dict so we don't leak it and let
-           * the caller surface the pending MemoryError. */
-          Py_DECREF(*dict);
-          *dict = nullptr;
+        if (PyDict_SetItem(merged, key, value) < 0) {
+          // Propagate the pending exception (typically MemoryError, or
+          // the rare hashing-side error). PyDict_New's strong ref is
+          // dropped via py_owned() so we don't leak `merged`, and
+          // *dict stays nullptr so the caller never sees a partially
+          // merged dict.
+          auto owned_merged = py_owned(merged);
           return nullptr;
         }
       }
     }
+    *dict = merged;
   } else if (objs == Py_None || objs == Py_False) {
     result = void_node;
-    *dict = nullptr;  // TODO improve
   } else if (objs == Py_True) {
     result = full_node;
-    *dict = nullptr;  // TODO improve
-  } else result = nullptr;
+  } else {
+    result = nullptr;
+  }
   return result;
 }
 
@@ -679,7 +715,6 @@ std::shared_ptr<AbstractNode> python_modulefunc(const ModuleInstantiation *op_mo
                                                 const std::shared_ptr<const Context>& cxt,
                                                 std::string& error)  // null & error: error, else: None
 {
-  PyObject *dummydict;
   std::shared_ptr<AbstractNode> result = nullptr;
   std::string errorstr = "";
   {
@@ -693,8 +728,11 @@ std::shared_ptr<AbstractNode> python_modulefunc(const ModuleInstantiation *op_mo
       return nullptr;
     }
 
-    if (PyObject_IsInstance(funcresult, reinterpret_cast<PyObject *>(&PyOpenSCADType)))
-      result = PyOpenSCADObjectToNode(funcresult, &dummydict);
+    if (PyObject_IsInstance(funcresult, reinterpret_cast<PyObject *>(&PyOpenSCADType))) {
+      PyObject *raw_dummydict = nullptr;
+      result = PyOpenSCADObjectToNode(funcresult, &raw_dummydict);
+      auto dummydict = py_owned(raw_dummydict);
+    }
     Py_XDECREF(funcresult);
   }
   return result;
@@ -1244,10 +1282,10 @@ static void PyOpenSCADItemRef_dealloc(PyOpenSCADItemRef *self)
 
 PyObject *PyOpenSCADItemRef_get_value(PyOpenSCADItemRef *self, void *closure)
 {
-  PyObject *dummydict;
-
+  PyObject *dummydict_raw = nullptr;
   std::shared_ptr<AbstractNode> parnode =
-    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self->parent), &dummydict);
+    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self->parent), &dummydict_raw);
+  auto dummydict = py_owned(dummydict_raw);
   if (self->index >= parnode->children.size()) {
     PyErr_SetString(PyExc_IndexError, "child index out of range");
     return NULL;
@@ -1257,14 +1295,17 @@ PyObject *PyOpenSCADItemRef_get_value(PyOpenSCADItemRef *self, void *closure)
 
 int PyOpenSCADItemRef_set_value(PyOpenSCADItemRef *self, PyObject *value, void *closure)
 {
-  PyObject *dummydict;
+  PyObject *parent_dict_raw = nullptr;
   std::shared_ptr<AbstractNode> parnode =
-    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self->parent), &dummydict);
+    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self->parent), &parent_dict_raw);
+  auto parent_dict = py_owned(parent_dict_raw);
   if (self->index >= parnode->children.size()) {
     PyErr_SetString(PyExc_IndexError, "child index out of range");
     return -1;
   }
-  std::shared_ptr<AbstractNode> childnode = PyOpenSCADObjectToNode(value, &dummydict);
+  PyObject *value_dict_raw = nullptr;
+  std::shared_ptr<AbstractNode> childnode = PyOpenSCADObjectToNode(value, &value_dict_raw);
+  auto value_dict = py_owned(value_dict_raw);
   if (!childnode) {
     PyErr_SetString(PyExc_TypeError, "invalid OpenSCAD object");
     return -1;
@@ -1380,9 +1421,10 @@ PyTypeObject PyOpenSCADObjectIterType = {
 
 PyObject *PyOpenSCAD_sq_item(PyOpenSCADObject *self, Py_ssize_t i)
 {
-  PyObject *dummydict;
+  PyObject *dummydict_raw = nullptr;
   std::shared_ptr<AbstractNode> node =
-    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self), &dummydict);
+    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self), &dummydict_raw);
+  auto dummydict = py_owned(dummydict_raw);
   if (i < 0 || i >= node->children.size()) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return nullptr;
@@ -1392,9 +1434,10 @@ PyObject *PyOpenSCAD_sq_item(PyOpenSCADObject *self, Py_ssize_t i)
 
 Py_ssize_t PyOpenSCAD_sq_length(PyOpenSCADObject *self)
 {
-  PyObject *dummydict;
+  PyObject *dummydict_raw = nullptr;
   std::shared_ptr<AbstractNode> node =
-    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self), &dummydict);
+    PyOpenSCADObjectToNode(reinterpret_cast<PyObject *>(self), &dummydict_raw);
+  auto dummydict = py_owned(dummydict_raw);
   return node->children.size();
 }
 

--- a/src/python/pyopenscad.h
+++ b/src/python/pyopenscad.h
@@ -65,6 +65,29 @@ using PyObjectUniquePtr = std::unique_ptr<PyObject, decltype(&PyObjectDeleter)>;
 // pyfunctions.cc (see issue #587).
 bool python_pyobject_to_utf8(PyObject *obj, std::string& out, const char *context);
 
+// Convenience factory: build a PyObjectUniquePtr without having to
+// repeat `&PyObjectDeleter` at every call site. Mostly used to wrap
+// `*dict` out-parameters from PyOpenSCADObjectToNode[Multi] (see the
+// ownership note on those functions below).
+inline PyObjectUniquePtr py_owned(PyObject *p = nullptr)
+{
+  return PyObjectUniquePtr(p, &PyObjectDeleter);
+}
+
+// Helper for the `child == nullptr` failure branch of
+// PyOpenSCADObjectToNode[Multi] callers. Since that function may now
+// return nullptr with a Python exception ALREADY SET (e.g.
+// MemoryError from the dict-merge path -- see #596), unconditionally
+// calling PyErr_SetString in the failure path would clobber the
+// original exception. This helper preserves any pending exception
+// and only synthesizes a fresh TypeError when none is set. Always
+// returns NULL so callers can `return propagate_or_typeerror(msg);`.
+inline PyObject *propagate_or_typeerror(const char *msg)
+{
+  if (!PyErr_Occurred()) PyErr_SetString(PyExc_TypeError, msg);
+  return NULL;
+}
+
 // Sole init entry point for the `_openscad` extension module.  Used
 // both when the module is embedded in the GUI/CLI (via
 // `PyImport_AppendInittab("_openscad", ...)`) and when CPython loads the
@@ -95,6 +118,14 @@ extern std::vector<PyObject *> python_member_callables;
 extern std::vector<std::string> python_member_names;
 bool trust_python_file(const std::string& file, const std::string& content);
 PyObject *PyOpenSCADObjectFromNode(PyTypeObject *type, const std::shared_ptr<AbstractNode>& node);
+
+// Both PyOpenSCADObjectToNode and PyOpenSCADObjectToNodeMulti set
+// `*dict` to either nullptr or a NEW STRONG REFERENCE that the caller
+// must Py_XDECREF (or hand to a PyObjectUniquePtr) when done with it.
+// Callers that don't need the dict must still Py_XDECREF the
+// out-parameter to avoid a per-call leak; using a PyObjectUniquePtr
+// is the recommended pattern. See issue #596 for the historical
+// borrow-vs-own asymmetry that this contract replaces.
 std::shared_ptr<AbstractNode> PyOpenSCADObjectToNode(PyObject *obj, PyObject **dict);
 std::shared_ptr<AbstractNode> PyOpenSCADObjectToNodeMulti(PyObject *objs, PyObject **dict);
 PyTypeObject *PyOpenSCADObjectType(PyObject *objs);

--- a/tests/data/pythonscad-echo/pyopenscadobjecttonodemulti-dict-leak.py
+++ b/tests/data/pythonscad-echo/pyopenscadobjecttonodemulti-dict-leak.py
@@ -1,0 +1,57 @@
+"""
+Regression test for issue #596: PyOpenSCADObjectToNodeMulti dict leak.
+
+Before the fix, every call that took the LIST branch of
+`PyOpenSCADObjectToNodeMulti` allocated a fresh `PyDict_New()` whose
+strong reference the caller never `Py_DECREF`-ed. That dict (plus the
+borrowed values it pinned) accumulated one-per-call, so a tight loop
+of e.g. `show([a, b])` leaked one dict per iteration -- visible in
+`gc.get_objects()` as a steadily growing object population.
+
+After the fix, the contract for `*dict` is "always a strong reference"
+on every input shape, and every audited call site releases it
+(typically via a `PyObjectUniquePtr` RAII wrapper). The
+`gc.get_objects()` count therefore stays effectively flat across the
+loop instead of growing linearly with N.
+
+The script self-asserts: it prints `dict_leak_ok` on the fixed binary
+and `dict_leak_FAIL` on the unfixed one, so the standard echo-test
+comparator catches a regression deterministically by string match --
+the *expected file* contains only that constant discriminator, no
+numeric threshold. The script itself does pick a threshold (`N // 4`,
+documented inline below) to decide which constant to print.
+"""
+import gc
+
+from pythonscad import cube, cylinder, show
+
+a = cube(10)
+b = cylinder(r=5, h=10)
+
+# Run a couple of warm-up iterations so any one-shot interpreter
+# allocations (lazy module imports, jit-style caches, etc.) settle
+# before we sample the baseline.
+for _ in range(50):
+    show([a, b])
+
+gc.collect()
+before = len(gc.get_objects())
+
+N = 1000
+for _ in range(N):
+    show([a, b])
+
+gc.collect()
+after = len(gc.get_objects())
+delta = after - before
+
+# Pre-fix: delta scales ~linearly with N (dozens of objects per leaked
+# dict because the merged dict pins the per-child borrowed values).
+# Post-fix: delta should be a small constant. Use N/4 as the cutoff;
+# that comfortably catches the one-dict-per-call leak while leaving
+# headroom for unrelated, non-deterministic interpreter behaviour.
+threshold = N // 4
+if delta < threshold:
+    print("dict_leak_ok")
+else:
+    print(f"dict_leak_FAIL delta={delta} threshold={threshold}")

--- a/tests/regression/pythonscadecho/pyopenscadobjecttonodemulti-dict-leak-expected.echo
+++ b/tests/regression/pythonscadecho/pyopenscadobjecttonodemulti-dict-leak-expected.echo
@@ -1,0 +1,1 @@
+dict_leak_ok


### PR DESCRIPTION
## Summary

Closes #596.

`PyOpenSCADObjectToNode[Multi](PyObject*, PyObject **dict)` had an
asymmetric, undocumented ownership contract for the `*dict`
out-parameter:

| Input shape                    | `*dict`            | Reference type |
|--------------------------------|--------------------|----------------|
| `PyOpenSCADType` instance      | `obj->dict`        | **borrowed**   |
| `PyList_Check(objs)`           | `PyDict_New(...)`  | **owned**      |
| `Py_None` / `Py_True` / `Py_False` | `nullptr`      | n/a            |

Almost every caller treated `*dict` as borrowed, so every call that
went through the **list** branch leaked one dict (plus all the
per-child borrowed values it pinned). For tight loops like

```python
for _ in range(1000):
    show([a, b])  # list path of PyOpenSCADObjectToNodeMulti
```

`gc.get_objects()` grew by ~1000.

This PR standardizes on "always strong reference" -- the same shape
the issue suggested as Option 1, combined with the
`PyObjectUniquePtr`-based RAII enforcement from Option 3.

## What changed

### Core fix: contract change

- `PyOpenSCADObjectToNode` and `PyOpenSCADObjectToNodeMulti` both now
  hand back **either** `nullptr` **or** a fresh strong reference,
  documented in a header comment on each declaration.
  - Instance branch `Py_XINCREF`s the existing `obj->dict` before
    handing it out.
  - List branch is unchanged in spirit (still `PyDict_New` + merge),
    but the per-child sub-dicts are now also strong refs, and the
    accumulator vector inside the function is
    `std::vector<PyObjectUniquePtr>` so every exit path (including
    the early `return nullptr` on a non-PyOpenSCAD list element)
    releases them.
  - None/True/False/error branches set `*dict = nullptr` cleanly
    instead of the previous `// TODO improve` placeholder.
- New `py_owned()` factory in `pyopenscad.h` so callers don't have to
  type out `PyObjectUniquePtr(raw, &PyObjectDeleter)` at every site.
- New `propagate_or_typeerror(msg)` helper for the recurring
  "`PyOpenSCADObjectToNode[Multi]` returned null → set TypeError →
  return null" pattern: raises `msg` only when no exception is in
  flight, otherwise lets the original (e.g. `MemoryError`) surface.
- Audit pass over **every** call site (~37 across 9 files):
  - Sites that previously discarded the dict now wrap the raw
    out-parameter in `auto x = py_owned(raw)` so it's released at
    end-of-scope.
  - Sites that read the dict (e.g. property merging into a parent's
    dict, key/value iteration in `python_show_core`,
    `python_export_obj_att`, `python_color_core`,
    `python_translate_sub`, `python_rotate_sub`,
    `python_mirror_sub`, `python_multmatrix_sub`,
    `python_csg_sub`/`oo_csg_sub`/`nb_sub` etc.) keep the existing
    `.get()`-style usage but now release the strong ref afterwards.
  - Sites that accumulate dicts across a loop (the `child_dict`
    vectors in `python_csg_sub`, `python_oo_csg_sub`,
    `python_nb_sub`) are now `std::vector<PyObjectUniquePtr>`, which
    also releases on early-return error paths.

### Subsequent hardening

The contract change above unblocked a cluster of related issues that
Copilot surfaced during the iterative review on this PR. They are
all also fixed in this PR, grouped by theme:

**Reference-count leaks of new Python objects** -- every site that
acquired a NEW reference (e.g. `PyUnicode_FromString`,
`PyUnicode_AsEncodedString`, `PyUnicode_FromStringAndSize`,
`PyDict_New`, the `python_number_*` transforms) is now wrapped in
`py_owned()` so the strong reference releases at end of scope.

**Pending-exception propagation** -- many call sites used to
overwrite a hard-failure exception (`MemoryError`,
`KeyboardInterrupt`) with their own `TypeError`. They now use
`propagate_or_typeerror()` or check `PyErr_Occurred()` first so the
original exception is preserved verbatim.

**`PyDict_SetItem` failure propagation** -- merge loops in
`python_csg_sub`, `python_oo_csg_sub`, `python_nb_sub`,
`python_resize_core`, `python_color_core`, `python_oo_clone`,
`python_skin`, and the transform `python_number_*` paths now check
the return value and propagate, instead of silently dropping the
key/value pair on OOM.

**Crash safety / type checks**

- `python_minkowski`: null-checks both children before pushing them
  into `node->children`; previously a degenerate input could build
  an invalid `CgalAdvNode` that crashed during geometry evaluation.
- `python_ifrep`: replaces a C-style `(LeafNode *)child.get()` cast
  with a `dynamic_cast<LeafNode *>` plus a null-guard, so a CSG
  combination passed by mistake (`union(a, b)`) now raises a clear
  `TypeError` instead of walking uninitialized vtable slots.
- `python_oo_clone`: null-checks the conversion result before
  dereferencing for `node->clone()`; previously a null `shared_ptr`
  segfaulted, or assigned null into `self->node` and returned
  `Py_RETURN_NONE` while a Python exception was still pending.
- `python_size_core` / `python_position_core`: distinguish "not an
  OpenSCAD object" (legit `Py_RETURN_NONE`) from "conversion failed
  with an exception set" (must propagate). Pre-existing C-API
  contract violation that surfaced as `SystemError` later.
- `python_nb_sub_vec3` (the core for `translate` / `scale` /
  `translateneg` / `translate-exp`, and -- importantly -- also the
  core for the standalone Python functions `translate()` and
  `scale()`): same shape -- a hard-failure `MemoryError` from the
  initial `PyOpenSCADObjectToNodeMulti` was being clobbered by
  downstream `PyErr_SetString("explode arg must be a list")` etc.
  Now propagates verbatim. Additionally, the `arg2 == nullptr`
  branch is null-guarded so it never hands a null
  `shared_ptr<AbstractNode>` to `PyOpenSCADObjectFromNode`. The
  guard is **narrow** -- it only gates the `arg2 == nullptr` path
  -- because the matrix-arithmetic fall-through (used by
  `pylaser`, `align2d.py`, etc. for `translate(<list>, <list>)`
  vector arithmetic) explicitly tolerates a null `child`.
- `python__setitem__`: the slot is wired to `mp_ass_subscript`, so
  CPython passes `v == NULL` for `del obj[key]`; previously the
  function would crash on `Py_INCREF(NULL)`. Deletion is now routed
  through `PyDict_DelItem`. The spurious unconditional `Py_INCREF(v)`
  on the assignment branch (which `PyDict_SetItem` already does for
  itself) is dropped, also fixing a pre-existing per-call refcount
  leak.
- All loops that previously used `for (int i = vec.size() - 1;
  i >= 0; --i)` to reverse-iterate now use
  `for (size_t i = vec.size(); i-- > 0; )` so they stay well-defined
  when the vector is empty.

**Drive-by polish**

- `"Unkown parameter name in CSG."` / `... in skin.` →
  `"Unknown ..."` across 6 user-visible `TypeError` messages in
  `py_csg.cc` and `py_extrude.cc` so users can grep / search docs
  for the canonical spelling.
- `python_pull_core` error message: `"Invalid type for  Object in
  translate\n"` (copy-paste artefact from
  `python_translate_sub`) → `"Invalid type for Object in pull"`
  matching project-wide style.
- Regression-test docstring: clarify that the *expected file* holds
  no numeric threshold (the script does pick its own internal
  `N // 4` cutoff to decide which discriminator string to print).

## Rebase note

Rebased onto `master` after #595 landed. The two PRs touched many
of the same `PyUnicode_AsEncodedString` callsites; this PR's
`py_owned(...)` wrappers were dropped where #595 had already
replaced the site with the cleaner `python_pyobject_to_utf8()`
helper, and `py_owned()` is kept only at sites #595 didn't cover
(notably `python_export_obj_att_pre_encode`'s outer
`PyOpenSCADObjectToNodeMulti` call and the per-iteration dict in
`python_export_core`'s dict-form path). The 32 review-round commits
were squashed into a single commit during the rebase since the
repo squash-merges PRs anyway.

## Files touched

12 files, +729 / -380:

```
src/python/pyopenscad.{h,cc}          contract change + py_owned + propagate_or_typeerror
src/python/pyfunctions.cc             oo_hasattr/getattr/setattr, __getitem__/__setitem__
src/python/py_csg.cc                  csg_sub, oo_csg_sub, nb_sub, nb_sub_vec3, minkowski, resize_core
src/python/py_ops.cc                  color_core, repair_core, fillet_core, oo_clone, align_core, ...
src/python/py_transform.cc            scale_sub, rotate_sub, mirror_sub, translate_sub
src/python/py_extrude.cc              skin, linear_extrude, rotate_extrude, path_extrude, ...
src/python/py_io.cc                   show_core, export_obj_att, export_core, Export3mfPartInfo
src/python/py_analysis.cc             mesh, separate, faces
src/python/py_primitives.cc           ifrep
tests/data/pythonscad-echo/...        new regression test
tests/regression/.../...              expected output for the regression test
```

## Test plan

- [x] New regression test
  `tests/data/pythonscad-echo/pyopenscadobjecttonodemulti-dict-leak.py`
  walks the list branch 1000 times and asserts via `gc.get_objects()`
  that the steady-state object count grows by less than `N/4`. On
  the unfixed binary the delta scaled linearly with N (~1000 objects
  per 1000 iterations); on this PR the observed delta is ~0.
- [x] `ctest -R pythonscad -j8` -- 86/86 pass locally on Linux
  (Mesa AMD).
- [x] `./scripts/beautify.sh` clean.
- [x] All Copilot review threads resolved (17 review rounds
  pre-rebase).
- [ ] CI green on HEAD post-rebase.

Made with [Cursor](https://cursor.com)
