### PR TITLE
fix(build): restore compilation when ENABLE_PYTHON=OFF

### DIFF
--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -7,6 +7,7 @@
 #include "core/CurveDiscretizer.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Value.h"
+#include "core/node.h"
 #include "geometry/linalg.h"
 
 #ifdef ENABLE_PYTHON

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -595,6 +595,14 @@ int cmdline(const CommandLine& cmd)
     text = std::string((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
   }
 
+  RenderVariables render_variables = {
+    .preview = fileformat::canPreview(export_format)
+                 ? (cmd.viewOptions.renderer == RenderType::OPENCSG ||
+                    cmd.viewOptions.renderer == RenderType::THROWNTOGETHER)
+                 : false,
+    .camera = cmd.camera,
+  };
+
 #ifdef ENABLE_PYTHON
   python_active = false;
   if (cmd.filename.c_str() != NULL) {
@@ -603,14 +611,6 @@ int cmdline(const CommandLine& cmd)
       else LOG("Python is not enabled");
     }
   }
-
-  RenderVariables render_variables = {
-    .preview = fileformat::canPreview(export_format)
-                 ? (cmd.viewOptions.renderer == RenderType::OPENCSG ||
-                    cmd.viewOptions.renderer == RenderType::THROWNTOGETHER)
-                 : false,
-    .camera = cmd.camera,
-  };
 
   std::string text_py = text;
   if (python_active) {
@@ -652,7 +652,6 @@ int cmdline(const CommandLine& cmd)
   }
 
   root_file->handleDependencies();
-
 
   if (cmd.animate.frames == 0) {
     render_variables.time = 0;


### PR DESCRIPTION
## Summary

The build was broken when configured without Python support
(`-DENABLE_PYTHON=OFF`). This PR restores it.

## Changes

- **`src/openscad.cc`**: `RenderVariables render_variables = {...}` was
  declared inside an `#ifdef ENABLE_PYTHON` block but used unconditionally
  later in the function, causing an "undeclared identifier" error when
  Python was disabled. Moved the declaration above the `#ifdef` block so it
  is always in scope.
- **`src/core/RotateExtrudeNode.h`**: Added a missing `#include
  "core/node.h"`. The header was previously pulled in transitively via the
  Python-only include path, so the file failed to compile when
  `ENABLE_PYTHON` was off.
- Removed an unrelated stray blank line in `src/openscad.cc`.

## Test plan

- [ ] `cmake -DENABLE_PYTHON=OFF .. && make` succeeds.
- [ ] `cmake -DENABLE_PYTHON=ON  .. && make` still succeeds (no regression).