### PR TITLE
fix(chore): accept defines on command line also during animation

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -665,7 +665,9 @@ int cmdline(const CommandLine& cmd)
 #ifdef ENABLE_PYTHON
       if (python_active) {
         initPython(PlatformUtils::applicationPath(), cmd.filename, &render_variables);
-        auto error = evaluatePython(text_py);
+        auto error = evaluatePython(commandline_commands);
+        if (error.size() > 0) LOG(error.c_str());
+        error = evaluatePython(text_py);
         if (error.size() > 0) LOG(error.c_str());
         finishPython();
       }


### PR DESCRIPTION
This PR fixes this by also send commandline_commands the python engine when animation is used