### PR TITLE
fix: resolve dangling pointer and free-nonheap-object bugs

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -423,14 +423,13 @@ std::unique_ptr<ExternalToolInterface> createExternalToolService(print_service_t
 void MainWindow::addMenuItemCB(QString callback)
 {
 #ifdef ENABLE_PYTHON
-  const char *cbstr = callback.toStdString().c_str();
   std::string content = loadInitFile();
   if (content.size() == 0) return;
   const auto& venv = venvBinDirFromSettings();
   const auto& binDir = venv.empty() ? PlatformUtils::applicationPath() : venv;
   initPython(binDir, "", nullptr);
   evaluatePython(content);
-  evaluatePython(cbstr);
+  evaluatePython(callback.toStdString());
   finishPython();
 #endif
 }

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -397,14 +397,12 @@ void export_debug_polyset(const PolySet& ps)
           ps->indices = vert;
   */
 
-  const PolySet psx(ps);
-
   Export3mfOptions options3mf;
   options3mf.decimalPrecision = 6;
   ExportInfo exportInfo = {.format = FileFormat::_3MF,
                            .sourceFilePath = "debug.3mf",
                            .options3mf = std::make_shared<Export3mfOptions>(options3mf)};
 
-  auto ss = std::shared_ptr<const Geometry>(&psx);
+  auto ss = std::make_shared<const PolySet>(ps);
   exportFileByName(ss, "debug.3mf", exportInfo);
 }


### PR DESCRIPTION
## Summary

Fixes two compiler-warned memory safety bugs from #644.

- **`src/gui/MainWindow.cc:426`**: Removed dangling `cbstr` pointer. `callback.toStdString()` returned a temporary whose `.c_str()` became invalid immediately. Since `evaluatePython` accepts `const std::string&`, we now pass `callback.toStdString()` directly, eliminating the intermediate variable entirely.
- **`src/io/export.cc:408`**: Replaced `std::shared_ptr<const Geometry>(&psx)` (wrapping a stack-allocated object) with `std::make_shared<const PolySet>(ps)`. The old code would call `delete` on a stack address when the shared_ptr destructed. The new one-liner allocates on the heap and removes the redundant `psx` copy.

Both fixes address warnings surfaced in CI:
- macOS: `-Wdangling-gsl`
- Windows: `-Wfree-nonheap-object`

## Test plan

- [x] Build passes without the two warnings on macOS and Windows CI
- [x] `ctest -j8` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)