### PR TITLE
refactor: replace anonymous typedef structs with named structs in export_foldable.h

### DIFF
--- a/src/io/export_foldable.h
+++ b/src/io/export_foldable.h
@@ -1,42 +1,42 @@
 
-typedef struct {
+struct lineS {
   Vector2d p1;
   Vector2d p2;
   int dashed = 0;
-} lineS;
+};
 
-typedef struct {
+struct labelS {
   Vector2d pt;
   double rot;
   double size;
   char text[10];
-} labelS;
+};
 
-typedef struct {
+struct sheetS {
   Vector2d min, max;
   std::vector<lineS> lines;
   std::vector<labelS> label;
-} sheetS;
+};
 
-typedef struct {
+struct plotSettingsS {
   double lasche;
   double rand;
   const char *paperformat;
   double paperwidth, paperheight;
   int bestend;
-} plotSettingsS;
+};
 
-typedef struct {
+struct plateS {
   std::vector<Vector2d> pt;     // actual points
   std::vector<Vector2d> pt_l1;  // leap starts
   std::vector<Vector2d> pt_l2;  // leap ends
   std::vector<Vector2d> bnd;    // Complete boundary representing points and leps
   int done;
-} plateS;
+};
 
-typedef struct {
+struct connS {
   unsigned int p1, f1, p2, f2;
   int done;
-} connS;
+};
 
 std::vector<sheetS> fold_3d(std::shared_ptr<const PolySet> ps, const plotSettingsS& plot_s);


### PR DESCRIPTION
## Summary

Fixes #646.

All six `typedef struct { ... } nameS;` definitions in `src/io/export_foldable.h` used anonymous structs with C-style typedefs. Because the structs contain C++ types (`std::vector`, default member initializers), they are non-C-compatible, which triggers `-Wnon-c-typedef-for-linkage` on macOS and Windows CI.

Each definition is replaced with an equivalent named `struct nameS { ... };`, which is the correct modern C++ style and eliminates the warning.

No behaviour change — the struct names (`lineS`, `labelS`, `sheetS`, `plotSettingsS`, `plateS`, `connS`) are unchanged, so all three includers (`export_pdf.cc`, `export_ps.cc`, `export_foldable.cc`) require no modification.

## Test plan

- [ ] Build passes without `-Wnon-c-typedef-for-linkage` warnings on macOS and Windows CI
- [ ] `ctest -j8` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)