### PR TITLE
fix(gui): improve color contrast for Python branding text in dark mode

### DIFF
--- a/resources/html/AboutDialog.html
+++ b/resources/html/AboutDialog.html
@@ -9,6 +9,7 @@
     <!-- Don't know why the master style sheet on the QApplication isn't effective for this. -->
     <style>
         p { font-size: 9pt }
+        a { color: __PYTHON_BRAND_COLOR__; }
     </style>
 </head>
 

--- a/src/gui/AboutDialog.h
+++ b/src/gui/AboutDialog.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <QDialog>
+#include <QFile>
 #include <QString>
 #include <QWidget>
 #include <string>
 
+#include "gui/UIUtils.h"
 #include "gui/qtgettext.h"
 #include "ui_AboutDialog.h"
 #include "version.h"
@@ -19,9 +21,18 @@ public:
     setupUi(this);
     this->setWindowTitle(QString(_("About PythonSCAD")) + " " +
                          QString::fromStdString(std::string(openscad_shortversionnumber)));
-    QString tmp = this->aboutText->toHtml();
-    tmp.replace("__VERSION__", QString::fromStdString(std::string(openscad_detailedversionnumber)));
-    this->aboutText->setHtml(tmp);
+
+    QString titleText = this->titleLabel->text();
+    titleText.replace("__PYTHON_BRAND_COLOR__", UIUtils::pythonBrandColor);
+    this->titleLabel->setText(titleText);
+
+    QFile htmlFile(":/html/AboutDialog.html");
+    if (htmlFile.open(QIODevice::ReadOnly)) {
+      QString tmp = QString::fromUtf8(htmlFile.readAll());
+      tmp.replace("__VERSION__", QString::fromStdString(std::string(openscad_detailedversionnumber)));
+      tmp.replace("__PYTHON_BRAND_COLOR__", UIUtils::pythonBrandColor);
+      this->aboutText->setHtml(tmp);
+    }
   }
 
 public slots:

--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -9,7 +9,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>About Open(Python)SCAD</string>
+   <string>About PythonSCAD</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="margin">
@@ -55,7 +55,7 @@
       <widget class="QLabel" name="titleLabel">
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
-&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: green;&quot;&gt;Open&lt;/span&gt;&lt;span style=&quot;color: blue;&quot;&gt;(Python)&lt;/span&gt;SCAD&lt;/p&gt;
+&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: #306591;&quot;&gt;Python&lt;/span&gt;SCAD&lt;/p&gt;
 &lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;&quot;&gt;The Programmers Solid 3D CAD Modeller&lt;/p&gt;
 &lt;/body&gt;&lt;/html&gt;
 

--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -55,7 +55,7 @@
       <widget class="QLabel" name="titleLabel">
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
-&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: #306591;&quot;&gt;Python&lt;/span&gt;SCAD&lt;/p&gt;
+&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: __PYTHON_BRAND_COLOR__;&quot;&gt;Python&lt;/span&gt;SCAD&lt;/p&gt;
 &lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;&quot;&gt;The Programmers Solid 3D CAD Modeller&lt;/p&gt;
 &lt;/body&gt;&lt;/html&gt;
 

--- a/src/gui/LaunchingScreen.cc
+++ b/src/gui/LaunchingScreen.cc
@@ -39,6 +39,10 @@ LaunchingScreen::LaunchingScreen(QWidget *parent) : QDialog(parent)
   this->setStyleSheet(
     "QDialog {background-image:url(':/icons/background.png')} QPushButton {color:white;}");
 
+  QString brandingText = this->label_3->text();
+  brandingText.replace("__PYTHON_BRAND_COLOR__", UIUtils::pythonBrandColor);
+  this->label_3->setText(brandingText);
+
   this->versionNumberLabel->setText("PythonSCAD " +
                                     QString::fromStdString(std::string(openscad_displayversionnumber)));
 

--- a/src/gui/LaunchingScreen.ui
+++ b/src/gui/LaunchingScreen.ui
@@ -312,7 +312,7 @@ QPushButton:pressed {
        </property>
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
-		&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: blue;&quot;&gt;Python&lt;/span&gt;SCAD&lt;/p&gt;
+		&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: #306591;&quot;&gt;Python&lt;/span&gt;SCAD&lt;/p&gt;
 &lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;&quot;&gt;The Programmers Solid 3D CAD Modeller&lt;/p&gt;
 &lt;/body&gt;&lt;/html&gt;
 

--- a/src/gui/LaunchingScreen.ui
+++ b/src/gui/LaunchingScreen.ui
@@ -312,7 +312,7 @@ QPushButton:pressed {
        </property>
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
-		&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: #306591;&quot;&gt;Python&lt;/span&gt;SCAD&lt;/p&gt;
+		&lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;&quot;&gt;&lt;span style=&quot;color: __PYTHON_BRAND_COLOR__;&quot;&gt;Python&lt;/span&gt;SCAD&lt;/p&gt;
 &lt;p style=&quot;font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;&quot;&gt;The Programmers Solid 3D CAD Modeller&lt;/p&gt;
 &lt;/body&gt;&lt;/html&gt;
 

--- a/src/gui/UIUtils.h
+++ b/src/gui/UIUtils.h
@@ -56,6 +56,8 @@ struct ExampleEntry {
 
 static const int maxRecentFiles = 10;
 
+inline constexpr const char *pythonBrandColor = "#306591";
+
 QFileInfo openFile(QWidget *parent = nullptr, QStringList extensions = {});
 
 QFileInfoList openFiles(QWidget *parent = nullptr, QStringList extensions = {});


### PR DESCRIPTION
## Summary

- Replace hardcoded CSS named color `blue` (`#0000FF`) with `#306591` for the \"Python\" span in both the welcome screen ([LaunchingScreen.ui](src/gui/LaunchingScreen.ui)) and the about dialog ([AboutDialog.ui](src/gui/AboutDialog.ui))
- Update the about dialog title from `Open(Python)SCAD` to `PythonSCAD` (window title and title label) to align with the welcome screen branding
- Centralize the brand color as `UIUtils::pythonBrandColor` in [UIUtils.h](src/gui/UIUtils.h); both UI files and the HTML about page use a `__PYTHON_BRAND_COLOR__` placeholder resolved at runtime, so future color changes require editing one constant
- Apply the same brand color to all links in [AboutDialog.html](resources/html/AboutDialog.html) via a CSS `a { color }` rule; the HTML is now loaded directly from QRC resources (replacing the `QTextBrowser::toHtml()` round-trip, which would strip unknown CSS values)

Closes #375

## Test plan

- [x] Launch the application in light mode and verify \"Python\" text in the welcome screen is readable
- [x] Switch to dark mode and verify \"Python\" text in the welcome screen has adequate contrast
- [x] Open the About dialog in light mode and verify title and links use the brand color
- [x] Open the About dialog in dark mode and verify title and links have adequate contrast
- [x] Verify version string still appears correctly in the About dialog HTML body

🤖 Generated with [Claude Code](https://claude.com/claude-code)