### PR TITLE
feat(ci): add Certum SimplySign Windows code signing

### DIFF
--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -1,10 +1,11 @@
 name: Sign Windows Artifacts (Certum SimplySign)
 description: >
-  Signs Windows PE files (.exe, .dll, .msix) using jsign with a Certum
-  SimplySign cloud HSM certificate. The private key never leaves Certum's
-  HSM; only the public certificate is stored in CI secrets.
-  When either certum-card-pin or certum-certificate-base64 is not set
-  the step is skipped silently so unsigned test builds still work.
+  Signs Windows Authenticode-signable artifacts (.exe, .dll, .msix) using
+  jsign with a Certum SimplySign cloud HSM certificate. The private key
+  never leaves Certum's HSM; only the public certificate is stored in CI
+  secrets. When either certum-card-pin or certum-certificate-base64 is not
+  set the signing steps are skipped (a log line is emitted) so unsigned
+  test builds still work.
 
 inputs:
   certum-certificate-base64:

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -1,0 +1,148 @@
+name: Sign Windows Artifacts (Certum SimplySign)
+description: >
+  Signs Windows PE files (.exe, .dll, .msix) using jsign with a Certum
+  SimplySign cloud HSM certificate. The private key never leaves Certum's
+  HSM; only the public certificate is stored in CI secrets.
+  When CERTUM_CARD_PIN is not set the step is skipped silently so
+  unsigned test builds still work.
+
+inputs:
+  certum-certificate-base64:
+    description: >
+      Base64-encoded PEM certificate exported from Certum (public cert only —
+      the private key stays on the SimplySign HSM). Store in a GitHub Actions
+      secret (e.g. CERTUM_CERTIFICATE_BASE64).
+    required: false
+    default: ''
+  certum-card-pin:
+    description: >
+      PIN for the SimplySign card/account. Store in a GitHub Actions secret
+      (e.g. CERTUM_CARD_PIN). When the SimplySign Android/iOS app is
+      configured for push-notification authorization, approving the prompt
+      in the app unblocks this step.
+    required: false
+    default: ''
+  timestamp-url:
+    description: 'RFC 3161 timestamp server URL'
+    required: false
+    default: 'http://time.certum.pl'
+  files:
+    description: >
+      Space-separated list of files (or glob patterns) to sign.
+      Example: "artifacts/*.exe artifacts/*.msix build/staging/*.dll"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check signing inputs
+      id: check
+      shell: powershell
+      env:
+        CERTUM_PIN: ${{ inputs.certum-card-pin }}
+        CERTUM_CERT: ${{ inputs.certum-certificate-base64 }}
+      run: |
+        if (-not $env:CERTUM_PIN -or -not $env:CERTUM_CERT) {
+          Write-Host "Certum signing secrets not set — skipping code signing."
+          "enabled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        } else {
+          Write-Host "Certum signing secrets present — signing will proceed."
+          "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        }
+
+    - name: Set up Java (required by jsign)
+      if: steps.check.outputs.enabled == 'true'
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+
+    - name: Download jsign
+      if: steps.check.outputs.enabled == 'true'
+      shell: powershell
+      run: |
+        $version = "7.1"
+        $url = "https://github.com/ebourg/jsign/releases/download/$version/jsign-$version.jar"
+        Write-Host "Downloading jsign $version from $url"
+        Invoke-WebRequest $url -OutFile "$env:RUNNER_TEMP\jsign.jar"
+
+    - name: Decode certificate
+      if: steps.check.outputs.enabled == 'true'
+      shell: powershell
+      env:
+        CERTUM_CERT_BASE64: ${{ inputs.certum-certificate-base64 }}
+      run: |
+        # Strip PEM header/footer lines and whitespace if present
+        $b64 = ($env:CERTUM_CERT_BASE64 -split "`n" |
+          Where-Object { $_ -notmatch '^\s*-----' -and $_.Trim() -ne '' } |
+          ForEach-Object { $_.Trim() }) -join ''
+        try {
+          $certBytes = [Convert]::FromBase64String($b64)
+        } catch {
+          Write-Error "certum-certificate-base64 is not valid Base64."
+          exit 1
+        }
+        $certPath = Join-Path $env:RUNNER_TEMP "certum.pem"
+        # Write back as PEM so jsign can parse it
+        $pemBody = [Convert]::ToBase64String($certBytes, 'InsertLineBreaks')
+        "-----BEGIN CERTIFICATE-----`n$pemBody`n-----END CERTIFICATE-----" |
+          Out-File -FilePath $certPath -Encoding ascii
+        Write-Host "Certificate decoded to $certPath"
+
+    - name: Sign files
+      if: steps.check.outputs.enabled == 'true'
+      shell: powershell
+      env:
+        CERTUM_PIN: ${{ inputs.certum-card-pin }}
+        TIMESTAMP_URL: ${{ inputs.timestamp-url }}
+        FILES_GLOB: ${{ inputs.files }}
+        JSIGN_JAR: ${{ runner.temp }}\jsign.jar
+      run: |
+        # Use the fixed well-known path written by the previous step
+        $certPath = Join-Path $env:RUNNER_TEMP "certum.pem"
+
+        # Expand glob patterns / space-separated paths to a concrete file list
+        $targets = @()
+        foreach ($pattern in $env:FILES_GLOB -split '\s+') {
+          $expanded = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue
+          if ($expanded) {
+            $targets += $expanded
+          } else {
+            Write-Warning "No files matched: $pattern"
+          }
+        }
+
+        if ($targets.Count -eq 0) {
+          Write-Error "No files found to sign. Check the 'files' input."
+          exit 1
+        }
+
+        Write-Host "Signing $($targets.Count) file(s):"
+        $targets | ForEach-Object { Write-Host "  $_" }
+
+        $failed = @()
+        foreach ($file in $targets) {
+          Write-Host "`nSigning: $($file.FullName)"
+          # jsign with CRYPTOCERTUM storetype talks directly to the
+          # SimplySign PKCS#11 module. The mobile app push notification
+          # fires here; approve it in the SimplySign app to unblock.
+          java -jar $env:JSIGN_JAR `
+            --storetype CRYPTOCERTUM `
+            --storepass $env:CERTUM_PIN `
+            --certfile $certPath `
+            --tsaurl $env:TIMESTAMP_URL `
+            --tsmode RFC3161 `
+            $file.FullName
+          if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to sign: $($file.FullName)"
+            $failed += $file.FullName
+          }
+        }
+
+        Remove-Item $certPath -Force -ErrorAction SilentlyContinue
+
+        if ($failed.Count -gt 0) {
+          Write-Error "Signing failed for $($failed.Count) file(s):`n$($failed -join "`n")"
+          exit 1
+        }
+        Write-Host "`nAll files signed successfully."

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -109,10 +109,12 @@ runs:
         # Use the fixed well-known path written by the previous step
         $certPath = Join-Path $env:RUNNER_TEMP "certum.pem"
 
-        # Expand glob patterns / space-separated paths to a concrete file list
+        # Expand glob patterns / space-separated paths to a concrete file list.
+        # Trim and skip empty tokens to avoid Get-ChildItem enumerating the
+        # current directory when the input has leading/trailing whitespace.
         $targets = @()
-        foreach ($pattern in $env:FILES_GLOB -split '\s+') {
-          $expanded = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue
+        foreach ($pattern in ($env:FILES_GLOB -split '\s+' | Where-Object { $_.Trim() -ne '' })) {
+          $expanded = Get-ChildItem -Path $pattern -File -ErrorAction SilentlyContinue
           if ($expanded) {
             $targets += $expanded
           } else {

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -3,8 +3,8 @@ description: >
   Signs Windows PE files (.exe, .dll, .msix) using jsign with a Certum
   SimplySign cloud HSM certificate. The private key never leaves Certum's
   HSM; only the public certificate is stored in CI secrets.
-  When CERTUM_CARD_PIN is not set the step is skipped silently so
-  unsigned test builds still work.
+  When either CERTUM_CARD_PIN or certum-certificate-base64 is not set
+  the step is skipped silently so unsigned test builds still work.
 
 inputs:
   certum-certificate-base64:

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -60,6 +60,32 @@ runs:
         distribution: temurin
         java-version: '21'
 
+    # jsign --storetype CRYPTOCERTUM communicates with the Certum SimplySign
+    # cloud HSM via the proCertum CardManager PKCS#11 driver. That driver must
+    # be installed on the runner; GitHub-hosted windows-latest runners do not
+    # include it. Install it here using the official silent installer.
+    # The installer URL and SHA-256 should be updated when Certum releases a
+    # new version. The current version is 3.3.8.
+    - name: Install proCertum CardManager (SimplySign PKCS#11 driver)
+      if: steps.check.outputs.enabled == 'true'
+      shell: powershell
+      run: |
+        $url = "https://www.certum.eu/en/software/procertum-cardmanager-download/"
+        Write-Warning @"
+        proCertum CardManager must be installed for Certum SimplySign signing.
+        GitHub-hosted runners do not include this software.
+        Please download the installer from:
+          $url
+        Pin its SHA-256 and installer URL in this action, then replace this
+        warning block with a silent install step such as:
+          Invoke-WebRequest <pinned-url> -OutFile cardmanager.exe
+          if ((Get-FileHash cardmanager.exe -Algorithm SHA256).Hash.ToLower() -ne '<expected>') { exit 1 }
+          Start-Process cardmanager.exe -ArgumentList '/S' -Wait
+        Until then, signing will fail with a PKCS#11 module not found error.
+        "@
+        # Do not exit 1 here — let jsign fail with its own error so the message
+        # above is visible in the log alongside the actual failure.
+
     - name: Download jsign
       if: steps.check.outputs.enabled == 'true'
       shell: powershell

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -3,7 +3,7 @@ description: >
   Signs Windows PE files (.exe, .dll, .msix) using jsign with a Certum
   SimplySign cloud HSM certificate. The private key never leaves Certum's
   HSM; only the public certificate is stored in CI secrets.
-  When either CERTUM_CARD_PIN or certum-certificate-base64 is not set
+  When either certum-card-pin or certum-certificate-base64 is not set
   the step is skipped silently so unsigned test builds still work.
 
 inputs:
@@ -61,30 +61,32 @@ runs:
         java-version: '21'
 
     # jsign --storetype CRYPTOCERTUM communicates with the Certum SimplySign
-    # cloud HSM via the proCertum CardManager PKCS#11 driver. That driver must
-    # be installed on the runner; GitHub-hosted windows-latest runners do not
-    # include it. Install it here using the official silent installer.
-    # The installer URL and SHA-256 should be updated when Certum releases a
-    # new version. The current version is 3.3.8.
-    - name: Install proCertum CardManager (SimplySign PKCS#11 driver)
+    # cloud HSM via the proCertum CardManager PKCS#11 driver. GitHub-hosted
+    # windows-latest runners do not include this software. Check for the DLL
+    # and fail fast with a clear error rather than letting jsign produce a
+    # cryptic PKCS#11 module-not-found message.
+    #
+    # To install the driver, replace this step with a pinned silent-install:
+    #   Invoke-WebRequest <url> -OutFile cardmanager.exe
+    #   if ((Get-FileHash cardmanager.exe -Algorithm SHA256).Hash -ne '<sha256>') { exit 1 }
+    #   Start-Process cardmanager.exe -ArgumentList '/S' -Wait
+    # Download the installer from https://www.certum.eu/en/cert_guide/
+    # and pin both the URL and SHA-256 before enabling this in production.
+    - name: Check proCertum CardManager (SimplySign PKCS#11 driver)
       if: steps.check.outputs.enabled == 'true'
       shell: powershell
       run: |
-        $url = "https://www.certum.eu/en/software/procertum-cardmanager-download/"
-        Write-Warning @"
-        proCertum CardManager must be installed for Certum SimplySign signing.
-        GitHub-hosted runners do not include this software.
-        Please download the installer from:
-          $url
-        Pin its SHA-256 and installer URL in this action, then replace this
-        warning block with a silent install step such as:
-          Invoke-WebRequest <pinned-url> -OutFile cardmanager.exe
-          if ((Get-FileHash cardmanager.exe -Algorithm SHA256).Hash.ToLower() -ne '<expected>') { exit 1 }
-          Start-Process cardmanager.exe -ArgumentList '/S' -Wait
-        Until then, signing will fail with a PKCS#11 module not found error.
-        "@
-        # Do not exit 1 here — let jsign fail with its own error so the message
-        # above is visible in the log alongside the actual failure.
+        $dll = "C:\Windows\System32\sc30pkcs11.dll"
+        if (-not (Test-Path $dll)) {
+          $msg = "proCertum CardManager PKCS#11 driver not found at $dll. " +
+            "jsign --storetype CRYPTOCERTUM requires this driver to communicate " +
+            "with the Certum SimplySign cloud HSM. GitHub-hosted runners do not include it. " +
+            "To fix: add a silent-install step for proCertum CardManager before this action runs. " +
+            "See doc/windows-code-signing.md for details."
+          Write-Error $msg
+          exit 1
+        }
+        Write-Host "proCertum CardManager PKCS#11 driver found at $dll"
 
     - name: Download jsign
       if: steps.check.outputs.enabled == 'true'

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -12,7 +12,8 @@ inputs:
       Base64-encoded DER certificate exported from Certum (public cert only —
       the private key stays on the SimplySign HSM). Obtain the DER bytes with
       `openssl x509 -in certum.pem -outform DER -out certum.cer`, then
-      `base64 -w0 certum.cer`. Store the result in a GitHub Actions secret
+      `base64 -w0 certum.cer` (Linux) or `base64 certum.cer | tr -d '\n'`
+      (macOS). Store the result in a GitHub Actions secret
       (e.g. CERTUM_CERTIFICATE_BASE64).
     required: false
     default: ''

--- a/.github/actions/sign-windows/action.yml
+++ b/.github/actions/sign-windows/action.yml
@@ -9,9 +9,11 @@ description: >
 inputs:
   certum-certificate-base64:
     description: >
-      Base64-encoded PEM certificate exported from Certum (public cert only —
-      the private key stays on the SimplySign HSM). Store in a GitHub Actions
-      secret (e.g. CERTUM_CERTIFICATE_BASE64).
+      Base64-encoded DER certificate exported from Certum (public cert only —
+      the private key stays on the SimplySign HSM). Obtain the DER bytes with
+      `openssl x509 -in certum.pem -outform DER -out certum.cer`, then
+      `base64 -w0 certum.cer`. Store the result in a GitHub Actions secret
+      (e.g. CERTUM_CERTIFICATE_BASE64).
     required: false
     default: ''
   certum-card-pin:
@@ -25,7 +27,7 @@ inputs:
   timestamp-url:
     description: 'RFC 3161 timestamp server URL'
     required: false
-    default: 'http://time.certum.pl'
+    default: 'https://time.certum.pl'
   files:
     description: >
       Space-separated list of files (or glob patterns) to sign.
@@ -62,9 +64,18 @@ runs:
       shell: powershell
       run: |
         $version = "7.1"
+        $expectedSha256 = "cfb48b07fdd2ee199bfc9e71d8dccdde67a799c4793602e446c7a101be62b3c4"
         $url = "https://github.com/ebourg/jsign/releases/download/$version/jsign-$version.jar"
-        Write-Host "Downloading jsign $version from $url"
-        Invoke-WebRequest $url -OutFile "$env:RUNNER_TEMP\jsign.jar"
+        $dest = "$env:RUNNER_TEMP\jsign.jar"
+        Write-Host "Downloading jsign $version"
+        Invoke-WebRequest $url -OutFile $dest
+        $actual = (Get-FileHash $dest -Algorithm SHA256).Hash.ToLower()
+        if ($actual -ne $expectedSha256) {
+          Write-Error "jsign SHA-256 mismatch: expected $expectedSha256 got $actual"
+          Remove-Item $dest -Force
+          exit 1
+        }
+        Write-Host "jsign SHA-256 verified."
 
     - name: Decode certificate
       if: steps.check.outputs.enabled == 'true'
@@ -72,19 +83,16 @@ runs:
       env:
         CERTUM_CERT_BASE64: ${{ inputs.certum-certificate-base64 }}
       run: |
-        # Strip PEM header/footer lines and whitespace if present
-        $b64 = ($env:CERTUM_CERT_BASE64 -split "`n" |
-          Where-Object { $_ -notmatch '^\s*-----' -and $_.Trim() -ne '' } |
-          ForEach-Object { $_.Trim() }) -join ''
+        # The secret is base64(DER). Decode to raw DER bytes and write a PEM
+        # file so jsign's --certfile argument can parse it.
         try {
-          $certBytes = [Convert]::FromBase64String($b64)
+          $derBytes = [Convert]::FromBase64String($env:CERTUM_CERT_BASE64.Trim())
         } catch {
           Write-Error "certum-certificate-base64 is not valid Base64."
           exit 1
         }
         $certPath = Join-Path $env:RUNNER_TEMP "certum.pem"
-        # Write back as PEM so jsign can parse it
-        $pemBody = [Convert]::ToBase64String($certBytes, 'InsertLineBreaks')
+        $pemBody = [Convert]::ToBase64String($derBytes, 'InsertLineBreaks')
         "-----BEGIN CERTIFICATE-----`n$pemBody`n-----END CERTIFICATE-----" |
           Out-File -FilePath $certPath -Encoding ascii
         Write-Host "Certificate decoded to $certPath"

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -314,25 +314,34 @@ jobs:
           echo "msix_name=$MSIX_NAME" >> "$GITHUB_OUTPUT"
           echo "Using MSIX filename: $MSIX_NAME"
 
-      # Build MSIX. The composite action handles: locating makeappx,
-      # generating AppxManifest.xml, staging assets, and packing.
-      # Signing is done in a separate step below using Certum SimplySign
-      # so the publisher-cn can be the real certificate CN when secrets
-      # are present, or the unsigned-namespace OID otherwise.
-      - name: Derive MSIX publisher CN
-        id: msix-publisher
+      # Single prerequisite check for MSIX signing. Emits:
+      #   signing_enabled — true only when all three secrets are present
+      #   publisher_dn    — real Subject DN when signing, OID placeholder otherwise
+      # actionlint does not allow secrets.* in if: expressions, so secrets
+      # are exposed as env vars and evaluated in shell.
+      - name: Check MSIX signing prerequisites
+        id: msix-sign-check
         shell: bash
         env:
           CERTUM_CERT: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
           CERTUM_PIN: ${{ secrets.CERTUM_CARD_PIN }}
-          CERTUM_CN: ${{ secrets.CERTUM_CERTIFICATE_CN }}
+          CERTUM_DN: ${{ secrets.CERTUM_CERTIFICATE_CN }}
         run: |
-          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_PIN" ] && [ -n "$CERTUM_CN" ]; then
-            echo "publisher_cn=$CERTUM_CN" >> "$GITHUB_OUTPUT"
+          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_PIN" ] && [ -n "$CERTUM_DN" ]; then
+            echo "signing_enabled=true" >> "$GITHUB_OUTPUT"
+            echo "publisher_dn=$CERTUM_DN" >> "$GITHUB_OUTPUT"
           else
-            echo "publisher_cn=CN=PythonSCAD, OID.2.25.311729368913984317654407730594956997722=1" >> "$GITHUB_OUTPUT"
+            echo "signing_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "publisher_dn=CN=PythonSCAD, OID.2.25.311729368913984317654407730594956997722=1" >> "$GITHUB_OUTPUT"
+            echo "Signing disabled: one or more of CERTUM_CERTIFICATE_BASE64, CERTUM_CARD_PIN, CERTUM_CERTIFICATE_CN is not set."
+            echo "Without all three secrets the MSIX publisher Subject DN would not match the signing certificate."
           fi
 
+      # Build MSIX. The composite action handles: locating makeappx,
+      # generating AppxManifest.xml, staging assets, and packing.
+      # Signing is handled separately below so the publisher Subject DN
+      # can be set to the real certificate DN when secrets are present,
+      # or the unsigned-namespace OID placeholder otherwise.
       - name: Build MSIX package
         id: msix
         uses: ./.github/actions/build-msix
@@ -340,34 +349,15 @@ jobs:
           staging-dir: build/staging
           executable-name: pythonscad.exe
           package-version: ${{ steps.msix-version.outputs.version }}
-          publisher-cn: ${{ steps.msix-publisher.outputs.publisher_cn }}
+          publisher-cn: ${{ steps.msix-sign-check.outputs.publisher_dn }}
           icon-source: resources/icons/pythonscad.png
           output-msix: ${{ steps.msix-filename.outputs.msix_name }}
 
-      # Check whether all three MSIX signing secrets are set.
-      # actionlint does not allow secrets.* in if: expressions, so we
-      # expose them as env vars and emit an output from a shell step.
-      - name: Check MSIX signing prerequisites
-        id: msix-sign-check
-        shell: bash
-        env:
-          CERTUM_CERT: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
-          CERTUM_PIN: ${{ secrets.CERTUM_CARD_PIN }}
-          CERTUM_CN: ${{ secrets.CERTUM_CERTIFICATE_CN }}
-        run: |
-          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_PIN" ] && [ -n "$CERTUM_CN" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping MSIX signing: one or more of CERTUM_CERTIFICATE_BASE64, CERTUM_CARD_PIN, CERTUM_CERTIFICATE_CN is not set."
-            echo "Without CERTUM_CERTIFICATE_CN the publisher-cn would not match the signing certificate Subject DN."
-          fi
-
-      # Gate MSIX signing on all three secrets. Without CERTUM_CERTIFICATE_CN
-      # the publisher-cn stays on the unsigned-namespace OID placeholder, which
-      # would not match the signing certificate Subject DN and produce an invalid MSIX.
+      # Gate MSIX signing on all three secrets (checked above). Without the
+      # real Subject DN the MSIX Identity Publisher would not match the signing
+      # certificate and makeappx/signtool would produce an invalid package.
       - name: Sign MSIX (Certum SimplySign)
-        if: steps.msix-sign-check.outputs.enabled == 'true'
+        if: steps.msix-sign-check.outputs.signing_enabled == 'true'
         uses: ./.github/actions/sign-windows
         with:
           certum-certificate-base64: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -324,9 +324,10 @@ jobs:
         shell: bash
         env:
           CERTUM_CERT: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
+          CERTUM_PIN: ${{ secrets.CERTUM_CARD_PIN }}
           CERTUM_CN: ${{ secrets.CERTUM_CERTIFICATE_CN }}
         run: |
-          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_CN" ]; then
+          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_PIN" ] && [ -n "$CERTUM_CN" ]; then
             echo "publisher_cn=$CERTUM_CN" >> "$GITHUB_OUTPUT"
           else
             echo "publisher_cn=CN=PythonSCAD, OID.2.25.311729368913984317654407730594956997722=1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -344,7 +344,30 @@ jobs:
           icon-source: resources/icons/pythonscad.png
           output-msix: ${{ steps.msix-filename.outputs.msix_name }}
 
+      # Determine whether all three MSIX signing secrets are present.
+      # secrets context is not available in if: expressions, so we
+      # expose them as env vars and check in a shell step instead.
+      - name: Check MSIX signing prerequisites
+        id: msix-sign-check
+        shell: bash
+        env:
+          CERTUM_CERT: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
+          CERTUM_PIN: ${{ secrets.CERTUM_CARD_PIN }}
+          CERTUM_CN: ${{ secrets.CERTUM_CERTIFICATE_CN }}
+        run: |
+          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_PIN" ] && [ -n "$CERTUM_CN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping MSIX signing: one or more of CERTUM_CERTIFICATE_BASE64, CERTUM_CARD_PIN, CERTUM_CERTIFICATE_CN is not set."
+            echo "Without CERTUM_CERTIFICATE_CN the publisher-cn would not match the signing certificate subject."
+          fi
+
+      # Gate MSIX signing on all three secrets. Without CERTUM_CERTIFICATE_CN
+      # the publisher-cn stays on the unsigned-namespace OID placeholder, which
+      # would not match the signing certificate subject and produce an invalid MSIX.
       - name: Sign MSIX (Certum SimplySign)
+        if: steps.msix-sign-check.outputs.enabled == 'true'
         uses: ./.github/actions/sign-windows
         with:
           certum-certificate-base64: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -269,6 +269,19 @@ jobs:
             echo "exe_name=$(basename "$EXE_FILE" .exe)" >> $GITHUB_OUTPUT
           fi
 
+      # Sign the NSIS installer EXE with Certum SimplySign.
+      # Requires repository secrets CERTUM_CERTIFICATE_BASE64 and CERTUM_CARD_PIN.
+      # If either secret is absent the step is skipped and an unsigned artifact
+      # is produced (suitable for test/snapshot builds).
+      # When signing is active the SimplySign Android/iOS app will show a push
+      # notification for each signed file — approve it to unblock the workflow.
+      - name: Sign artifacts (Certum SimplySign)
+        uses: ./.github/actions/sign-windows
+        with:
+          certum-certificate-base64: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
+          certum-card-pin: ${{ secrets.CERTUM_CARD_PIN }}
+          files: artifacts/*.exe
+
       - name: Upload ZIP package
         if: steps.artifacts.outputs.zip_path != ''
         uses: actions/upload-artifact@v7
@@ -285,12 +298,6 @@ jobs:
           path: ${{ steps.artifacts.outputs.exe_path }}
           retention-days: 30
 
-      # Build MSIX before the release upload so it can be included in the release assets.
-      # The composite action handles: locating makeappx, generating AppxManifest.xml,
-      # staging assets, packing, and optional code signing.
-      # To enable code signing add secrets WINDOWS_SIGN_CERTIFICATE (base64 PFX) and
-      # WINDOWS_SIGN_CERTIFICATE_PASSWORD to the repository, then uncomment the
-      # sign-certificate-base64 / sign-certificate-password inputs below.
       - name: Derive MSIX filename (match CPack ZIP naming)
         id: msix-filename
         run: |
@@ -306,6 +313,24 @@ jobs:
           echo "msix_name=$MSIX_NAME" >> "$GITHUB_OUTPUT"
           echo "Using MSIX filename: $MSIX_NAME"
 
+      # Build MSIX. The composite action handles: locating makeappx,
+      # generating AppxManifest.xml, staging assets, and packing.
+      # Signing is done in a separate step below using Certum SimplySign
+      # so the publisher-cn can be the real certificate CN when secrets
+      # are present, or the unsigned-namespace OID otherwise.
+      - name: Derive MSIX publisher CN
+        id: msix-publisher
+        shell: bash
+        env:
+          CERTUM_CERT: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
+          CERTUM_CN: ${{ secrets.CERTUM_CERTIFICATE_CN }}
+        run: |
+          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_CN" ]; then
+            echo "publisher_cn=$CERTUM_CN" >> "$GITHUB_OUTPUT"
+          else
+            echo "publisher_cn=CN=PythonSCAD, OID.2.25.311729368913984317654407730594956997722=1" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build MSIX package
         id: msix
         uses: ./.github/actions/build-msix
@@ -313,11 +338,16 @@ jobs:
           staging-dir: build/staging
           executable-name: pythonscad.exe
           package-version: ${{ steps.msix-version.outputs.version }}
-          publisher-cn: 'CN=PythonSCAD, OID.2.25.311729368913984317654407730594956997722=1'
+          publisher-cn: ${{ steps.msix-publisher.outputs.publisher_cn }}
           icon-source: resources/icons/pythonscad.png
           output-msix: ${{ steps.msix-filename.outputs.msix_name }}
-          # sign-certificate-base64: ${{ secrets.WINDOWS_SIGN_CERTIFICATE }}
-          # sign-certificate-password: ${{ secrets.WINDOWS_SIGN_CERTIFICATE_PASSWORD }}
+
+      - name: Sign MSIX (Certum SimplySign)
+        uses: ./.github/actions/sign-windows
+        with:
+          certum-certificate-base64: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
+          certum-card-pin: ${{ secrets.CERTUM_CARD_PIN }}
+          files: ${{ steps.msix-filename.outputs.msix_name }}
 
       - name: Upload MSIX artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -327,9 +327,12 @@ jobs:
           CERTUM_PIN: ${{ secrets.CERTUM_CARD_PIN }}
           CERTUM_DN: ${{ secrets.CERTUM_CERTIFICATE_CN }}
         run: |
-          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_PIN" ] && [ -n "$CERTUM_DN" ]; then
+          # Strip CR/LF so a DN pasted from PowerShell doesn't produce a
+          # multi-line GITHUB_OUTPUT entry that breaks downstream parsing.
+          CERTUM_DN_CLEAN="$(printf '%s' "$CERTUM_DN" | tr -d '\r\n')"
+          if [ -n "$CERTUM_CERT" ] && [ -n "$CERTUM_PIN" ] && [ -n "$CERTUM_DN_CLEAN" ]; then
             echo "signing_enabled=true" >> "$GITHUB_OUTPUT"
-            echo "publisher_dn=$CERTUM_DN" >> "$GITHUB_OUTPUT"
+            echo "publisher_dn=$CERTUM_DN_CLEAN" >> "$GITHUB_OUTPUT"
           else
             echo "signing_enabled=false" >> "$GITHUB_OUTPUT"
             echo "publisher_dn=CN=PythonSCAD, OID.2.25.311729368913984317654407730594956997722=1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -276,11 +276,12 @@ jobs:
       # When signing is active the SimplySign Android/iOS app will show a push
       # notification for each signed file — approve it to unblock the workflow.
       - name: Sign artifacts (Certum SimplySign)
+        if: steps.artifacts.outputs.exe_path != ''
         uses: ./.github/actions/sign-windows
         with:
           certum-certificate-base64: ${{ secrets.CERTUM_CERTIFICATE_BASE64 }}
           certum-card-pin: ${{ secrets.CERTUM_CARD_PIN }}
-          files: artifacts/*.exe
+          files: ${{ steps.artifacts.outputs.exe_path }}
 
       - name: Upload ZIP package
         if: steps.artifacts.outputs.zip_path != ''

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -344,9 +344,9 @@ jobs:
           icon-source: resources/icons/pythonscad.png
           output-msix: ${{ steps.msix-filename.outputs.msix_name }}
 
-      # Determine whether all three MSIX signing secrets are present.
-      # secrets context is not available in if: expressions, so we
-      # expose them as env vars and check in a shell step instead.
+      # Check whether all three MSIX signing secrets are set.
+      # actionlint does not allow secrets.* in if: expressions, so we
+      # expose them as env vars and emit an output from a shell step.
       - name: Check MSIX signing prerequisites
         id: msix-sign-check
         shell: bash
@@ -360,12 +360,12 @@ jobs:
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "Skipping MSIX signing: one or more of CERTUM_CERTIFICATE_BASE64, CERTUM_CARD_PIN, CERTUM_CERTIFICATE_CN is not set."
-            echo "Without CERTUM_CERTIFICATE_CN the publisher-cn would not match the signing certificate subject."
+            echo "Without CERTUM_CERTIFICATE_CN the publisher-cn would not match the signing certificate Subject DN."
           fi
 
       # Gate MSIX signing on all three secrets. Without CERTUM_CERTIFICATE_CN
       # the publisher-cn stays on the unsigned-namespace OID placeholder, which
-      # would not match the signing certificate subject and produce an invalid MSIX.
+      # would not match the signing certificate Subject DN and produce an invalid MSIX.
       - name: Sign MSIX (Certum SimplySign)
         if: steps.msix-sign-check.outputs.enabled == 'true'
         uses: ./.github/actions/sign-windows

--- a/doc/windows-code-signing.md
+++ b/doc/windows-code-signing.md
@@ -38,7 +38,7 @@ During the purchase/onboarding process Certum will:
 ## Part 2: Export your public certificate
 
 The private key stays on Certum's HSM and cannot be exported. You only need
-the **public certificate** (PEM format) for the CI workflow.
+the **public certificate in DER format** (base64-encoded) for the CI workflow.
 
 ### 2.1 Install proCertum CardManager
 
@@ -103,7 +103,7 @@ In your repository: **Settings → Secrets and variables → Actions**, add:
 
 | Secret name | Description |
 | --- | --- |
-| `CERTUM_CERTIFICATE_BASE64` | Full base64 output of your `certum.pem` file (from step 2.3) |
+| `CERTUM_CERTIFICATE_BASE64` | Full base64 output of your `certum.cer` DER file (from step 2.3) |
 | `CERTUM_CARD_PIN` | Your SimplySign card PIN |
 | `CERTUM_CERTIFICATE_CN` | Full Subject string of your certificate (from step 2.4), used as MSIX `publisher-cn` |
 
@@ -173,8 +173,8 @@ osslsigncode verify -in PythonSCAD-*-Installer.exe
 
 1. Purchase Certum Open Source Code Signing on SimplySign.
 2. Install SimplySign app on Android or iOS and link it to your account.
-3. Install proCertum CardManager; export your public certificate as PEM.
-4. Base64-encode the PEM and add it as `CERTUM_CERTIFICATE_BASE64` secret.
+3. Install proCertum CardManager; export your public certificate as DER (`certum.cer`).
+4. Base64-encode the DER file and add it as `CERTUM_CERTIFICATE_BASE64` secret.
 5. Add your SimplySign PIN as `CERTUM_CARD_PIN` secret.
 6. Add your certificate Subject string as `CERTUM_CERTIFICATE_CN` secret.
 7. Trigger the Windows package build; approve the SimplySign notification(s).

--- a/doc/windows-code-signing.md
+++ b/doc/windows-code-signing.md
@@ -45,35 +45,42 @@ the **public certificate** (PEM format) for the CI workflow.
 Download and install **proCertum CardManager** from the Certum website. This
 provides the PKCS#11 module that jsign uses to communicate with SimplySign.
 
-### 2.2 Export the certificate as PEM
+### 2.2 Export the certificate as DER
 
-On Windows, open a PowerShell prompt and run:
+The CI action expects **base64-encoded DER** (the raw binary certificate format),
+not a PEM text file. Export the DER bytes from your system certificate store:
+
+On Windows (PowerShell):
 
 ```powershell
-# List certificates on your SimplySign account
+# List certificates — find your Certum cert by thumbprint or issuer
 certutil -scinfo
 
-# Export the certificate to PEM (replace CERT_THUMBPRINT with your cert's thumbprint)
+# Export raw DER bytes (replace CERT_THUMBPRINT with your cert's thumbprint)
 $cert = Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.Thumbprint -eq 'CERT_THUMBPRINT' }
-$pemContent = "-----BEGIN CERTIFICATE-----`n" +
-  [Convert]::ToBase64String($cert.RawData, 'InsertLineBreaks') +
-  "`n-----END CERTIFICATE-----"
-$pemContent | Out-File -FilePath certum.pem -Encoding ascii
+[IO.File]::WriteAllBytes("certum.cer", $cert.RawData)
 ```
 
-Alternatively, use OpenSSL once the certificate appears in your system store:
+On Linux/macOS (if the cert was already downloaded as `.pem`):
 
 ```bash
-openssl x509 -in certum.cer -inform DER -out certum.pem
+openssl x509 -in certum.pem -outform DER -out certum.cer
 ```
 
-### 2.3 Base64-encode the PEM for GitHub
+### 2.3 Base64-encode the DER for GitHub
 
 ```bash
-base64 -w 0 certum.pem
+# Linux/macOS
+base64 -w0 certum.cer
+
+# PowerShell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("certum.cer"))
 ```
 
-Copy the entire output — you will paste it into a GitHub secret.
+Copy the entire single-line output — you will paste it into a GitHub secret.
+
+**Important:** the secret must be base64 of the raw DER bytes, not base64 of a
+PEM text file. The two look similar but are not interchangeable.
 
 ### 2.4 Find your certificate's CN
 

--- a/doc/windows-code-signing.md
+++ b/doc/windows-code-signing.md
@@ -70,10 +70,13 @@ openssl x509 -in certum.pem -outform DER -out certum.cer
 ### 2.3 Base64-encode the DER for GitHub
 
 ```bash
-# Linux/macOS
+# Linux (GNU coreutils)
 base64 -w0 certum.cer
 
-# PowerShell
+# macOS (BSD base64 — does not support -w)
+base64 certum.cer | tr -d '\n'
+
+# PowerShell (Windows)
 [Convert]::ToBase64String([IO.File]::ReadAllBytes("certum.cer"))
 ```
 

--- a/doc/windows-code-signing.md
+++ b/doc/windows-code-signing.md
@@ -1,0 +1,179 @@
+# Windows Code Signing with Certum SimplySign
+
+<!-- markdownlint-disable MD013 -->
+
+This guide explains how to sign PythonSCAD Windows builds (NSIS installer `.exe`
+and MSIX package) using a **Certum Open Source Code Signing** certificate on
+the SimplySign cloud HSM. The private key never leaves Certum's infrastructure;
+signing is authorized via a push notification on your Android or iOS device.
+
+## Overview
+
+- Signing uses [jsign](https://ebourg.github.io/jsign/), a Java-based
+  Authenticode signing tool with native Certum SimplySign support.
+- The GitHub Actions workflow signs artifacts automatically during the
+  `Build Windows Native Package` job.
+- When a signing operation is triggered, the **SimplySign mobile app** sends a
+  push notification to your phone. Approving it (with your PIN or biometric)
+  unblocks the workflow and completes the signature.
+- If the signing secrets are not configured the workflow still runs and produces
+  unsigned artifacts — suitable for snapshot/test builds.
+
+## Part 1: Purchase the Certificate
+
+Buy the **Open Source Code Signing on SimplySign** product from
+[certum.store](https://certum.store/open-source-code-signing-on-simplysign.html).
+
+- ~$58/year (pricing may change)
+- 5 000 signatures per month
+- Requires proof of open-source project status
+
+During the purchase/onboarding process Certum will:
+
+1. Verify your identity and project
+2. Issue a certificate tied to your SimplySign account
+3. Guide you through installing the **SimplySign** app on your Android or iOS
+   device
+
+## Part 2: Export your public certificate
+
+The private key stays on Certum's HSM and cannot be exported. You only need
+the **public certificate** (PEM format) for the CI workflow.
+
+### 2.1 Install proCertum CardManager
+
+Download and install **proCertum CardManager** from the Certum website. This
+provides the PKCS#11 module that jsign uses to communicate with SimplySign.
+
+### 2.2 Export the certificate as PEM
+
+On Windows, open a PowerShell prompt and run:
+
+```powershell
+# List certificates on your SimplySign account
+certutil -scinfo
+
+# Export the certificate to PEM (replace CERT_THUMBPRINT with your cert's thumbprint)
+$cert = Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.Thumbprint -eq 'CERT_THUMBPRINT' }
+$pemContent = "-----BEGIN CERTIFICATE-----`n" +
+  [Convert]::ToBase64String($cert.RawData, 'InsertLineBreaks') +
+  "`n-----END CERTIFICATE-----"
+$pemContent | Out-File -FilePath certum.pem -Encoding ascii
+```
+
+Alternatively, use OpenSSL once the certificate appears in your system store:
+
+```bash
+openssl x509 -in certum.cer -inform DER -out certum.pem
+```
+
+### 2.3 Base64-encode the PEM for GitHub
+
+```bash
+base64 -w 0 certum.pem
+```
+
+Copy the entire output — you will paste it into a GitHub secret.
+
+### 2.4 Find your certificate's CN
+
+The MSIX `publisher-cn` field must exactly match the Subject CN of your
+certificate. Find it with:
+
+```powershell
+$cert = Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.Thumbprint -eq 'CERT_THUMBPRINT' }
+$cert.Subject
+```
+
+It will look something like `CN=Your Name, O=Open Source Developer, ...`.
+You need the full Subject string in exactly this format.
+
+---
+
+## Part 3: GitHub Secrets
+
+In your repository: **Settings → Secrets and variables → Actions**, add:
+
+| Secret name | Description |
+| --- | --- |
+| `CERTUM_CERTIFICATE_BASE64` | Full base64 output of your `certum.pem` file (from step 2.3) |
+| `CERTUM_CARD_PIN` | Your SimplySign card PIN |
+| `CERTUM_CERTIFICATE_CN` | Full Subject string of your certificate (from step 2.4), used as MSIX `publisher-cn` |
+
+The workflow skips signing silently when `CERTUM_CERTIFICATE_BASE64` or
+`CERTUM_CARD_PIN` are absent, so unsigned test builds continue to work without
+any changes.
+
+---
+
+## Part 4: How the workflow uses this
+
+The `Build Windows Native Package` workflow
+(`.github/workflows/build-windows-native.yml`) calls the reusable composite
+action `.github/actions/sign-windows/action.yml` twice:
+
+1. **After NSIS packaging** — signs `artifacts/*.exe` (the installer)
+2. **After MSIX packaging** — signs the `.msix` file
+
+When `CERTUM_CERTIFICATE_CN` is also set, the MSIX `publisher-cn` is
+automatically switched from the unsigned-namespace OID placeholder to your real
+certificate subject, which is required for a validly signed MSIX.
+
+### Mobile app interaction
+
+Each file signing operation contacts the SimplySign cloud HSM. If your account
+is configured for push-notification authorization:
+
+- The **SimplySign app** shows a notification on your phone
+- You approve with your PIN or biometric
+- The workflow step unblocks and continues
+
+For a release with two signed files (`.exe` and `.msix`) you will receive
+**two notifications**. Keep the GitHub Actions page open in a browser tab so
+you can see progress.
+
+### Timeout
+
+GitHub Actions steps time out after **6 hours** by default — you have plenty
+of time to respond to the phone notification at your convenience during a
+release.
+
+---
+
+## Part 5: Verifying signatures
+
+After downloading a release artifact, verify the signature on Windows:
+
+```powershell
+# Check the NSIS installer
+Get-AuthenticodeSignature .\PythonSCAD-*-Installer.exe | Format-List
+
+# Check the MSIX
+Get-AuthenticodeSignature .\PythonSCAD-*.msix | Format-List
+```
+
+Both should show `Status: Valid` and a `SignerCertificate` issued by Certum.
+
+On Linux with osslsigncode:
+
+```bash
+osslsigncode verify -in PythonSCAD-*-Installer.exe
+```
+
+---
+
+## Summary checklist
+
+1. Purchase Certum Open Source Code Signing on SimplySign.
+2. Install SimplySign app on Android or iOS and link it to your account.
+3. Install proCertum CardManager; export your public certificate as PEM.
+4. Base64-encode the PEM and add it as `CERTUM_CERTIFICATE_BASE64` secret.
+5. Add your SimplySign PIN as `CERTUM_CARD_PIN` secret.
+6. Add your certificate Subject string as `CERTUM_CERTIFICATE_CN` secret.
+7. Trigger the Windows package build; approve the SimplySign notification(s).
+8. Verify signatures on the downloaded artifacts.
+
+Keep your SimplySign PIN secret. Never commit certificate private keys — with
+SimplySign there are none to commit.
+
+<!-- markdownlint-enable MD013 -->

--- a/doc/windows-code-signing.md
+++ b/doc/windows-code-signing.md
@@ -85,18 +85,18 @@ Copy the entire single-line output — you will paste it into a GitHub secret.
 **Important:** the secret must be base64 of the raw DER bytes, not base64 of a
 PEM text file. The two look similar but are not interchangeable.
 
-### 2.4 Find your certificate's CN
+### 2.4 Find your certificate's full Subject DN
 
-The MSIX `publisher-cn` field must exactly match the Subject CN of your
-certificate. Find it with:
+The MSIX `publisher-cn` field must exactly match the full **Subject Distinguished
+Name (DN)** of your certificate — not just the CN component. Find it with:
 
 ```powershell
 $cert = Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.Thumbprint -eq 'CERT_THUMBPRINT' }
 $cert.Subject
 ```
 
-It will look something like `CN=Your Name, O=Open Source Developer, ...`.
-You need the full Subject string in exactly this format.
+It will look something like `CN=Your Name, O=Open Source Developer, C=PL`.
+Copy the **entire string** exactly as printed — all components, in the same order.
 
 ---
 
@@ -108,7 +108,7 @@ In your repository: **Settings → Secrets and variables → Actions**, add:
 | --- | --- |
 | `CERTUM_CERTIFICATE_BASE64` | Full base64 output of your `certum.cer` DER file (from step 2.3) |
 | `CERTUM_CARD_PIN` | Your SimplySign card PIN |
-| `CERTUM_CERTIFICATE_CN` | Full Subject string of your certificate (from step 2.4), used as MSIX `publisher-cn` |
+| `CERTUM_CERTIFICATE_CN` | Full Subject DN of your certificate (from step 2.4), used as MSIX `publisher-cn` |
 
 The workflow skips signing silently when `CERTUM_CERTIFICATE_BASE64` or
 `CERTUM_CARD_PIN` are absent, so unsigned test builds continue to work without

--- a/doc/windows-code-signing.md
+++ b/doc/windows-code-signing.md
@@ -129,6 +129,25 @@ When `CERTUM_CERTIFICATE_CN` is also set, the MSIX `publisher-cn` is
 automatically switched from the unsigned-namespace OID placeholder to your real
 certificate subject, which is required for a validly signed MSIX.
 
+### Runner prerequisite: proCertum CardManager
+
+`jsign --storetype CRYPTOCERTUM` communicates with the SimplySign cloud HSM
+via the **proCertum CardManager PKCS#11 driver** (`sc30pkcs11.dll`).
+GitHub-hosted `windows-latest` runners do not include this software.
+
+The sign-windows action checks for the DLL at startup and fails fast with a
+clear error if it is missing. Before enabling signing in production you must
+add a silent-install step to `.github/actions/sign-windows/action.yml`:
+
+```powershell
+Invoke-WebRequest <pinned-url> -OutFile cardmanager.exe
+if ((Get-FileHash cardmanager.exe -Algorithm SHA256).Hash.ToLower() -ne '<sha256>') { exit 1 }
+Start-Process cardmanager.exe -ArgumentList '/S' -Wait
+```
+
+Download the installer from the Certum website, pin both the URL and SHA-256,
+and replace the placeholder comment in the action before your first signed release.
+
 ### Mobile app interaction
 
 Each file signing operation contacts the SimplySign cloud HSM. If your account

--- a/doc/windows-code-signing.md
+++ b/doc/windows-code-signing.md
@@ -110,8 +110,8 @@ In your repository: **Settings → Secrets and variables → Actions**, add:
 | `CERTUM_CARD_PIN` | Your SimplySign card PIN |
 | `CERTUM_CERTIFICATE_CN` | Full Subject DN of your certificate (from step 2.4), used as MSIX `publisher-cn` |
 
-The workflow skips signing silently when `CERTUM_CERTIFICATE_BASE64` or
-`CERTUM_CARD_PIN` are absent, so unsigned test builds continue to work without
+The workflow logs a skip message and produces unsigned artifacts when any of
+the required secrets are absent, so test builds continue to work without
 any changes.
 
 ---
@@ -122,12 +122,14 @@ The `Build Windows Native Package` workflow
 (`.github/workflows/build-windows-native.yml`) calls the reusable composite
 action `.github/actions/sign-windows/action.yml` twice:
 
-1. **After NSIS packaging** — signs `artifacts/*.exe` (the installer)
+1. **After NSIS packaging** — signs the resolved installer path
 2. **After MSIX packaging** — signs the `.msix` file
 
-When `CERTUM_CERTIFICATE_CN` is also set, the MSIX `publisher-cn` is
-automatically switched from the unsigned-namespace OID placeholder to your real
-certificate subject, which is required for a validly signed MSIX.
+When all three secrets (`CERTUM_CERTIFICATE_BASE64`, `CERTUM_CARD_PIN`, and
+`CERTUM_CERTIFICATE_CN`) are present, the MSIX `Identity Publisher` field is
+automatically set to your real certificate Subject DN. Otherwise the
+unsigned-namespace OID placeholder is used, which is required for a validly
+signed MSIX — the DN must match the signing certificate exactly.
 
 ### Runner prerequisite: proCertum CardManager
 


### PR DESCRIPTION
## Summary

Closes #633

- Add `.github/actions/sign-windows` reusable composite action that signs Windows Authenticode-signable artifacts (.exe, .dll, .msix) via [jsign](https://ebourg.github.io/jsign/) with the `CRYPTOCERTUM` storetype, which talks directly to Certum's SimplySign cloud HSM via the proCertum CardManager PKCS#11 driver — no PFX export needed.
- Wire the action into `build-windows-native.yml` to sign the NSIS installer `.exe` and the `.msix` after packaging. Both steps skip (with a log line) when secrets are absent so unsigned snapshot/test builds continue to work unchanged.
- Add `doc/windows-code-signing.md` — full setup guide covering certificate purchase, DER export, GitHub secrets, runner prerequisites, and signature verification; mirrors the existing `doc/macos-code-signing.md` in style.

### How signing works at release time

1. The `Build Windows Native Package` workflow runs on release.
2. The action checks that the proCertum CardManager PKCS#11 driver (`sc30pkcs11.dll`) is present — fails fast with a clear error if not.
3. After packaging, the `Sign artifacts` and `Sign MSIX` steps invoke jsign.
4. jsign contacts the Certum SimplySign cloud HSM, which sends a **push notification to the maintainer's Android/iOS app**.
5. The maintainer approves in the app → signing completes → workflow continues.

### Three GitHub secrets to add (once the certificate is purchased)

| Secret | Value |
| --- | --- |
| `CERTUM_CERTIFICATE_BASE64` | Base64-encoded DER certificate from Certum (`base64 -w0 certum.cer` on Linux, `base64 certum.cer \| tr -d '\n'` on macOS) |
| `CERTUM_CARD_PIN` | SimplySign card PIN |
| `CERTUM_CERTIFICATE_CN` | Full Subject Distinguished Name of the certificate (used as MSIX `publisher-cn`) |

### Runner prerequisite

`jsign --storetype CRYPTOCERTUM` requires the **proCertum CardManager PKCS#11 driver** on the runner. GitHub-hosted `windows-latest` runners do not include it. The action currently fails fast with a clear error when the driver is missing. A pinned silent-install step must be added before the first signed release — see `doc/windows-code-signing.md` Part 4 for the template.

## Test plan

- [ ] Verify workflow YAML passes `zizmor` and `actionlint` (done via pre-commit hooks on this branch)
- [ ] Trigger `Build Windows Native Package` via `workflow_dispatch` **without** secrets set — confirm signing steps are skipped and unsigned artifacts are produced as before
- [ ] Install proCertum CardManager, add the three secrets, trigger a test build, approve the SimplySign push notifications, verify signatures with `Get-AuthenticodeSignature` on the resulting `.exe` and `.msix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)