### PR TITLE
fix(gui): shorten IPC socket name to fit macOS sun_path limit

### DIFF
--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -338,7 +338,22 @@ QString lockFilePath()
 QString serverNameFromPath(const QString& path)
 {
   const QByteArray hash = QCryptographicHash::hash(path.toUtf8(), QCryptographicHash::Sha1).toHex();
-  return QStringLiteral("pythonscad.instance.") + QString::fromUtf8(hash);
+  const QString longName = QStringLiteral("pythonscad.instance.") + QString::fromUtf8(hash);
+
+#if defined(Q_OS_UNIX)
+  // POSIX sockaddr_un.sun_path is at most 104 bytes (103 usable + null terminator).
+  // QLocalServer places the socket under QDir::tempPath() + '/'. On macOS, that
+  // expands to /var/folders/<2>/<32>/T (~51 chars), so the full 60-char name would
+  // produce a 112-char path that exceeds the limit and causes listen() to fail.
+  // Fall back to a short prefix ("ps." + full 40-char SHA-1 hex = 43 chars) whenever
+  // the temp-dir prefix would push us over the limit.
+  const QString tmpPrefix = QDir::tempPath() + QLatin1Char('/');
+  if (tmpPrefix.size() + longName.size() > 103) {
+    return QStringLiteral("ps.") + QString::fromUtf8(hash);
+  }
+#endif
+
+  return longName;
 }
 
 QString serverName()


### PR DESCRIPTION
## Summary

- Fixes the IPC single-instance handoff being completely broken on macOS (#623).
- On macOS, `QLocalServer` places the socket file under `QDir::tempPath()` which expands to `/var/folders/<2>/<32>/T` (~51 chars). The previous server name `pythonscad.instance.<40-hex-sha1>` (60 chars) produced a combined socket path of ~111 chars, exceeding the 104-byte `sockaddr_un.sun_path` POSIX limit.
- When the temp-dir prefix would push the full path over 103 usable bytes, fall back to the shorter prefix `ps.` + full 40-char SHA-1 hex (43 chars total), keeping the socket path at ~94 chars on macOS. Linux and Windows are unaffected (`/tmp/` keeps the total at 65 chars).

## Test plan

- [x] Launch PythonSCAD from the terminal on macOS — confirm no "Could not start the local IPC server" warning
- [x] Launch a second instance from the terminal with a file argument — confirm the file opens in the existing window instead of showing "not responding"
- [x] Verify existing Linux behaviour unchanged (no regression in IPC single-instance)

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)