### PR TITLE
fix(gui): restore New button in welcome dialog when Python is disabled

### DIFF
--- a/src/gui/LaunchingScreen.cc
+++ b/src/gui/LaunchingScreen.cc
@@ -67,11 +67,6 @@ LaunchingScreen::LaunchingScreen(QWidget *parent) : QDialog(parent)
     this->treeWidget->addTopLevelItem(categoryItem);
   }
 
-#ifdef ENABLE_PYTHON
-  connect(this->pushButtonNew, &QPushButton::clicked, this, &LaunchingScreen::openPython);
-#else
-  this->pushButtonNew->hide();
-#endif
   connect(this->pushButtonOpen, &QPushButton::clicked, this, &LaunchingScreen::openUserFile);
   connect(this->pushButtonHelp, &QPushButton::clicked, this, &LaunchingScreen::openUserManualURL);
   connect(this->recentList->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
@@ -167,7 +162,11 @@ void LaunchingScreen::openUserManualURL() const
 
 void LaunchingScreen::on_pushButtonNew_clicked()
 {
+#ifdef ENABLE_PYTHON
+  openPython();
+#else
   accept();
+#endif
 }
 
 void LaunchingScreen::on_pushButtonOpen_clicked()


### PR DESCRIPTION
## Summary

- Commit 97c42c9 ("Some Transformation") collapsed `pushButtonNew` and `pushButtonNewPython` into a single `pushButtonNew`, but accidentally hid the button in non-Python builds instead of connecting it to `accept()` as it was before that refactor.
- This restores the original behavior: when `ENABLE_PYTHON=OFF`, the "New" button in the welcome dialog is visible and opens a new (blank) document.

Fixes #616

## Test plan

- [ ] Build with `-DENABLE_PYTHON=OFF` and verify the "New" button appears in the welcome/launching screen dialog
- [ ] Click "New" — should dismiss the dialog and open a blank editor
- [ ] Build with `-DENABLE_PYTHON=ON` and verify "New" still opens a new Python file as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)