### PR TITLE
fix(gui): remove automatic parameter refresh timer

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -5004,8 +5004,16 @@ void MainWindow::openRemainingFiles(const QStringList& filenames)
     // populates the customizer once.
     QTimer::singleShot(0, this, [this]() {
       if (activeEditor && !GuiLocker::isLocked()) {
-        auto guard = scopedSetCurrentOutput();
-        parseTopLevelDocument(true);
+        try {
+          auto guard = scopedSetCurrentOutput();
+          parseTopLevelDocument(true);
+        } catch (const HardWarningException&) {
+          exceptionCleanup();
+        } catch (const std::exception& ex) {
+          UnknownExceptionCleanup(ex.what());
+        } catch (...) {
+          UnknownExceptionCleanup();
+        }
       }
     });
   }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3588,22 +3588,7 @@ void MainWindow::editorContentChanged()
 
     // removes the live selection feedbacks in both the 3d view and editor.
     clearAllSelectionIndicators();
-
-    // debounced refresh of customizer parameters so they show without F5
-    parameterRefreshTimer->start();
   }
-}
-
-void MainWindow::refreshParametersFromEditor()
-{
-  if (isClosing || isBeingDestroyed) return;
-  if (GuiLocker::isLocked()) {
-    if (parameterRefreshTimer) parameterRefreshTimer->start();
-    return;
-  }
-  if (!activeEditor) return;
-  auto guard = scopedSetCurrentOutput();
-  parseTopLevelDocument(true);
 }
 
 void MainWindow::on_viewActionTop_triggered()
@@ -3972,11 +3957,6 @@ void MainWindow::onTabManagerAboutToCloseEditor(EditorInterface *closingEditor)
 void MainWindow::onTabManagerEditorContentReloaded(EditorInterface *reloadedEditor)
 {
   setCurrentOutput();
-  // Opening/reloading sets editor text which arms parameterRefreshTimer; that debounced
-  // parseTopLevelDocument() would call parseDocument() again (e.g. second Python trust dialog).
-  if (parameterRefreshTimer) {
-    parameterRefreshTimer->stop();
-  }
   try {
     // when a new editor is created, it is important to compile the initial geometry
     // so the customizer panels are ok.
@@ -4396,11 +4376,6 @@ void MainWindow::setupCoreSubsystems()
   consoleUpdater->setSingleShot(true);
   connect(consoleUpdater, &QTimer::timeout, this->console, &Console::update);
   this->consoleUpdater->start(0);  // Show initial messages immediately
-
-  parameterRefreshTimer = new QTimer(this);
-  parameterRefreshTimer->setSingleShot(true);
-  parameterRefreshTimer->setInterval(1000);
-  connect(parameterRefreshTimer, &QTimer::timeout, this, &MainWindow::refreshParametersFromEditor);
 
   progressThrottle->start();
 }
@@ -5019,11 +4994,20 @@ void MainWindow::openRemainingFiles(const QStringList& filenames)
       if (ok) windowIndex = parsedIndex;
     }
     tabManager->restoreSession(TabManager::getSessionFilePath(), windowIndex);
-    // Note: do NOT call parseTopLevelDocument() here.
-    // restoreSession() -> tabSwitched() -> onTabManagerEditorChanged() already
-    // triggers actionRenderPreview() which compiles the document and initializes
-    // Python. Calling parseTopLevelDocument() again would re-enter initPython()
-    // after the CSG worker has released the GIL, causing a crash.
+    // After restore, populate the customizer via a single dry-run parse.
+    // We use QTimer::singleShot(0) to defer until after the event loop has
+    // processed the compile triggered by tabSwitched()->onTabManagerEditorChanged(),
+    // avoiding a re-entrant initPython() call while the CSG worker holds the GIL.
+    // If auto-reload is on, parseTopLevelDocument() was already called synchronously
+    // inside compile(), so GuiLocker will be locked (CSG thread running) and we skip.
+    // If auto-reload is off, no compile runs, GuiLocker is free, and the dry-run
+    // populates the customizer once.
+    QTimer::singleShot(0, this, [this]() {
+      if (activeEditor && !GuiLocker::isLocked()) {
+        auto guard = scopedSetCurrentOutput();
+        parseTopLevelDocument(true);
+      }
+    });
   }
 
   activeEditor->setFocus();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -88,7 +88,6 @@ public:
 
   QTimer *autoReloadTimer;
   QTimer *waitAfterReloadTimer;
-  QTimer *parameterRefreshTimer;
   RenderStatistic renderStatistic;
 
   std::shared_ptr<SourceFile> rootFile;            // Result of parsing
@@ -457,7 +456,6 @@ public slots:
   void on_viewActionResetView_triggered();
   void on_viewActionViewAll_triggered();
   void editorContentChanged();
-  void refreshParametersFromEditor();
   void leftClick(QPoint coordinate);
   void rightClick(QPoint coordinate);
   void dragEnterEvent(QDragEnterEvent *event) override;


### PR DESCRIPTION
## Summary

**Problem:** When typing code in PythonSCAD, the editor evaluates incomplete/syntactically invalid code every 1 second, producing spurious error messages in the console (issue #370).

**Root cause:** The `parameterRefreshTimer` (added in PR #415 to populate the customizer without F5) was evaluating code whenever the user paused typing.

**Solution:** 
- Remove the automatic 1-second debounced timer entirely (restores OpenSCAD's behavior)
- Call `parseTopLevelDocument(true)` once after session restore, deferred via `QTimer::singleShot(0)` to avoid re-entrant Python initialization
- This preserves the session restore customizer value restoration while eliminating the typing-time errors

## How it works

When session restore fires `tabSwitched()`:
- If auto-reload is **enabled**: `onTabManagerEditorChanged()` → `actionRenderPreview()` → `compile()` → `parseTopLevelDocument()` already runs synchronously, populating the customizer. Our deferred lambda checks `GuiLocker::isLocked()` and skips (already done).
- If auto-reload is **disabled**: No compile runs, `GuiLocker` is free, the deferred lambda fires cleanly and populates the customizer once.

## Testing

- [x] Build succeeds
- [x] Session restore populates customizer with saved values (both auto-reload on/off)
- [x] Typing incomplete code produces no error messages in console
- [x] F5/F6 render still works correctly
- [x] Pre-commit hooks pass

Fixes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)