### PR TITLE
fix(gui): route all compile/parse output to console widget

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3603,7 +3603,7 @@ void MainWindow::refreshParametersFromEditor()
     return;
   }
   if (!activeEditor) return;
-  setCurrentOutput();
+  auto guard = scopedSetCurrentOutput();
   parseTopLevelDocument(true);
 }
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1175,6 +1175,7 @@ void MainWindow::compile(bool reload, bool forcedone)
 
 void MainWindow::waitAfterReload()
 {
+  setCurrentOutput();
   no_exceptions_for_warnings();
   auto mtime = this->rootFile->handleDependencies();
   auto stop = would_have_thrown();
@@ -1400,6 +1401,7 @@ void MainWindow::compileCSGThread(void)
 }
 void MainWindow::compileCSGDone()
 {
+  setCurrentOutput();
 #ifdef ENABLE_PYTHON
   python_lock();
 #endif
@@ -3601,6 +3603,7 @@ void MainWindow::refreshParametersFromEditor()
     return;
   }
   if (!activeEditor) return;
+  setCurrentOutput();
   parseTopLevelDocument(true);
 }
 
@@ -3969,6 +3972,7 @@ void MainWindow::onTabManagerAboutToCloseEditor(EditorInterface *closingEditor)
 
 void MainWindow::onTabManagerEditorContentReloaded(EditorInterface *reloadedEditor)
 {
+  setCurrentOutput();
   // Opening/reloading sets editor text which arms parameterRefreshTimer; that debounced
   // parseTopLevelDocument() would call parseDocument() again (e.g. second Python trust dialog).
   if (parameterRefreshTimer) {


### PR DESCRIPTION
## Summary

Fixes #626 — compile and Python error messages were appearing in the terminal instead of the PythonSCAD console widget.

Several code paths that trigger compilation, CSG rendering, or file reloading were missing a `setCurrentOutput()` call. Without it, `PRINT_NOCACHE` falls through to `std::cerr` because `outputhandler` is `nullptr`.

**Four paths fixed:**

- **`refreshParametersFromEditor()`** — the 1 s debounced parse triggered by editor edits. This was the primary path for the Python syntax-error case reported in #626.
- **`compileCSGDone()`** — the async CSG-worker completion slot. By the time the worker signals done, the constructor's `scopedSetCurrentOutput` guard has already been torn down, so all render-summary messages ("Normalized tree has N elements!", "Compile and preview finished.", "Total rendering time: …") were going to the terminal.
- **`waitAfterReload()`** — timer-driven compile for include/library dependency updates; was calling `compile()` with no handler set.
- **`onTabManagerEditorContentReloaded()`** — file-reload slot that calls `parseDocument()`, which emits "Parser error: syntax error" for Python files processed through the OpenSCAD parser fallback.

In all four cases the fix is a single `setCurrentOutput()` call at the top of the function. The paired `clearCurrentOutput()` is already handled by `compileEnded()` at the end of every compile/render cycle.

## Test plan

- [x] Open a `.py` file with a Python syntax error; confirm the error appears in the **Console** dock, not the terminal
- [x] Confirm "Normalize tree has N elements!", "Compile and preview finished.", and "Total rendering time:" appear in the Console dock after a successful render, not the terminal
- [x] Edit a `.py` file in-editor, wait ~1 s for the debounced re-parse; confirm any error goes to the Console dock
- [x] Verify no regression for `.scad` files (errors and render messages still appear in Console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)