### PR TITLE
fix(ci): bind-mount output dir in arm64 Docker builds for deb and rpm

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -236,9 +236,11 @@ jobs:
           else
             KEY_INPUT=""
           fi
+          mkdir -p /tmp/debs
           printf '%s' "$KEY_INPUT" | docker run --rm -i \
             --platform linux/arm64 \
             -v "$PWD:/workspace" \
+            -v /tmp/debs:/tmp/debs \
             -w /workspace \
             -e OUTPUT_DIR=/tmp/debs \
             -e DEBIAN_DISTRO="$MATRIX_DISTRO" \
@@ -275,10 +277,6 @@ jobs:
               chmod +x ./scripts/build-debian-package.sh
               ./scripts/build-debian-package.sh
             '
-
-          # Copy built packages from Docker to host
-          sudo cp -r /tmp/debs /tmp/debs-host || true
-          sudo mv /tmp/debs-host /tmp/debs || true
 
       - name: Get version for release upload
         id: version

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -279,9 +279,11 @@ jobs:
           DO_SIGN: ${{ (github.event_name == 'release' || github.event.inputs.upload_to_release != '') && 'true' || 'false' }}
         run: |
           # Run the entire build inside a Docker container with proper ARM64 emulation
+          mkdir -p /tmp/rpms
           docker run --rm \
             --platform linux/arm64 \
             -v "$PWD:/workspace" \
+            -v /tmp/rpms:/tmp/rpms \
             -w /workspace \
             -e OUTPUT_DIR=/tmp/rpms \
             -e FEDORA_RELEASE=${{ matrix.version }} \
@@ -405,10 +407,6 @@ jobs:
                 done
               fi
             '
-
-          # Copy built packages from Docker to host
-          sudo cp -r /tmp/rpms /tmp/rpms-host || true
-          sudo mv /tmp/rpms-host /tmp/rpms || true
 
       - name: Test package installation (amd64 only)
         if: matrix.arch == 'amd64'


### PR DESCRIPTION
## Summary

- **Root cause (fixes #615):** The `OUTPUT_DIR=/tmp/debs` (resp. `/tmp/rpms`) passed via `-e` to the arm64 `docker run` step pointed to a path *inside* the container. Only `$PWD:/workspace` was bind-mounted, so after `docker run --rm` exited the output directory was gone. The post-run `cp -r … || true` / `mv … || true` lines silently succeeded while producing nothing, causing the rename and upload steps to `exit 1` on every arm64 release build.
- **Fix (deb):** Pre-create `/tmp/debs` on the host runner before `docker run` and add `-v /tmp/debs:/tmp/debs` to the invocation. Drop the now-redundant post-run copy/move shuffle.
- **Fix (rpm):** Same pattern applied to `build-rpm-packages.yml` — pre-create `/tmp/rpms` and add `-v /tmp/rpms:/tmp/rpms`.

## Test plan

- [x] Trigger a `workflow_dispatch` run of **Build Debian packages** and verify the arm64 matrix entries produce a `.deb` in `/tmp/debs` and pass the rename step
- [x] Trigger a `workflow_dispatch` run of **Build RPM packages** and verify the arm64 matrix entries produce an `.rpm` in `/tmp/rpms` and pass the upload step
- [x] Confirm amd64 matrix entries are unaffected (no bind-mount change there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)