### PR TITLE
fix(build): guard sha256_digest call for nettle 4.0 API change

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -185,6 +185,7 @@
 #ifdef ENABLE_PYTHON
 #include "nettle/base64.h"
 #include "nettle/sha2.h"
+#include "nettle/version.h"
 #include "python/python_public.h"
 
 std::string SHA256HashString(std::string aString)
@@ -194,7 +195,11 @@ std::string SHA256HashString(std::string aString)
 
   sha256_init(&sha256_ctx);
   sha256_update(&sha256_ctx, aString.length(), (uint8_t *)aString.c_str());
+#if NETTLE_VERSION_MAJOR >= 4
+  sha256_digest(&sha256_ctx, digest);
+#else
   sha256_digest(&sha256_ctx, SHA256_DIGEST_SIZE, digest);
+#endif
 
   base64_encode_ctx base64_ctx;
   char digest_base64[BASE64_ENCODE_LENGTH(SHA256_DIGEST_SIZE) + 1];


### PR DESCRIPTION
## Summary

Fixes #629.

Homebrew upgraded `nettle` from 3.10.2 to 4.0, which removed the redundant `length` parameter from all hash digest functions. The macOS CI build started failing with:

```
src/gui/MainWindow.cc:197:3: error: no matching function for call to 'nettle_sha256_digest'
  sha256_digest(&sha256_ctx, SHA256_DIGEST_SIZE, digest);
```

The fix adds `#include "nettle/version.h"` and guards the call with `#if NETTLE_VERSION_MAJOR >= 4` to use the 2-arg form on nettle ≥ 4 and the existing 3-arg form on nettle 3.x (Linux).

## Test plan

- [ ] macOS CI build passes (nettle 4.0)
- [ ] Linux CI build passes (nettle 3.x)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)