### PR TITLE
fix(macos): replace deprecated kUTTypePNG with CFSTR("public.png")

### DIFF
--- a/src/io/imageutils-macosx.cc
+++ b/src/io/imageutils-macosx.cc
@@ -69,7 +69,7 @@ bool write_png(std::ostream& output, unsigned char *pixels, int width, int heigh
 
   const CFIndex fileImageIndex = 1;
   CFMutableDictionaryRef fileDict = nullptr;
-  CFStringRef fileUTType = kUTTypePNG;
+  CFStringRef fileUTType = CFSTR("public.png");
   // Create an image destination opaque reference for authoring an image file
   CGImageDestinationRef imageDest =
     CGImageDestinationCreateWithDataConsumer(dataconsumer, fileUTType, fileImageIndex, fileDict);


### PR DESCRIPTION
## Summary

Fixes #647.

`kUTTypePNG` was deprecated in macOS 12.0 and triggers `-Wdeprecated-declarations` in CI builds. The constant is simply a `CFStringRef` wrapping the UTI string `"public.png"`, so it can be replaced directly with `CFSTR("public.png")` — no semantic change, no new framework imports, no `@available` guards needed.

The alternative (`UTTypePNG` from `<UniformTypeIdentifiers/UniformTypeIdentifiers.h>`) is Objective-C and only available from macOS 11+, which would require a bridged cast and an availability check. Using the raw UTI string is simpler and equally correct.

**File changed:** `src/io/imageutils-macosx.cc:72`

## Test plan

- [ ] macOS CI build passes without `-Wdeprecated-declarations` warning at `imageutils-macosx.cc:72`
- [ ] PNG export still works correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)