### PR TITLE
feat(distributions): add support for Fedora 44 and Ubuntu 26.04 LTS

### DIFF
--- a/supported-distributions.json
+++ b/supported-distributions.json
@@ -110,6 +110,19 @@
       ]
     },
     {
+      "family": "fedora",
+      "name": "Fedora",
+      "version": "44",
+      "codename": "44",
+      "lts": false,
+      "eol_date": "2027-06",
+      "runner": "ubuntu-24.04",
+      "docker_image": "fedora:44",
+      "architectures": [
+        "amd64"
+      ]
+    },
+    {
       "family": "el",
       "name": "Rocky Linux",
       "version": "9",

--- a/supported-distributions.json
+++ b/supported-distributions.json
@@ -45,6 +45,19 @@
       ]
     },
     {
+      "family": "ubuntu",
+      "name": "Ubuntu",
+      "version": "26.04",
+      "codename": "resolute",
+      "lts": true,
+      "eol_date": "2031-05",
+      "runner": "ubuntu-24.04",
+      "docker_image": "ubuntu:resolute",
+      "architectures": [
+        "amd64"
+      ]
+    },
+    {
       "family": "debian",
       "name": "Debian",
       "version": "11",


### PR DESCRIPTION
This PR will add packages for Fedora 44 and Ubuntu 26.04 LTS to upcoming releases.

This will fix #622.