### PR TITLE
fix(ci): harden workflows — permissions, template-injection, shellcheck, hash-pin (#613)

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,6 +7,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   assign:
     permissions:

--- a/.github/workflows/beautify.yml
+++ b/.github/workflows/beautify.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+
 jobs:
   Beautify:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -124,7 +124,7 @@ jobs:
           echo "AppImage not found: $APPIMAGE_FILE"
           exit 1
         fi
-        if ! sudo apt-get update -qq; then true; fi
+        sudo apt-get update -qq || true
         sudo apt-get install -y -qq gnupg 2>/dev/null || true
         export GNUPGHOME="${HOME}/.gnupg"
         mkdir -p "$GNUPGHOME"

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -157,7 +157,8 @@ jobs:
         STEPS_APPIMAGE_OUTPUTS_FILEPATH: ${{ steps.appimage.outputs.filepath }}
         STEPS_SIGN_OUTPUTS_ASC_PATH: ${{ steps.sign.outputs.asc_path }}
       run: |
-        gh release upload "$RELEASE_TAG" \
-          "$STEPS_APPIMAGE_OUTPUTS_FILEPATH" \
-          ${STEPS_SIGN_OUTPUTS_ASC_PATH:+"$STEPS_SIGN_OUTPUTS_ASC_PATH"} \
-          --clobber
+        UPLOAD_ARGS=("$STEPS_APPIMAGE_OUTPUTS_FILEPATH")
+        if [ -n "$STEPS_SIGN_OUTPUTS_ASC_PATH" ]; then
+          UPLOAD_ARGS+=("$STEPS_SIGN_OUTPUTS_ASC_PATH")
+        fi
+        gh release upload "$RELEASE_TAG" "${UPLOAD_ARGS[@]}" --clobber

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -150,11 +150,13 @@ jobs:
 
     - name: Upload AppImage to release
       if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
-      uses: softprops/action-gh-release@v3
-      with:
-        files: |
-          ${{ steps.appimage.outputs.filepath }}
-          ${{ steps.sign.outputs.asc_path }}
-        tag_name: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
+        STEPS_APPIMAGE_OUTPUTS_FILEPATH: ${{ steps.appimage.outputs.filepath }}
+        STEPS_SIGN_OUTPUTS_ASC_PATH: ${{ steps.sign.outputs.asc_path }}
+      run: |
+        gh release upload "$RELEASE_TAG" \
+          "$STEPS_APPIMAGE_OUTPUTS_FILEPATH" \
+          ${STEPS_SIGN_OUTPUTS_ASC_PATH:+"$STEPS_SIGN_OUTPUTS_ASC_PATH"} \
+          --clobber

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -105,9 +105,9 @@ jobs:
     - name: Get AppImage filename
       id: appimage
       run: |
-        APPIMAGE_FILE=$(ls dist/PythonSCAD-*.AppImage | head -1)
-        echo "filename=$(basename ${APPIMAGE_FILE})" >> $GITHUB_OUTPUT
-        echo "filepath=${APPIMAGE_FILE}" >> $GITHUB_OUTPUT
+        APPIMAGE_FILE=$(find dist -maxdepth 1 -name 'PythonSCAD-*.AppImage' | head -1)
+        echo "filename=$(basename "${APPIMAGE_FILE}")" >> "$GITHUB_OUTPUT"
+        echo "filepath=${APPIMAGE_FILE}" >> "$GITHUB_OUTPUT"
 
     - name: Sign AppImage (release only)
       id: sign
@@ -124,7 +124,8 @@ jobs:
           echo "AppImage not found: $APPIMAGE_FILE"
           exit 1
         fi
-        sudo apt-get update -qq && sudo apt-get install -y -qq gnupg 2>/dev/null || true
+        if ! sudo apt-get update -qq; then true; fi
+        sudo apt-get install -y -qq gnupg 2>/dev/null || true
         export GNUPGHOME="${HOME}/.gnupg"
         mkdir -p "$GNUPGHOME"
         chmod 700 "$GNUPGHOME"
@@ -139,7 +140,7 @@ jobs:
           -u "$GPG_KEY_ID" --detach-sign --armor "$APPIMAGE_FILE"
         echo "Signed: ${APPIMAGE_FILE}.asc"
         gpg --verify "${APPIMAGE_FILE}.asc" "$APPIMAGE_FILE"
-        echo "asc_path=${APPIMAGE_FILE}.asc" >> $GITHUB_OUTPUT
+        echo "asc_path=${APPIMAGE_FILE}.asc" >> "$GITHUB_OUTPUT"
 
     - name: Upload AppImage as artifact
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -106,6 +106,10 @@ jobs:
       id: appimage
       run: |
         APPIMAGE_FILE=$(find dist -maxdepth 1 -name 'PythonSCAD-*.AppImage' | head -1)
+        if [ -z "$APPIMAGE_FILE" ] || [ ! -f "$APPIMAGE_FILE" ]; then
+          echo "ERROR: No AppImage found in dist/" >&2
+          exit 1
+        fi
         echo "filename=$(basename "${APPIMAGE_FILE}")" >> "$GITHUB_OUTPUT"
         echo "filepath=${APPIMAGE_FILE}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -15,10 +15,15 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build-appimage:
     name: Build AppImage (Qt${{ matrix.qt_version }} / ${{ matrix.arch }})
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -90,7 +90,10 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     # Note: Don't use container field for ARM64 - it pulls amd64 images
     # ARM64 builds use explicit docker run with --platform flag
-    container: ${{ matrix.arch == 'amd64' && matrix.docker_image || null }} # zizmor: ignore[unpinned-images]
+    # zizmor: ignore[unpinned-images] — images are tag-pinned in
+    # supported-distributions.json (e.g. ubuntu:jammy), not digest-pinned.
+    # Accepted risk; digest-pinning is tracked in #663.
+    container: ${{ matrix.arch == 'amd64' && matrix.docker_image || null }}
 
     steps:
       - name: Ensure git and gh CLI are available (amd64 container)

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -108,7 +108,7 @@ jobs:
             > /etc/apt/sources.list.d/github-cli.list
           apt-get update
           apt-get install -y gh
-          git config --global --add safe.directory '*'
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -288,8 +288,8 @@ jobs:
       - name: Get version for release upload
         id: version
         run: |
-          VERSION=$(cat VERSION.txt | tr -d '\n' | tr -d '\r')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION=$(tr -d '\n\r' < VERSION.txt)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Rename package for GitHub Release (family + distro + arch)
         env:
@@ -298,7 +298,7 @@ jobs:
           MATRIX_DISTRO: ${{ matrix.distro }}
           MATRIX_ARCH: ${{ matrix.arch }}
         run: |
-          DEB_FILE=$(ls /tmp/debs/pythonscad_*.deb | head -1)
+          DEB_FILE=$(find /tmp/debs -maxdepth 1 -name 'pythonscad_*.deb' | head -1)
           if [ -z "$DEB_FILE" ]; then
             echo "Error: No .deb file found"
             exit 1

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -333,12 +333,10 @@ jobs:
 
       - name: Upload to GitHub Release
         if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
-        uses: softprops/action-gh-release@v3
-        with:
-          files: /tmp/debs/pythonscad_*.deb
-          tag_name: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
+        run: gh release upload "$RELEASE_TAG" /tmp/debs/pythonscad_*.deb --clobber
 
   publish-apt-repo:
     name: Publish APT repository to SFTP

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -100,7 +100,7 @@ jobs:
           apt-get install -y git ca-certificates curl
           # Install gh CLI so the release-upload step works inside the container
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-            | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            -o /usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
             > /etc/apt/sources.list.d/github-cli.list
           apt-get update

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -85,7 +85,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     # Note: Don't use container field for ARM64 - it pulls amd64 images
     # ARM64 builds use explicit docker run with --platform flag
-    container: ${{ matrix.arch == 'amd64' && matrix.docker_image || null }}
+    container: ${{ matrix.arch == 'amd64' && matrix.docker_image || null }} # zizmor: ignore[unpinned-images]
 
     steps:
       - name: Ensure git is available and configure (amd64 container)

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -126,17 +126,18 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
           TZ: Etc/UTC
+          MATRIX_DISTRO: ${{ matrix.distro }}
         run: |
           sudo apt-get update
 
           # Determine Qt profile based on distribution version
           # Older distros (Ubuntu 22.04, Debian 11) use Qt5, newer use Qt6
-          if [ "${{ matrix.distro }}" = "jammy" ] || [ "${{ matrix.distro }}" = "bullseye" ]; then
+          if [ "$MATRIX_DISTRO" = "jammy" ] || [ "$MATRIX_DISTRO" = "bullseye" ]; then
             QT_PROFILE="pythonscad-qt5"
           else
             QT_PROFILE="pythonscad-qt6"
           fi
-          echo "Using profile: $QT_PROFILE for ${{ matrix.distro }}"
+          echo "Using profile: $QT_PROFILE for $MATRIX_DISTRO"
 
           # Install base dependencies using get-dependencies
           sudo ./scripts/get-dependencies.py --yes --profile "$QT_PROFILE"
@@ -155,6 +156,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
           TZ: Etc/UTC
+          MATRIX_DISTRO: ${{ matrix.distro }}
         run: |
           apt-get update
           # Install git and Python first (needed for uni-get-dependencies)
@@ -162,12 +164,12 @@ jobs:
 
           # Determine Qt profile based on distribution version
           # Older distros (Ubuntu 22.04, Debian 11) use Qt5, newer use Qt6
-          if [ "${{ matrix.distro }}" = "jammy" ] || [ "${{ matrix.distro }}" = "bullseye" ]; then
+          if [ "$MATRIX_DISTRO" = "jammy" ] || [ "$MATRIX_DISTRO" = "bullseye" ]; then
             QT_PROFILE="pythonscad-qt5"
           else
             QT_PROFILE="pythonscad-qt6"
           fi
-          echo "Using profile: $QT_PROFILE for ${{ matrix.distro }}"
+          echo "Using profile: $QT_PROFILE for $MATRIX_DISTRO"
 
           # Install base dependencies using get-dependencies (running as root, no sudo needed)
           ./scripts/get-dependencies.py --yes --profile "$QT_PROFILE"
@@ -285,6 +287,11 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Rename package for GitHub Release (family + distro + arch)
+        env:
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
+          MATRIX_FAMILY: ${{ matrix.family }}
+          MATRIX_DISTRO: ${{ matrix.distro }}
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
           DEB_FILE=$(ls /tmp/debs/pythonscad_*.deb | head -1)
           if [ -z "$DEB_FILE" ]; then
@@ -292,8 +299,8 @@ jobs:
             exit 1
           fi
 
-          VERSION="${{ steps.version.outputs.version }}"
-          NEW_NAME="pythonscad_${VERSION}-1_${{ matrix.family }}_${{ matrix.distro }}_${{ matrix.arch }}.deb"
+          VERSION="${STEPS_VERSION_OUTPUTS_VERSION}"
+          NEW_NAME="pythonscad_${VERSION}-1_${MATRIX_FAMILY}_${MATRIX_DISTRO}_${MATRIX_ARCH}.deb"
           mv "$DEB_FILE" "/tmp/debs/$NEW_NAME"
           ls -lh /tmp/debs/
 

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -19,6 +19,9 @@ concurrency:
   group: publish-apt-repo
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   prepare-matrix:
     name: Prepare build matrix from supported distributions
@@ -80,6 +83,8 @@ jobs:
     name: Build .deb (${{ matrix.family }} / ${{ matrix.distro }} / ${{ matrix.arch }})
     needs: prepare-matrix
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -93,11 +93,18 @@ jobs:
     container: ${{ matrix.arch == 'amd64' && matrix.docker_image || null }} # zizmor: ignore[unpinned-images]
 
     steps:
-      - name: Ensure git is available and configure (amd64 container)
+      - name: Ensure git and gh CLI are available (amd64 container)
         if: matrix.arch == 'amd64' && matrix.docker_image
         run: |
           apt-get update
-          apt-get install -y git ca-certificates
+          apt-get install -y git ca-certificates curl
+          # Install gh CLI so the release-upload step works inside the container
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            > /etc/apt/sources.list.d/github-cli.list
+          apt-get update
+          apt-get install -y gh
           git config --global --add safe.directory '*'
 
       - name: Checkout code

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -82,7 +82,7 @@ jobs:
             -DUSE_BUILTIN_MANIFOLD=ON
 
           # Build
-          make -j$NUMCPU
+          make -j"$NUMCPU"
 
           # Find the app bundle
           APP_BUNDLE=$(find . -maxdepth 1 -name "*.app" -type d | head -1)
@@ -134,8 +134,8 @@ jobs:
             echo "ERROR: No .app bundle found in build_MACOSX"
             exit 1
           fi
-          echo "app_bundle=$APP_BUNDLE" >> $GITHUB_OUTPUT
-          echo "app_name=$(basename $APP_BUNDLE)" >> $GITHUB_OUTPUT
+          echo "app_bundle=$APP_BUNDLE" >> "$GITHUB_OUTPUT"
+          echo "app_name=$(basename "$APP_BUNDLE")" >> "$GITHUB_OUTPUT"
           echo "Found app bundle: $APP_BUNDLE"
 
       - name: Bundle runtime Python deps (IPython) into .app
@@ -234,7 +234,7 @@ jobs:
             -DUSE_BUILTIN_MANIFOLD=ON
 
           # Build
-          make -j$NUMCPU
+          make -j"$NUMCPU"
 
           # Find the app bundle
           APP_BUNDLE=$(find . -maxdepth 1 -name "*.app" -type d | head -1)
@@ -286,8 +286,8 @@ jobs:
             echo "ERROR: No .app bundle found in build_MACOSX"
             exit 1
           fi
-          echo "app_bundle=$APP_BUNDLE" >> $GITHUB_OUTPUT
-          echo "app_name=$(basename $APP_BUNDLE)" >> $GITHUB_OUTPUT
+          echo "app_bundle=$APP_BUNDLE" >> "$GITHUB_OUTPUT"
+          echo "app_name=$(basename "$APP_BUNDLE")" >> "$GITHUB_OUTPUT"
           echo "Found app bundle: $APP_BUNDLE"
 
       - name: Bundle runtime Python deps (IPython) into .app
@@ -427,10 +427,10 @@ jobs:
           # Debug: List frameworks in each bundle
           echo "=== Debug: x86_64 frameworks ==="
           if [ -d "$X86_BUNDLE/Contents/Frameworks" ]; then
-            find "$X86_BUNDLE/Contents/Frameworks" -name "*.framework" -type d -maxdepth 1 2>/dev/null | while read fw; do
+            find "$X86_BUNDLE/Contents/Frameworks" -name "*.framework" -type d -maxdepth 1 2>/dev/null | while IFS= read -r fw; do
               fw_name=$(basename "$fw" .framework)
               # Find actual version directory instead of using Current symlink
-              ACTUAL_VER=$(ls "$fw/Versions/" 2>/dev/null | grep -v "Current" | head -1)
+              ACTUAL_VER=$(find "$fw/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" -exec basename {} \; 2>/dev/null | head -1)
               if [ -n "$ACTUAL_VER" ] && [ -f "$fw/Versions/$ACTUAL_VER/$fw_name" ]; then
                 echo "$(basename "$fw"): $(lipo -info "$fw/Versions/$ACTUAL_VER/$fw_name" 2>&1 | grep -o 'x86_64\|arm64' | tr '\n' ' ')"
               fi
@@ -438,10 +438,10 @@ jobs:
           fi
           echo "=== Debug: arm64 frameworks ==="
           if [ -d "$ARM_BUNDLE/Contents/Frameworks" ]; then
-            find "$ARM_BUNDLE/Contents/Frameworks" -name "*.framework" -type d -maxdepth 1 2>/dev/null | while read fw; do
+            find "$ARM_BUNDLE/Contents/Frameworks" -name "*.framework" -type d -maxdepth 1 2>/dev/null | while IFS= read -r fw; do
               fw_name=$(basename "$fw" .framework)
               # Find actual version directory instead of using Current symlink
-              ACTUAL_VER=$(ls "$fw/Versions/" 2>/dev/null | grep -v "Current" | head -1)
+              ACTUAL_VER=$(find "$fw/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" -exec basename {} \; 2>/dev/null | head -1)
               if [ -n "$ACTUAL_VER" ] && [ -f "$fw/Versions/$ACTUAL_VER/$fw_name" ]; then
                 echo "$(basename "$fw"): $(lipo -info "$fw/Versions/$ACTUAL_VER/$fw_name" 2>&1 | grep -o 'x86_64\|arm64' | tr '\n' ' ')"
               fi
@@ -483,7 +483,7 @@ jobs:
             DYLIB_PATHS=$(echo -e "$DYLIB_PATHS\n$ARM_DYLIBS" | sort -u)
           fi
 
-          echo "$DYLIB_PATHS" | while read rel_path; do
+          echo "$DYLIB_PATHS" | while IFS= read -r rel_path; do
             [ -z "$rel_path" ] && continue
             x86_file="$X86_BUNDLE/$rel_path"
             arm_file="$ARM_BUNDLE/$rel_path"
@@ -515,7 +515,7 @@ jobs:
             FRAMEWORK_PATHS=$(echo -e "$FRAMEWORK_PATHS\n$ARM_FRAMEWORKS" | sort -u)
           fi
 
-          echo "$FRAMEWORK_PATHS" | while read framework_rel; do
+          echo "$FRAMEWORK_PATHS" | while IFS= read -r framework_rel; do
             [ -z "$framework_rel" ] && continue
             framework_name=$(basename "$framework_rel" .framework)
 
@@ -535,7 +535,7 @@ jobs:
             # Qt frameworks have binary at: QtCore.framework/Versions/A/QtCore
             # Find the actual version directory (usually 'A') instead of using 'Current' symlink
             if [ -d "$x86_framework/Versions" ]; then
-              ACTUAL_VERSION=$(ls "$x86_framework/Versions/" 2>/dev/null | grep -v "Current" | head -1)
+              ACTUAL_VERSION=$(find "$x86_framework/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" 2>/dev/null | head -1 | xargs -I{} basename {})
               if [ -n "$ACTUAL_VERSION" ]; then
                 framework_binary="Versions/$ACTUAL_VERSION/$framework_name"
                 if [ -f "$x86_framework/$framework_binary" ]; then
@@ -551,8 +551,8 @@ jobs:
 
                 # Also merge framework Resources if they contain binaries
                 if [ -d "$x86_framework/Versions/$ACTUAL_VERSION" ]; then
-                  find "$x86_framework/Versions/$ACTUAL_VERSION" -name "*.dylib" -type f 2>/dev/null | while read lib; do
-                    lib_rel="${lib#$x86_framework/}"
+                  find "$x86_framework/Versions/$ACTUAL_VERSION" -name "*.dylib" -type f 2>/dev/null | while IFS= read -r lib; do
+                    lib_rel="${lib#"$x86_framework/"}"
                     x86_lib="$x86_framework/$lib_rel"
                     arm_lib="$arm_framework/$lib_rel"
                     merged_lib="$merged_framework/$lib_rel"
@@ -582,9 +582,9 @@ jobs:
               cp -R "$arm_python" "$MERGED_DIR/$APP_NAME/Contents/Frameworks/"
             elif [ -d "$x86_python" ] && [ -d "$arm_python" ]; then
               # In both - merge binaries
-              PYTHON_VERSION=$(ls "$x86_python/Versions/" 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
+              PYTHON_VERSION=$(find "$x86_python/Versions/" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
               if [ -z "$PYTHON_VERSION" ]; then
-                PYTHON_VERSION=$(ls "$arm_python/Versions/" 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
+                PYTHON_VERSION=$(find "$arm_python/Versions/" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
               fi
 
               if [ -n "$PYTHON_VERSION" ]; then
@@ -602,8 +602,8 @@ jobs:
                 fi
 
                 # Merge Python extension modules (.so files)
-                find "$x86_python" -name "*.so" -type f 2>/dev/null | while read so_file; do
-                  rel_path="${so_file#$x86_python/}"
+                find "$x86_python" -name "*.so" -type f 2>/dev/null | while IFS= read -r so_file; do
+                  rel_path="${so_file#"$x86_python/"}"
                   x86_so="$x86_python/$rel_path"
                   arm_so="$arm_python/$rel_path"
                   merged_so="$MERGED_DIR/$APP_NAME/Contents/Frameworks/Python.framework/$rel_path"
@@ -644,7 +644,7 @@ jobs:
             PLUGIN_PATHS=$(echo -e "$PLUGIN_PATHS\n$ARM_PLUGINS" | sort -u)
           fi
 
-          echo "$PLUGIN_PATHS" | while read rel_path; do
+          echo "$PLUGIN_PATHS" | while IFS= read -r rel_path; do
             [ -z "$rel_path" ] && continue
             x86_plugin="$X86_BUNDLE/$rel_path"
             arm_plugin="$ARM_BUNDLE/$rel_path"
@@ -718,8 +718,8 @@ jobs:
               "$FRAMEWORKS_DIR/libbrotlicommon.1.dylib"
           fi
 
-          echo "app_bundle=$MERGED_DIR/$APP_NAME" >> $GITHUB_OUTPUT
-          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+          echo "app_bundle=$MERGED_DIR/$APP_NAME" >> "$GITHUB_OUTPUT"
+          echo "app_name=$APP_NAME" >> "$GITHUB_OUTPUT"
 
           # Verify main executable is universal
           echo "=== Verifying main executable ==="
@@ -779,12 +779,12 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           if [ -z "$BUILD_CERTIFICATE_BASE64" ]; then
-            echo "cert_installed=false" >> $GITHUB_OUTPUT
+            echo "cert_installed=false" >> "$GITHUB_OUTPUT"
             echo "No BUILD_CERTIFICATE_BASE64 secret set; skipping certificate install (ad-hoc signing will be used)."
             exit 0
           fi
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
@@ -792,7 +792,7 @@ jobs:
           security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH"
-          echo "cert_installed=true" >> $GITHUB_OUTPUT
+          echo "cert_installed=true" >> "$GITHUB_OUTPUT"
           echo "Apple code signing certificate installed."
 
       - name: Fix app bundle for macOS distribution
@@ -805,10 +805,10 @@ jobs:
           EXEC_NAME=$(basename "$APP_BUNDLE" .app)
           if [ "${STEPS_INSTALL_CERT_OUTPUTS_CERT_INSTALLED}" = "true" ] && [ -n "$SIGNING_IDENTITY" ]; then
             SIGN_ID="$SIGNING_IDENTITY"
-            CODESIGN_EXTRA="--timestamp --options runtime"
+            CODESIGN_EXTRA=(--timestamp --options runtime)
           else
             SIGN_ID="-"
-            CODESIGN_EXTRA=""
+            CODESIGN_EXTRA=()
           fi
 
           echo "=== Fixing executable permissions ==="
@@ -833,42 +833,44 @@ jobs:
 
           echo "=== Signing all binaries (inside-out approach) ==="
           # Step 1: Sign all standalone dylibs (not in frameworks)
-          find "$APP_BUNDLE/Contents/Frameworks" -name "*.dylib" -type f -exec codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA {} \; 2>&1 | grep -v "replacing existing signature" || true
-          find "$APP_BUNDLE/Contents/PlugIns" -name "*.dylib" -type f -exec codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA {} \; 2>&1 | grep -v "replacing existing signature" || true
+          find "$APP_BUNDLE/Contents/Frameworks" -name "*.dylib" -type f -exec codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" {} \; 2>&1 | grep -v "replacing existing signature" || true
+          find "$APP_BUNDLE/Contents/PlugIns" -name "*.dylib" -type f -exec codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" {} \; 2>&1 | grep -v "replacing existing signature" || true
 
           # Step 2: Sign Python framework components (innermost first)
           if [ -d "$APP_BUNDLE/Contents/Frameworks/Python.framework" ]; then
             echo "=== Signing Python framework ==="
             PY_FW="$APP_BUNDLE/Contents/Frameworks/Python.framework"
-            PY_VER=$(ls "$PY_FW/Versions/" 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
+            PY_VER=$(find "$PY_FW/Versions/" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
             if [ -n "$PY_VER" ]; then
               PY_ROOT="$PY_FW/Versions/$PY_VER"
               # Sign all .so extension modules (lib-dynload and any other Mach-O)
               echo "Signing Python .so modules..."
-              find "$PY_ROOT" -name "*.so" -type f 2>/dev/null | while read f; do
+              find "$PY_ROOT" -name "*.so" -type f 2>/dev/null | while IFS= read -r f; do
                 if file "$f" | grep -q Mach-O; then
-                  codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$f" 2>&1 | grep -v "replacing existing signature" || true
+                  codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1 | grep -v "replacing existing signature" || true
                 fi
               done
               # Sign bin/python3.x and any other Mach-O in bin
               echo "Signing Python binaries..."
               for bin in "$PY_ROOT/bin"/*; do
-                [ -f "$bin" ] && file "$bin" | grep -q Mach-O && codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$bin" 2>&1 | grep -v "replacing existing signature" || true
+                if [ -f "$bin" ] && file "$bin" | grep -q Mach-O; then
+                  codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$bin" 2>&1 | grep -v "replacing existing signature" || true
+                fi
               done
               # Sign nested Python.app: executable first, then the app bundle
               if [ -f "$PY_ROOT/Resources/Python.app/Contents/MacOS/Python" ]; then
                 echo "Signing nested Python.app..."
-                codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$PY_ROOT/Resources/Python.app/Contents/MacOS/Python" 2>&1 | grep -v "replacing existing signature" || true
-                codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$PY_ROOT/Resources/Python.app" 2>&1 | grep -v "replacing existing signature" || true
+                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Resources/Python.app/Contents/MacOS/Python" 2>&1 | grep -v "replacing existing signature" || true
+                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Resources/Python.app" 2>&1 | grep -v "replacing existing signature" || true
               fi
               # Sign main Python framework binary
               if [ -f "$PY_ROOT/Python" ]; then
                 echo "Signing Python framework binary..."
-                codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$PY_ROOT/Python" 2>&1 | grep -v "replacing existing signature" || true
+                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Python" 2>&1 | grep -v "replacing existing signature" || true
               fi
               # Sign the Python framework itself as a bundle
               echo "Signing Python.framework as a bundle..."
-              codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$PY_FW" 2>&1 | grep -v "replacing existing signature" || true
+              codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_FW" 2>&1 | grep -v "replacing existing signature" || true
             fi
           fi
 
@@ -881,24 +883,24 @@ jobs:
 
             # Find the actual version directory (usually 'A')
             if [ -d "$fw/Versions" ]; then
-              ACTUAL_VERSION=$(ls "$fw/Versions/" 2>/dev/null | grep -v "Current" | head -1)
+              ACTUAL_VERSION=$(find "$fw/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" -exec basename {} \; 2>/dev/null | head -1)
               if [ -n "$ACTUAL_VERSION" ]; then
                 # Sign any dylibs within the framework version
-                find "$fw/Versions/$ACTUAL_VERSION" -name "*.dylib" -type f 2>/dev/null | while read lib; do
+                find "$fw/Versions/$ACTUAL_VERSION" -name "*.dylib" -type f 2>/dev/null | while IFS= read -r lib; do
                   if file "$lib" | grep -q "Mach-O"; then
-                    codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$lib" 2>&1 | grep -v "replacing existing signature" || true
+                    codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$lib" 2>&1 | grep -v "replacing existing signature" || true
                   fi
                 done
 
                 # Sign the main framework binary if it exists
                 if [ -f "$fw/Versions/$ACTUAL_VERSION/$fw_name" ]; then
-                  codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$fw/Versions/$ACTUAL_VERSION/$fw_name" 2>&1 | grep -v "replacing existing signature" || true
+                  codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$fw/Versions/$ACTUAL_VERSION/$fw_name" 2>&1 | grep -v "replacing existing signature" || true
                 fi
               fi
             fi
 
             # Sign the framework itself as a bundle (this is critical for spctl validation)
-            codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$fw" 2>&1 | grep -v "replacing existing signature" || true
+            codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$fw" 2>&1 | grep -v "replacing existing signature" || true
           done
 
           # Diagnose framework structure before signing
@@ -908,7 +910,7 @@ jobs:
             fw_name=$(basename "$fw")
             echo "--- Framework: $fw_name ---"
             echo "Top-level structure:"
-            ls -la "$fw/" 2>/dev/null | head -15
+            find "$fw/" -maxdepth 1 -ls 2>/dev/null | head -15
             echo ""
             echo "Recursive structure (max depth 3):"
             find "$fw" -maxdepth 3 -ls 2>/dev/null | head -30
@@ -932,14 +934,14 @@ jobs:
           # Step 4: Sign the main executable
           echo "=== Signing main executable ==="
           if [ -f "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME" ]; then
-            codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME" 2>&1 | grep -v "replacing existing signature" || true
+            codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME" 2>&1 | grep -v "replacing existing signature" || true
           fi
 
           # Step 5: Sign the app bundle itself (NOT with --deep, since we already signed components)
           # This is the proper way to sign bundles according to Apple's guidelines
           # CODESIGN_EXTRA adds --timestamp --options runtime for notarization when using Developer ID
           echo "=== Signing app bundle ==="
-          codesign --force --sign "$SIGN_ID" $CODESIGN_EXTRA --verbose=4 "$APP_BUNDLE" 2>&1 || true
+          codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" --verbose=4 "$APP_BUNDLE" 2>&1 || true
 
           # Remove quarantine attributes
           xattr -cr "$APP_BUNDLE" 2>/dev/null || true
@@ -950,6 +952,7 @@ jobs:
       - name: Validate code signature
         run: |
           APP_BUNDLE="${STEPS_MERGE_OUTPUTS_APP_BUNDLE}"
+          # shellcheck disable=SC2034
           EXEC_NAME=$(basename "$APP_BUNDLE" .app)
 
           echo "=== Validating code signature with codesign ==="
@@ -964,7 +967,7 @@ jobs:
           # This is the critical validation that checks if macOS will allow the app to run
           # At this stage, "Unnotarized Developer ID" is acceptable (notarization happens later with DMG)
           # But we want to catch issues like "invalid destination for symbolic link"
-          SPCTL_OUTPUT=$(spctl --assess --type execute --verbose=4 "$APP_BUNDLE" 2>&1) || SPCTL_RESULT=$?
+          SPCTL_OUTPUT=$(spctl --assess --type execute --verbose=4 "$APP_BUNDLE" 2>&1)
           echo "$SPCTL_OUTPUT"
 
           if echo "$SPCTL_OUTPUT" | grep -q "rejected"; then
@@ -1024,7 +1027,7 @@ jobs:
           for fw in "$APP_BUNDLE/Contents/Frameworks"/*.framework; do
             [ ! -d "$fw" ] && continue
             echo "--- $(basename "$fw") ---"
-            ls -la "$fw/" | head -10
+            find "$fw/" -maxdepth 1 -ls 2>/dev/null | head -10
             echo "Symlinks:"
             find "$fw" -type l -ls 2>/dev/null | head -5
             echo ""
@@ -1053,7 +1056,7 @@ jobs:
           for fw in "$STAGED_APP/Contents/Frameworks"/*.framework; do
             [ ! -d "$fw" ] && continue
             echo "--- $(basename "$fw") ---"
-            ls -la "$fw/" | head -10
+            find "$fw/" -maxdepth 1 -ls 2>/dev/null | head -10
             echo "Symlinks:"
             find "$fw" -type l -exec sh -c 'echo "$1 -> $(readlink "$1")"' _ {} \; 2>/dev/null | head -5
             echo ""
@@ -1063,7 +1066,7 @@ jobs:
           echo "=== Creating DMG ==="
           hdiutil create -volname "PythonSCAD" -srcfolder "$DMG_STAGING" -ov -format UDZO "$DMG_NAME"
 
-          echo "dmg_file=$DMG_NAME" >> $GITHUB_OUTPUT
+          echo "dmg_file=$DMG_NAME" >> "$GITHUB_OUTPUT"
           echo "Created DMG: $DMG_NAME"
 
           echo "=== DEBUG: Mounting DMG to inspect contents ==="
@@ -1076,7 +1079,7 @@ jobs:
             for fw in "$TEST_MOUNT/$APP_NAME/Contents/Frameworks"/*.framework; do
               [ ! -d "$fw" ] && continue
               echo "--- $(basename "$fw") ---"
-              ls -la "$fw/" | head -10
+              find "$fw/" -maxdepth 1 -ls 2>/dev/null | head -10
               echo "Symlinks:"
               find "$fw" -type l -exec sh -c 'link="$1"; target=$(readlink "$link"); echo "$link -> $target"; [ -e "$target" ] || echo "  BROKEN!"' _ {} \; 2>/dev/null | head -10
               echo ""
@@ -1156,6 +1159,7 @@ jobs:
         continue-on-error: true
         run: |
           DMG_FILE="${STEPS_DMG_OUTPUTS_DMG_FILE}"
+          # shellcheck disable=SC2034
           APP_BUNDLE="${STEPS_MERGE_OUTPUTS_APP_BUNDLE}"
 
           echo "=== Final validation of DMG and app bundle ==="
@@ -1259,9 +1263,11 @@ jobs:
           echo "Creating tar of pre-DMG app bundle for debugging..."
           tar -czf /tmp/out/pre-dmg-app-bundle.tar.gz -C "$(dirname "$APP_BUNDLE")" "$(basename "$APP_BUNDLE")"
 
-          echo "dmg_path=/tmp/out/$basename_dmg" >> $GITHUB_OUTPUT
-          echo "dmg_name=$(basename "$basename_dmg" .dmg)" >> $GITHUB_OUTPUT
-          echo "validation_status=${STEPS_VALIDATION_OUTCOME}" >> $GITHUB_OUTPUT
+          {
+            echo "dmg_path=/tmp/out/$basename_dmg"
+            echo "dmg_name=$(basename "$basename_dmg" .dmg)"
+            echo "validation_status=${STEPS_VALIDATION_OUTCOME}"
+          } >> "$GITHUB_OUTPUT"
 
           # List what we have
           echo "Artifacts prepared:"
@@ -1325,4 +1331,4 @@ jobs:
       - name: Clean up signing keychain
         if: always() && steps.install_cert.outputs.cert_installed == 'true'
         run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+          security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" 2>/dev/null || true

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -136,6 +136,8 @@ jobs:
           echo "Found app bundle: $APP_BUNDLE"
 
       - name: Bundle runtime Python deps (IPython) into .app
+        env:
+          STEPS_APPNAME_OUTPUTS_APP_BUNDLE: ${{ steps.appname.outputs.app_bundle }}
         run: |
           # Destination must match `bundledFallbackPaths` in
           # src/python/pyopenscad.cc: ../Resources/pythonscad-bundled-py
@@ -143,7 +145,7 @@ jobs:
           # NOT Contents/Frameworks/: macOS `codesign` treats every
           # subdirectory there as a sub-bundle and chokes on pip's
           # `*.dist-info` metadata directories.
-          APP_BUNDLE="${{ steps.appname.outputs.app_bundle }}"
+          APP_BUNDLE="${STEPS_APPNAME_OUTPUTS_APP_BUNDLE}"
           BUNDLE_DEST="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           chmod +x ./scripts/bundle-runtime-python.sh
           BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
@@ -286,6 +288,8 @@ jobs:
           echo "Found app bundle: $APP_BUNDLE"
 
       - name: Bundle runtime Python deps (IPython) into .app
+        env:
+          STEPS_APPNAME_OUTPUTS_APP_BUNDLE: ${{ steps.appname.outputs.app_bundle }}
         run: |
           # Destination must match `bundledFallbackPaths` in
           # src/python/pyopenscad.cc: ../Resources/pythonscad-bundled-py
@@ -293,7 +297,7 @@ jobs:
           # NOT Contents/Frameworks/: macOS `codesign` treats every
           # subdirectory there as a sub-bundle and chokes on pip's
           # `*.dist-info` metadata directories.
-          APP_BUNDLE="${{ steps.appname.outputs.app_bundle }}"
+          APP_BUNDLE="${STEPS_APPNAME_OUTPUTS_APP_BUNDLE}"
           BUNDLE_DEST="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           chmod +x ./scripts/bundle-runtime-python.sh
           BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
@@ -749,12 +753,14 @@ jobs:
           otool -L "$FRAMEWORKS_DIR/QtCore.framework/Versions/A/QtCore" | grep -E "icu|brotli" || echo "No ICU or brotli references found"
 
       - name: Bundle runtime Python deps (IPython) into merged .app
+        env:
+          STEPS_MERGE_OUTPUTS_APP_BUNDLE: ${{ steps.merge.outputs.app_bundle }}
         run: |
           # Pure-Python wheels are architecture-independent, so we just
           # re-run the bundler on the merged universal .app rather than
           # trying to lipo per-arch bundles together. Anything previously
           # installed by the per-arch jobs gets overwritten by --upgrade.
-          APP_BUNDLE="${{ steps.merge.outputs.app_bundle }}"
+          APP_BUNDLE="${STEPS_MERGE_OUTPUTS_APP_BUNDLE}"
           BUNDLE_DEST="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           chmod +x ./scripts/bundle-runtime-python.sh
           BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -535,7 +535,7 @@ jobs:
             # Qt frameworks have binary at: QtCore.framework/Versions/A/QtCore
             # Find the actual version directory (usually 'A') instead of using 'Current' symlink
             if [ -d "$x86_framework/Versions" ]; then
-              ACTUAL_VERSION=$(find "$x86_framework/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" 2>/dev/null | head -1 | xargs -I{} basename {})
+              ACTUAL_VERSION=$(find "$x86_framework/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" -exec basename {} \; 2>/dev/null | head -1)
               if [ -n "$ACTUAL_VERSION" ]; then
                 framework_binary="Versions/$ACTUAL_VERSION/$framework_name"
                 if [ -f "$x86_framework/$framework_binary" ]; then

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -1304,12 +1304,10 @@ jobs:
 
       - name: Upload artifacts to release
         if: (github.event_name == 'release' || github.event.inputs.upload_to_release != '') && steps.validation.outcome == 'success'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: /tmp/out/*.dmg
-          tag_name: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
+        run: gh release upload "$RELEASE_TAG" /tmp/out/*.dmg --clobber
 
       - name: Fail workflow if validation failed
         if: always()

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -967,7 +967,7 @@ jobs:
           # This is the critical validation that checks if macOS will allow the app to run
           # At this stage, "Unnotarized Developer ID" is acceptable (notarization happens later with DMG)
           # But we want to catch issues like "invalid destination for symbolic link"
-          SPCTL_OUTPUT=$(spctl --assess --type execute --verbose=4 "$APP_BUNDLE" 2>&1)
+          SPCTL_OUTPUT=$(spctl --assess --type execute --verbose=4 "$APP_BUNDLE" 2>&1) || true
           echo "$SPCTL_OUTPUT"
 
           if echo "$SPCTL_OUTPUT" | grep -q "rejected"; then

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -973,7 +973,7 @@ jobs:
           set -e
           echo "$SPCTL_OUTPUT"
 
-          if [ $SPCTL_EXIT -ne 0 ]; then
+          if [ "$SPCTL_EXIT" -ne 0 ]; then
             if echo "$SPCTL_OUTPUT" | grep -q "source=Unnotarized Developer ID"; then
               echo "⚠ App is signed but not yet notarized (expected at this stage)"
               echo "✓ Notarization will happen when creating the DMG"

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -967,8 +967,10 @@ jobs:
           # This is the critical validation that checks if macOS will allow the app to run
           # At this stage, "Unnotarized Developer ID" is acceptable (notarization happens later with DMG)
           # But we want to catch issues like "invalid destination for symbolic link"
+          set +e
           SPCTL_OUTPUT=$(spctl --assess --type execute --verbose=4 "$APP_BUNDLE" 2>&1)
           SPCTL_EXIT=$?
+          set -e
           echo "$SPCTL_OUTPUT"
 
           if [ $SPCTL_EXIT -ne 0 ]; then

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build-intel:
     runs-on: macos-15-intel
@@ -327,6 +330,8 @@ jobs:
     needs: [build-intel, build-arm64]
     name: Merge Universal Binary and Package
     timeout-minutes: 60
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -967,10 +967,11 @@ jobs:
           # This is the critical validation that checks if macOS will allow the app to run
           # At this stage, "Unnotarized Developer ID" is acceptable (notarization happens later with DMG)
           # But we want to catch issues like "invalid destination for symbolic link"
-          SPCTL_OUTPUT=$(spctl --assess --type execute --verbose=4 "$APP_BUNDLE" 2>&1) || true
+          SPCTL_OUTPUT=$(spctl --assess --type execute --verbose=4 "$APP_BUNDLE" 2>&1)
+          SPCTL_EXIT=$?
           echo "$SPCTL_OUTPUT"
 
-          if echo "$SPCTL_OUTPUT" | grep -q "rejected"; then
+          if [ $SPCTL_EXIT -ne 0 ]; then
             if echo "$SPCTL_OUTPUT" | grep -q "source=Unnotarized Developer ID"; then
               echo "⚠ App is signed but not yet notarized (expected at this stage)"
               echo "✓ Notarization will happen when creating the DMG"

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -93,13 +93,17 @@ jobs:
     container: ${{ matrix.arch == 'amd64' && matrix.container || null }} # zizmor: ignore[unpinned-images]
 
     steps:
-      - name: Install git and basic tools (amd64 container)
+      - name: Install git, basic tools, and gh CLI (amd64 container)
         if: matrix.arch == 'amd64'
         run: |
           if [ -f /etc/fedora-release ]; then
-            dnf install -y git tar gzip
+            dnf install -y git tar gzip 'dnf-command(config-manager)'
+            dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+            dnf install -y gh
           else
-            dnf install -y git tar gzip epel-release
+            dnf install -y git tar gzip epel-release 'dnf-command(config-manager)'
+            dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+            dnf install -y gh
           fi
 
       - name: Checkout code

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -19,6 +19,9 @@ concurrency:
   group: publish-yum-repo
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   prepare-matrix:
     name: Prepare build matrix from supported distributions
@@ -79,6 +82,8 @@ jobs:
     name: Build .rpm (${{ matrix.distro }} ${{ matrix.version }} ${{ matrix.arch }})
     needs: prepare-matrix
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -103,7 +103,7 @@ jobs:
           fi
           # Write the gh CLI repo file inline — avoids DNF4 vs DNF5
           # config-manager syntax differences and curl-minimal conflicts on EL9.
-          printf '[gh-cli]\nname=packages for the GitHub CLI\nbaseurl=https://cli.github.com/packages/rpm\nenabled=1\ngpgcheck=1\ngpgkey=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x23F3D4EA75716059\n' \
+          printf '[gh-cli]\nname=packages for the GitHub CLI\nbaseurl=https://cli.github.com/packages/rpm\nenabled=1\ngpgcheck=1\ngpgkey=https://cli.github.com/packages/githubcli-archive-keyring.gpg\n' \
             > /etc/yum.repos.d/gh-cli.repo
           dnf install -y gh
 

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -96,15 +96,16 @@ jobs:
       - name: Install git, basic tools, and gh CLI (amd64 container)
         if: matrix.arch == 'amd64'
         run: |
+          # Use curl to drop the repo file directly — avoids DNF4 vs DNF5
+          # config-manager syntax differences (Fedora 41+ ships DNF5).
           if [ -f /etc/fedora-release ]; then
-            dnf install -y git tar gzip 'dnf-command(config-manager)'
-            dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-            dnf install -y gh
+            dnf install -y git tar gzip curl
           else
-            dnf install -y git tar gzip epel-release 'dnf-command(config-manager)'
-            dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-            dnf install -y gh
+            dnf install -y git tar gzip curl epel-release
           fi
+          curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
+            > /etc/yum.repos.d/gh-cli.repo
+          dnf install -y gh
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -90,7 +90,10 @@ jobs:
 
     # Note: Don't use container field for ARM64 - it pulls amd64 images
     # ARM64 builds use explicit docker run with --platform flag
-    container: ${{ matrix.arch == 'amd64' && matrix.container || null }} # zizmor: ignore[unpinned-images]
+    # zizmor: ignore[unpinned-images] — images are tag-pinned in
+    # supported-distributions.json (e.g. fedora:44, rockylinux:9), not
+    # digest-pinned. Accepted risk; digest-pinning is tracked in #663.
+    container: ${{ matrix.arch == 'amd64' && matrix.container || null }}
 
     steps:
       - name: Install git, basic tools, and gh CLI (amd64 container)

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -151,8 +151,10 @@ jobs:
           fi
 
           # Set VERSION environment variable for spec file parsing
-          export VERSION=$(cat VERSION.txt | tr -d '\n' | tr -d '\r')
-          export CHANGELOG_DATE=$(date "+%a %b %d %Y")
+          VERSION=$(tr -d '\n\r' < VERSION.txt)
+          export VERSION
+          CHANGELOG_DATE=$(date "+%a %b %d %Y")
+          export CHANGELOG_DATE
 
           # Install build dependencies from spec file
           dnf builddep -y pythonscad.spec
@@ -262,7 +264,7 @@ jobs:
           done
 
           # Clean up passphrase file if it exists (RPM 4.x path)
-          [ -n "${PASSPHRASE_FILE:-}" ] && rm -f "$PASSPHRASE_FILE" || true
+          if [ -n "${PASSPHRASE_FILE:-}" ]; then rm -f "$PASSPHRASE_FILE"; fi
 
           # Import public key into RPM keyring for verification
           gpg --export -a "${{ secrets.GPG_KEY_ID }}" > /tmp/pubkey.asc

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -277,6 +277,9 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           DO_SIGN: ${{ (github.event_name == 'release' || github.event.inputs.upload_to_release != '') && 'true' || 'false' }}
+          MATRIX_VERSION: ${{ matrix.version }}
+          MATRIX_DISTRO: ${{ matrix.distro }}
+          MATRIX_CONTAINER: ${{ matrix.container }}
         run: |
           # Run the entire build inside a Docker container with proper ARM64 emulation
           mkdir -p /tmp/rpms
@@ -286,14 +289,14 @@ jobs:
             -v /tmp/rpms:/tmp/rpms \
             -w /workspace \
             -e OUTPUT_DIR=/tmp/rpms \
-            -e FEDORA_RELEASE=${{ matrix.version }} \
-            -e DISTRO_TYPE=${{ matrix.distro }} \
+            -e FEDORA_RELEASE="$MATRIX_VERSION" \
+            -e DISTRO_TYPE="$MATRIX_DISTRO" \
             -e ARCH=aarch64 \
             -e GPG_SIGNING_KEY="$GPG_SIGNING_KEY" \
             -e GPG_PASSPHRASE="$GPG_PASSPHRASE" \
             -e GPG_KEY_ID="$GPG_KEY_ID" \
             -e DO_SIGN="$DO_SIGN" \
-            ${{ matrix.container }} \
+            "$MATRIX_CONTAINER" \
             bash -c '
               set -e
 

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -438,12 +438,10 @@ jobs:
 
       - name: Upload to GitHub Release
         if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
-        uses: softprops/action-gh-release@v3
-        with:
-          files: /tmp/rpms/*
-          tag_name: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
+        run: gh release upload "$RELEASE_TAG" /tmp/rpms/* --clobber
 
   publish-yum-repo:
     name: Publish YUM repository to SFTP

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -96,14 +96,14 @@ jobs:
       - name: Install git, basic tools, and gh CLI (amd64 container)
         if: matrix.arch == 'amd64'
         run: |
-          # Use curl to drop the repo file directly — avoids DNF4 vs DNF5
-          # config-manager syntax differences (Fedora 41+ ships DNF5).
           if [ -f /etc/fedora-release ]; then
-            dnf install -y git tar gzip curl
+            dnf install -y git tar gzip
           else
-            dnf install -y git tar gzip curl epel-release
+            dnf install -y git tar gzip epel-release
           fi
-          curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
+          # Write the gh CLI repo file inline — avoids DNF4 vs DNF5
+          # config-manager syntax differences and curl-minimal conflicts on EL9.
+          printf '[gh-cli]\nname=packages for the GitHub CLI\nbaseurl=https://cli.github.com/packages/rpm\nenabled=1\ngpgcheck=1\ngpgkey=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x23F3D4EA75716059\n' \
             > /etc/yum.repos.d/gh-cli.repo
           dnf install -y gh
 

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -85,7 +85,7 @@ jobs:
 
     # Note: Don't use container field for ARM64 - it pulls amd64 images
     # ARM64 builds use explicit docker run with --platform flag
-    container: ${{ matrix.arch == 'amd64' && matrix.container || null }}
+    container: ${{ matrix.arch == 'amd64' && matrix.container || null }} # zizmor: ignore[unpinned-images]
 
     steps:
       - name: Install git and basic tools (amd64 container)

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -15,9 +15,14 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build-package:
     runs-on: windows-latest
+    permissions:
+      contents: write
     name: Windows Native Package (Qt6)
     defaults:
       run:

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -269,6 +269,7 @@ jobs:
 
       - name: Upload artifacts to release
         if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -59,7 +59,7 @@ jobs:
           TAG="${RELEASE_TAG_NAME:-$UPLOAD_TO_RELEASE}"
           # Strip leading 'v' for CMake (e.g. v0.6.0 -> 0.6.0)
           OPENSCAD_VERSION="${TAG#v}"
-          echo "OPENSCAD_VERSION=$OPENSCAD_VERSION" >> $GITHUB_ENV
+          echo "OPENSCAD_VERSION=$OPENSCAD_VERSION" >> "$GITHUB_ENV"
           echo "Using release version for package name: $OPENSCAD_VERSION"
 
       - name: Setup (detached) tmate session if enabled

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -269,11 +269,7 @@ jobs:
 
       - name: Upload artifacts to release
         if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            artifacts/*.zip
-            artifacts/*.exe
-          tag_name: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.upload_to_release }}
+        run: gh release upload "$RELEASE_TAG" artifacts/*.zip artifacts/*.exe --clobber

--- a/.github/workflows/code-tidy.yml
+++ b/.github/workflows/code-tidy.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+
 jobs:
   RunClangTidy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,6 +15,9 @@ concurrency:
   group: deploy-website
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy-website:
     name: Build and deploy mkdocs website

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     strategy:

--- a/.github/workflows/pip-build-and-test.yml
+++ b/.github/workflows/pip-build-and-test.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pip-build-and-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -63,4 +63,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -9,6 +9,9 @@ on:
         required: true
         default: 'warning'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -34,6 +34,11 @@ rules:
       #     `*: hash-pin` rule kicks in and the linter raises a hard
       #     error, instead of silently allowing the supply-chain
       #     surface to grow.
+      #   - softprops/action-gh-release has been replaced with the
+      #     built-in `gh release upload` CLI, so it no longer appears
+      #     in any workflow.
+      #   - pypa/gh-action-pypi-publish is hash-pinned (receives
+      #     id-token: write for OIDC publishing to PyPI).
       policies:
         actions/*: ref-pin
         # Third-party — tracked for hash-pinning in #613:
@@ -42,8 +47,6 @@ rules:
         msys2/setup-msys2: ref-pin
         mxschmitt/action-tmate: ref-pin
         nanzm/get-time-action: ref-pin
-        pypa/gh-action-pypi-publish: ref-pin
-        softprops/action-gh-release: ref-pin
         ssciwr/setup-mesa-dist-win: ref-pin
         takanome-dev/assign-issue-action: ref-pin
         # Anything not listed above must be hash-pinned.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -47,6 +47,7 @@ rules:
         msys2/setup-msys2: ref-pin
         mxschmitt/action-tmate: ref-pin
         nanzm/get-time-action: ref-pin
+        # pypa/gh-action-pypi-publish is hash-pinned (id-token: write); omitted here.
         ssciwr/setup-mesa-dist-win: ref-pin
         takanome-dev/assign-issue-action: ref-pin
         # Anything not listed above must be hash-pinned.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,9 +79,9 @@ repos:
       hooks:
           # Lints GitHub Actions workflow files: schema validation,
           # expression syntax, pinned-action checks, etc. When
-          # shellcheck is on PATH (it is on CI via shellcheck-py
-          # below), actionlint also checks workflow run: blocks for
-          # SC2086, SC2012, SC2162, etc.
+          # shellcheck is on PATH (GitHub-hosted runners ship it in
+          # the base image), actionlint also checks workflow run:
+          # blocks for SC2086, SC2012, SC2162, etc.
           - id: actionlint
     - repo: https://github.com/shellcheck-py/shellcheck-py
       rev: v0.11.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,10 +78,10 @@ repos:
       rev: v1.7.12
       hooks:
           # Lints GitHub Actions workflow files: schema validation,
-          # expression syntax, pinned-action checks, etc. Shellcheck
-          # integration is active: workflow run: blocks are checked
-          # for SC2086, SC2012, SC2162, etc. alongside standalone
-          # *.sh files (covered by the shellcheck-py hook below).
+          # expression syntax, pinned-action checks, etc. When
+          # shellcheck is on PATH (it is on CI via shellcheck-py
+          # below), actionlint also checks workflow run: blocks for
+          # SC2086, SC2012, SC2162, etc.
           - id: actionlint
     - repo: https://github.com/shellcheck-py/shellcheck-py
       rev: v0.11.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,23 +78,11 @@ repos:
       rev: v1.7.12
       hooks:
           # Lints GitHub Actions workflow files: schema validation,
-          # expression syntax, pinned-action checks, etc.
-          #
-          # `-shellcheck=` (empty) disables actionlint's bundled
-          # shellcheck integration on workflow `run:` blocks. The
-          # integration is genuinely valuable, but the existing
-          # workflow `run:` blocks have a long tail of pre-existing
-          # SC2086 / SC2012 / SC2015 / etc. findings that are tracked
-          # for cleanup in #613. Without this flag, behaviour
-          # diverges between contributors who have `shellcheck`
-          # installed (CI runners; many Linux distros) and those
-          # who don't (a typical macOS dev box). Drop this arg once
-          # the #613 backlog is clear so workflow-embedded shell
-          # gets shellchecked too. Standalone `*.sh` files are
-          # already linted by the separate `shellcheck-py` hook
-          # below, regardless of this flag.
+          # expression syntax, pinned-action checks, etc. Shellcheck
+          # integration is active: workflow run: blocks are checked
+          # for SC2086, SC2012, SC2162, etc. alongside standalone
+          # *.sh files (covered by the shellcheck-py hook below).
           - id: actionlint
-            args: ["-shellcheck="]
     - repo: https://github.com/shellcheck-py/shellcheck-py
       rev: v0.11.0.1
       hooks:


### PR DESCRIPTION
## Summary

Addresses all open findings from #613. Both `actionlint` and `zizmor` now pass with zero findings (6 suppressed false positives, 159 intentionally suppressed by existing policy).

**Changes:**

- **Unpinned-images false positives** (`build-debian-packages.yml`, `build-rpm-packages.yml`): Added `# zizmor: ignore[unpinned-images]` on the dynamic matrix container expressions that zizmor can't statically resolve (images are pinned in the matrix definition).

- **Template injection** (`build-debian-packages.yml`, `build-rpm-packages.yml`, `build-macos-release.yml`): Routed all `${{ matrix.* }}` and `${{ steps.*.outputs.* }}` expressions through `env:` blocks; `run:` blocks now reference only shell variables.

- **Excessive permissions**: Added `permissions: contents: read` at the top level of all 15 workflows that were missing it. Per-job `permissions: contents: write` added to the 5 jobs that upload release artifacts.

- **softprops/action-gh-release replaced**: All 5 uses replaced with the pre-installed `gh release upload` CLI. Eliminates the external dependency entirely — no supply-chain surface, no hash-pin needed, no Dependabot updates required.

- **pypa/gh-action-pypi-publish hash-pinned**: Used a branch reference (`release/v1`) with `id-token: write` for OIDC PyPI publishing. Now pinned to commit SHA; ref-pin policy exception removed from `zizmor.yml`.

- **shellcheck backlog cleared** (72 findings across 5 workflows): SC2086 (unquoted variables), SC2162 (read without -r), SC2010/SC2012 (ls→find), SC2002 (useless cat), SC2155 (masked export), SC2015 (A&&B||C), SC2034 (cross-step vars annotated), SC2129 (combined >> redirections), SC2295 (pattern expansion).

- **actionlint shellcheck suppression removed**: Dropped `-shellcheck=` from the pre-commit hook now that the backlog is cleared.

## Test plan

- [ ] `actionlint .github/workflows/*.yml` exits 0 with no output
- [ ] `zizmor --no-progress .github/workflows/*.yml` reports "No findings to report. Good job!"
- [ ] All existing CI workflows pass (pre-commit, actionlint, zizmor)
- [ ] Verify release upload still works on next release (gh CLI replaces softprops)

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)