### PR TITLE
fix: improve error handling and string comparisons

### DIFF
--- a/src/gui/OctoPrint.cc
+++ b/src/gui/OctoPrint.cc
@@ -167,7 +167,11 @@ const QString OctoPrint::upload(const QString& exportFileName, const QString& fi
   filePart.setHeader(QNetworkRequest::ContentTypeHeader, QVariant{"application/octet-stream"});
 
   auto *file = new QFile(exportFileName, multiPart);
-  file->open(QIODevice::ReadOnly);
+  if (!file->open(QIODevice::ReadOnly)) {
+    qWarning() << "Failed to open file:" << file->fileName();
+    delete multiPart;
+    return {};
+  }
   filePart.setBodyDevice(file);
 
   multiPart->append(filePart);

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1047,11 +1047,6 @@ void ScintillaEditor::uncommentSelection()
       qsci->setSelection(line, 0, line, strlen(commentString));
       qsci->removeSelectedText();
     }
-    // Handles the case where there's a comment without space
-    else if (commentString == "# " && lineText.startsWith("#")) {
-      qsci->setSelection(line, 0, line, 1);
-      qsci->removeSelectedText();
-    }
   }
   if (hasSelection) {
     qsci->setSelection(lineFrom, 0, lineTo, std::max(0, qsci->lineLength(lineTo) - 1));


### PR DESCRIPTION
## Summary

Fixes #648 — two error handling issues in GUI code.

**1. OctoPrint.cc:170** — Unchecked return value on `file->open()`:
In Qt 6, `QIODevice::open()` is marked with `[[nodiscard]]` attribute. The code was ignoring the return value, so file open failures went undetected. Now checks the return value, logs a warning if it fails, and returns an empty string (consistent with other failure paths in the codebase).

**2. ScintillaEditor.cc:1051** — Unreachable code due to pointer comparison bug:
The original code attempted to compare `commentString` (a `const char*`) to a string literal using `==`, which compares pointer addresses. The entire `else if` branch was unreachable since the first `if` already handles all cases (commentString is either "//" or "#", both without spaces). Removed the unreachable branch and its misleading comment.

**Files changed:** `src/gui/OctoPrint.cc`, `src/gui/ScintillaEditor.cc`

## Test plan

- [ ] macOS CI build passes without the two warnings at OctoPrint.cc:170 and ScintillaEditor.cc:1051
- [ ] Comment/uncomment functionality still works correctly in editor
- [ ] OctoPrint upload handles file open failures gracefully (with warning log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)