### PR TITLE
fix(python): guard FrepNode include behind ENABLE_LIBFIVE

### DIFF
--- a/src/python/py_primitives.cc
+++ b/src/python/py_primitives.cc
@@ -37,7 +37,9 @@
 #include "PolySet.h"
 #include "PolySetBuilder.h"
 #include "GeometryEvaluator.h"
+#ifdef ENABLE_LIBFIVE
 #include "FrepNode.h"
+#endif
 #include "core/FreetypeRenderer.h"
 #include "core/TextNode.h"
 


### PR DESCRIPTION
Guard the `#include "FrepNode.h"` in `py_primitives.cc` behind `#ifdef ENABLE_LIBFIVE` so builds without libfive support compile cleanly.