### PR TITLE
fix(gui): defer editorContentChanged signal until activeEditor is set

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -547,7 +547,6 @@ void TabManager::createTab(const QString& filename, bool initializeEmptyEditor)
   editor->addTemplate();
 
   connect(editor, &EditorInterface::contentsChanged, this, &TabManager::updateActionUndoState);
-  connect(editor, &EditorInterface::contentsChanged, parent, &MainWindow::editorContentChanged);
   connect(editor, &EditorInterface::contentsChanged, this, &TabManager::setContentRenderState);
   // Bump autosave generation on each edit while dirty. modificationChanged only fires when the
   // modified flag toggles, so typing in an already-dirty tab would otherwise not advance
@@ -590,6 +589,8 @@ void TabManager::createTab(const QString& filename, bool initializeEmptyEditor)
     }
   }
   parent->activeEditor = editor;
+  // Connect only after activeEditor is set; editorContentChanged() dereferences it immediately.
+  connect(editor, &EditorInterface::contentsChanged, parent, &MainWindow::editorContentChanged);
   editorList.insert(editor);
 
   // Get the name of the tab in editor


### PR DESCRIPTION
## Summary

Fixes #690 — crash (SIGSEGV) on startup when opening a file via the welcome/launcher dialog.

- `TabManager::createTab` was connecting `contentsChanged → MainWindow::editorContentChanged` **before** loading the file into the editor buffer.
- When `openTabFile` / `refreshDocument` called `editor->setPlainText(...)`, the signal fired while `parent->activeEditor` was still `nullptr` (it is only assigned after the file-loading block).
- `MainWindow::editorContentChanged` dereferences `activeEditor` on its very first line → null pointer dereference → SIGSEGV.
- The fix moves that single `connect()` call to immediately after `parent->activeEditor = editor`, so the slot is only reachable once the pointer is valid.

## Test plan

- [ ] Launch `./pythonscad` with no arguments, pick a file from the welcome screen → should open without crash
- [ ] Launch `./pythonscad <file>` directly → still works as before
- [ ] Open additional tabs while running → `editorContentChanged` fires correctly for subsequent edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)