### PR TITLE
fix(csg): handle missing CONCAT case in CSGTreeEvaluator switch

### DIFF
--- a/src/core/CSGTreeEvaluator.cc
+++ b/src/core/CSGTreeEvaluator.cc
@@ -116,6 +116,7 @@ void CSGTreeEvaluator::applyToChildren(State& state, const AbstractNode& node, O
           }
         }
         break;
+      case OpenSCADOperator::CONCAT:
       case OpenSCADOperator::UNION:
         if (t != t1 && t != t2 && t1->isHighlight() && t2->isHighlight()) {
           t->setHighlight(true);


### PR DESCRIPTION
A switch statement on an enum doesn't handle the CONCAT case, which will fall through to default behavior.
CONCAT should be handled exactly like UNION and this PR will add this.

Closes #645.