### PR TITLE
fix(python): sweep PyBytes_AS_STRING(NULL) UB out of pyopenscad/pyconversion

### DIFF
--- a/src/python/pyconversion.cc
+++ b/src/python/pyconversion.cc
@@ -57,9 +57,20 @@ int python_numberval(PyObject *number, double *result, int *flags, int flagor)
     return 0;
   }
   if (PyUnicode_Check(number) && flags != nullptr) {
-    PyObjectUniquePtr str(PyUnicode_AsEncodedString(number, "utf-8", "~"), &PyObjectDeleter);
-    const char *str1 = PyBytes_AS_STRING(str.get());
-    sscanf(str1, "%lf", result);
+    /* python_numberval() is a best-effort coercion that returns
+     * 0/1 and does not propagate Python exceptions to the caller.
+     * The helper can fail with a TypeError on unencodable str
+     * contents (lone surrogates under the "strict" handler) or on
+     * a misbehaving custom utf-8 codec, and can propagate
+     * MemoryError / KeyboardInterrupt verbatim. We have no way to
+     * surface any of those cleanly here, so clear the indicator
+     * and report "not coercible" to the caller. */
+    std::string str_utf8;
+    if (!python_pyobject_to_utf8(number, str_utf8, "python_numberval()")) {
+      PyErr_Clear();
+      return 1;
+    }
+    sscanf(str_utf8.c_str(), "%lf", result);
     *flags |= flagor;
     return 0;
   }

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -621,10 +621,24 @@ void python_catch_error(std::string& errorstr)
 
   if (pyExcValue != nullptr) {
     PyObjectUniquePtr str_exc_value(PyObject_Repr(pyExcValue), &PyObjectDeleter);
-    PyObjectUniquePtr pyExcValueStr(PyUnicode_AsEncodedString(str_exc_value.get(), "utf-8", "~"),
-                                    PyObjectDeleter);
-    char *suberror = PyBytes_AS_STRING(pyExcValueStr.get());
-    if (suberror != nullptr) errorstr += suberror;
+    /* Best-effort: this is a void error-formatter, so we cannot
+     * propagate a helper failure to a caller. Clear any exception
+     * the helper sets (e.g. TypeError from a repr() containing lone
+     * surrogates) and degrade silently to no-append.
+     *
+     * Same treatment for a NULL repr -- PyObject_Repr() also leaves
+     * an exception set on failure, and we don't want to poison the
+     * next unrelated C-API call from the GUI. */
+    if (str_exc_value.get() != nullptr) {
+      std::string suberror;
+      if (python_pyobject_to_utf8(str_exc_value.get(), suberror, "python_catch_error()")) {
+        errorstr += suberror;
+      } else {
+        PyErr_Clear();
+      }
+    } else {
+      PyErr_Clear();
+    }
     Py_XDECREF(pyExcValue);
   }
   if (pyExcTraceback != nullptr) {
@@ -847,17 +861,18 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
         if (!PyUnicode_Check(key)) {
           continue;
         }
-        PyObjectUniquePtr keyUtf(PyUnicode_AsEncodedString(key, "utf-8", "~"), &PyObjectDeleter);
-        if (keyUtf.get() == nullptr) {
+        /* Best-effort cleanup walk: a key we can't UTF-8 encode is
+         * a key we can't compare against the inventory anyway, so
+         * skip it (and clear the helper's exception). */
+        std::string keyStrStr;
+        if (!python_pyobject_to_utf8(key, keyStrStr, "initPython() __main__ key")) {
+          PyErr_Clear();
           continue;
         }
-        const char *keyStr = PyBytes_AS_STRING(keyUtf.get());
-        if (keyStr == nullptr) {
-          continue;
-        }
+        const char *keyStr = keyStrStr.c_str();
         if (std::find(std::begin(pythonInventory), std::end(pythonInventory), keyStr) ==
             std::end(pythonInventory)) {
-          if (strlen(keyStr) < 4 || strncmp(keyStr, "stat", 4) != 0) {
+          if (keyStrStr.size() < 4 || strncmp(keyStr, "stat", 4) != 0) {
             mainKeysToDelete.emplace_back(keyStr);
           }
         }
@@ -882,12 +897,12 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
           if (!PyUnicode_Check(k1)) {
             continue;
           }
-          PyObjectUniquePtr k1Utf(PyUnicode_AsEncodedString(k1, "utf-8", "~"), &PyObjectDeleter);
-          if (k1Utf.get() == nullptr) {
+          std::string k1StrStr;
+          if (!python_pyobject_to_utf8(k1, k1StrStr, "initPython() sys.<attr> key")) {
+            PyErr_Clear();
             continue;
           }
-          const char *k1Str = PyBytes_AS_STRING(k1Utf.get());
-          if (k1Str == nullptr || strcmp(k1Str, "modules") != 0) {
+          if (k1StrStr != "modules") {
             continue;
           }
           PyObject *mm = PyDict_GetItem(sysdict, k1);
@@ -905,32 +920,33 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
             if (!PyUnicode_Check(k2)) {
               continue;
             }
-            PyObjectUniquePtr k2Utf(PyUnicode_AsEncodedString(k2, "utf-8", "~"), &PyObjectDeleter);
-            if (k2Utf.get() == nullptr) {
+            std::string k2StrStr;
+            if (!python_pyobject_to_utf8(k2, k2StrStr, "initPython() sys.modules key")) {
+              PyErr_Clear();
               continue;
             }
-            const char *k2Str = PyBytes_AS_STRING(k2Utf.get());
-            if (k2Str == nullptr) {
-              continue;
-            }
+            const char *k2Str = k2StrStr.c_str();
             PyObject *value2 = PyDict_GetItem(mm, k2);
             if (value2 == nullptr || !PyModule_Check(value2)) {
               continue;
             }
             PyObject *modrepr = PyObject_Repr(value2);
             if (modrepr == nullptr) {
+              /* Same exception-hygiene treatment as the catcher /
+               * catch_error sites: PyObject_Repr() leaves a
+               * TypeError / MemoryError / etc. set on failure;
+               * clear it so we do not poison the next iteration's
+               * C-API calls. */
+              PyErr_Clear();
               continue;
             }
             PyObjectUniquePtr modreprOwned(modrepr, &PyObjectDeleter);
-            PyObjectUniquePtr modReprUtf(PyUnicode_AsEncodedString(modrepr, "utf-8", "~"),
-                                         &PyObjectDeleter);
-            if (modReprUtf.get() == nullptr) {
+            std::string modReprStr;
+            if (!python_pyobject_to_utf8(modrepr, modReprStr, "initPython() repr(module)")) {
+              PyErr_Clear();
               continue;
             }
-            const char *modreprstr = PyBytes_AS_STRING(modReprUtf.get());
-            if (modreprstr == nullptr) {
-              continue;
-            }
+            const char *modreprstr = modReprStr.c_str();
             if (strstr(modreprstr, "(frozen)") != nullptr) continue;
             if (strstr(modreprstr, "(built-in)") != nullptr) continue;
             if (strstr(modreprstr, "/encodings/") != nullptr) continue;
@@ -1088,9 +1104,15 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
       if (!PyUnicode_Check(key)) {
         continue;
       }
-      PyObjectUniquePtr key1(PyUnicode_AsEncodedString(key, "utf-8", "~"), &PyObjectDeleter);
-      const char *key_str = PyBytes_AsString(key1.get());
-      if (key_str != nullptr) pythonInventory.push_back(key_str);
+      /* Best-effort inventory snapshot of __main__ at initPython() time.
+       * Skip (and clear) keys we can't UTF-8 encode -- they couldn't be
+       * compared against on the cleanup walk above either. */
+      std::string key_str;
+      if (!python_pyobject_to_utf8(key, key_str, "initPython() inventory key")) {
+        PyErr_Clear();
+        continue;
+      }
+      pythonInventory.push_back(key_str);
     }
   }
   std::ostringstream stream;
@@ -1229,16 +1251,37 @@ stderr_bak = None\n\
     PyObjectUniquePtr catcher(nullptr, &PyObjectDeleter);
     catcher.reset(
       PyObject_GetAttrString(pythonMainModule.get(), i == 1 ? "catcher_err" : "catcher_out"));
-    if (catcher == nullptr) continue;
+    if (catcher == nullptr) {
+      /* The catcher_out / catcher_err globals are installed by
+       * python_init_code above, but a user script could `del` them
+       * (or replace them with something that raises on attribute
+       * access). PyObject_GetAttrString sets AttributeError /
+       * MemoryError / etc. on failure -- clear it so we don't
+       * poison the next unrelated C-API call. */
+      PyErr_Clear();
+      continue;
+    }
     PyObjectUniquePtr command_output(nullptr, &PyObjectDeleter);
     command_output.reset(PyObject_GetAttrString(catcher.get(), "data"));
+    if (command_output.get() == nullptr) {
+      PyErr_Clear();
+      continue;
+    }
 
-    PyObjectUniquePtr command_output_value(nullptr, &PyObjectDeleter);
-    command_output_value.reset(PyUnicode_AsEncodedString(command_output.get(), "utf-8", "~"));
-    const char *command_output_bytes = PyBytes_AS_STRING(command_output_value.get());
-    if (command_output_bytes != nullptr && *command_output_bytes != '\0') {
-      if (i == 1) error += command_output_bytes; /* output to console */
-      else LOG(command_output_bytes);            /* error to LOG */
+    /* Best-effort capture of the catcher's accumulated stdout/stderr.
+     * The helper can fail if `data` is somehow not a str (a
+     * misbehaving catcher reimplementation), or if the str contains
+     * lone surrogates that the strict utf-8 handler refuses to
+     * encode. Drop the chunk in either case rather than crashing or
+     * appending garbage to the user-visible error string. */
+    std::string command_output_str;
+    if (!python_pyobject_to_utf8(command_output.get(), command_output_str, "captured Python output")) {
+      PyErr_Clear();
+      continue;
+    }
+    if (!command_output_str.empty()) {
+      if (i == 1) error += command_output_str; /* output to console */
+      else LOG(command_output_str.c_str());    /* error to LOG */
     }
   }
   PyRun_SimpleString(python_exit_code);


### PR DESCRIPTION
Closes #597.

## Summary

`#587` / `#595` fixed the user-reachable crash path of the broken

```cpp
PyObject *value1 = PyUnicode_AsEncodedString(key, "utf-8", "~");
const char *value_str = PyBytes_AS_STRING(value1);   // UB on NULL
if (value_str == nullptr) continue;                  // dead check
```

idiom in `python_export_core` and the user-reachable sites in `pyfunctions.cc` / `pydata.cc`. The same idiom survived in **less user-reachable Tier-C sites** in `pyopenscad.cc` and `pyconversion.cc`. They aren't reachable through the simple `export({non_str: cube(10)}, ...)` reproducer that motivated #587, but they are the same class of bug and #597 tracks them as a deliberate sweep while the helper is still fresh.

The two underlying defects at every site:

* `PyBytes_AS_STRING(NULL)` is UB and yields a small non-NULL offset on every platform we ship to, so the `if (str != nullptr)` guards were dead.
* `"~"` is **not** a registered Python error handler, so encoding silently raises `LookupError` on any unencodable code point (lone surrogates etc.) instead of substituting -- which then triggers the dead-check path.

This PR doesn't introduce a new helper or new test data; it just routes every remaining call site through the existing `python_pyobject_to_utf8(obj, out, context)` helper from `pyopenscad.h` (introduced in #595), which uses `"strict"` and propagates / converts encoding failures consistently.

## Sites swept

* **`pyconversion.cc` `python_numberval`** -- best-effort string -> double coercion. The function returns 0/1 and does not propagate exceptions, so on helper failure we `PyErr_Clear()` and report "not coercible" (return 1).
* **`pyopenscad.cc` `python_catch_error`** -- void error formatter. On helper failure, clear and degrade silently to no-append rather than feeding the dummy pointer into ``std::string::operator+=``.
* **`pyopenscad.cc` `initPython` cleanup walk** (4 sites) -- ``__main__`` key snapshot, ``sys.<attr>`` key match, ``sys.modules`` key snapshot, and the ``repr(module)`` filter for frozen / built-in / site-packages modules. All best-effort -- skip + clear on helper failure.
* **`pyopenscad.cc` `initPython` inventory snapshot** -- same best-effort pattern. This site additionally used ``PyBytes_AsString`` (the function form) on a possibly-NULL bytes object; ``PyBytes_AsString(NULL)`` calls ``PyBytes_Check(NULL)`` which dereferences via ``Py_TYPE(NULL)``, so it was also UB.
* **`pyopenscad.cc` Python-output catcher** -- subprocess stdout/stderr; helper failure is clear-and-skip-this-stream rather than appending garbage to the user-visible error string. Also added the missing null-check on ``PyObject_GetAttrString(catcher, "data")``.

## Out of scope (deliberately, per #597)

* `python__setitem__` -- tracked separately by #594, separate behaviour bug (silently-swallowed exception, not a crash).
* `py_ops.cc` color-name sites (`python_color_core`, `python_repair_core`) -- they still use the bogus ``"~"`` error handler, but they correctly null-check the bytes object before calling ``PyBytes_AS_STRING``, so they are not UB. Can be folded into a follow-up PR if desired.

## Test plan

- [x] `cmake --build build` clean (no warnings introduced)
- [x] `pre-commit run --files <changed files>` clean
- [ ] CI green on Linux / macOS / Windows
- [ ] Manual smoke: GUI starts, runs a Python script, catches a deliberately-thrown exception, output console shows the formatted error.

## Severity

Low to medium per #597 -- triggered only by:
- Numeric coercion of a `str` whose codepoints can't be UTF-8-encoded by a misbehaving codec
- Catching a Python exception whose ``repr()`` contains lone surrogates
- Loading a module with non-str names in ``__main__``
- Piping subprocess output containing non-UTF-8 bytes into the catcher

But the same class of bug as #587, and worth sweeping while the pattern is still fresh.


Made with [Cursor](https://cursor.com)