### PR TITLE
fix(gui): offer exit or discard when session file is too new

### DIFF
--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.24\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2015-03-06 10:27+0100\n"
 "Last-Translator: Miro Hrončok <miro@hroncok.cz>\n"
 "Language-Team: Czech <miro@hroncok.cz>\n"
@@ -523,7 +523,7 @@ msgid "Clear console"
 msgstr "Konzole"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 #, fuzzy
 msgid "Save As..."
 msgstr "Uložit &jako..."
@@ -1241,7 +1241,7 @@ msgid "Select Design"
 msgstr "Aplikace"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "Najít &předchozí"
@@ -3175,7 +3175,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr " Pro podrobnosti nahlédněte do <a href=\"#console\">konzole</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3223,12 +3223,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Aplikace"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3236,73 +3236,73 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Exportovat %s soubor(ů)"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Soubor(ů) (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Exportovat CSG soubor"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG soubory (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Exportovat obrázek"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG Soubory (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 #, fuzzy
 msgid "&Editor"
 msgstr "Editor"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 #, fuzzy
 msgid "&Console"
 msgstr "Konzole"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Skrýt &terminál"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Skrýt nástrojové lišty"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "Animovat"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "Seznam &písem"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Barevné téma:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Skrýt nástrojové lišty"
@@ -3449,21 +3449,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "&Design"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "OpenSCAD designy(*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Soubor(ů) (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3471,11 +3471,11 @@ msgstr ""
 "%1 již existuje.\n"
 "Chcete jej nahradit?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3485,11 +3485,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3499,49 +3499,72 @@ msgstr ""
 "%1 již existuje.\n"
 "Chcete jej nahradit?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Soubor"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 #, fuzzy
 msgid "Close Tab"
 msgstr "Zavřít"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Chcete uložit změny?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Příště nezobrazovat"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3551,7 +3574,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3560,49 +3583,40 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 #, fuzzy
 msgid "Failed to open file for writing"
 msgstr "Nepodařilo se otevřít soubor %s: %s"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr ""
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Uložit soubor"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Uložit &jako..."

--- a/locale/de.po
+++ b/locale/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2014.01.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2021-12-04 20:17+0100\n"
 "Last-Translator: Torsten Paul <Torsten.Paul@gmx.de>\n"
 "Language-Team: German\n"
@@ -542,7 +542,7 @@ msgid "Clear console"
 msgstr "Konsole löschen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "Speichern &Unter..."
 
@@ -1271,7 +1271,7 @@ msgid "Select Design"
 msgstr "Aktion"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1332,7 +1332,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&Fenster"
@@ -3186,7 +3186,7 @@ msgstr ""
 " Für Details die <a href=\"#errorlog\">Fehlerliste</a> oder <a "
 "href=\"#console\">Konsolen-Fenster</a> öffnen."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3234,12 +3234,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Application"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3247,70 +3247,70 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "%1 Datei exportieren"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Dateien (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Export CSG File"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG Dateien (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Image exportieren"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG Dateien (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr "&Editor"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "&Konsole"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "C&ustomizer"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Fehlerliste"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "Animation"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "&Fontliste"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Farbschema:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "3D Symbolleiste ausblenden"
@@ -3459,21 +3459,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "D&esign"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "OpenSCAD Designs (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Dateien (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3481,11 +3481,11 @@ msgstr ""
 "%1 existiert bereits.\n"
 "Möchten Sie die Datei ersetzen?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3495,11 +3495,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3509,48 +3509,71 @@ msgstr ""
 "%1 existiert bereits.\n"
 "Möchten Sie die Datei ersetzen?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "Dateiname kopieren"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "Pfad kopieren"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Datei öffen"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr "Reiter schließen"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Möchten Sie die Änderungen speichern?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Dialog nicht wieder anzeigen"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3560,7 +3583,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3569,48 +3592,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Datei konnte nicht zum schreiben geöffnet werden"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Fehler beim speichern des Designs"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Speichern Unter..."

--- a/locale/es.po
+++ b/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2025-04-10 09:14-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: Español\n"
@@ -522,7 +522,7 @@ msgid "Clear console"
 msgstr "Limpiar consola"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "Guardar Como..."
 
@@ -1237,7 +1237,7 @@ msgid "Select Design"
 msgstr "Acción"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1298,7 +1298,7 @@ msgid "Ctrl+R"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&Ventana"
@@ -3115,7 +3115,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr ""
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3163,12 +3163,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Aplicación"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3176,70 +3176,70 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Exportar el archivo %1"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Archivos (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Exportar archivo CSG"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "Archivos CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Exportar una imagen"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "Archivos PNG (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 #, fuzzy
 msgid "&Editor"
 msgstr "Editar"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "&Consola"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Widget de parámetros"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 msgid "Error-&Log"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 msgid "&Animate"
 msgstr "&Animar"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "Lista de &Fuentes"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Paleta de colores:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 msgid "&Viewport-Control"
 msgstr ""
 
@@ -3381,21 +3381,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "&Diseñar"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "Diseños OpenSCAD (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Archivos (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3403,11 +3403,11 @@ msgstr ""
 "%1 ya existe.\n"
 "Desea reemplazarlo?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3417,11 +3417,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3431,48 +3431,71 @@ msgstr ""
 "%1 ya existe.\n"
 "Desea reemplazarlo?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "Abrir Archiv&o"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "¿Desea guardar los cambios?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "No mostrar de nuevo"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3482,7 +3505,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3491,48 +3514,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr ""
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Guardar como..."

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.07\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2019-09-17 \n"
 "Last-Translator: Pierre ROUZEAU <github.com/PRouzeau>\n"
 "Language-Team: French\n"
@@ -536,7 +536,7 @@ msgid "Clear console"
 msgstr "Effacer la console"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 #, fuzzy
 msgid "Save As..."
 msgstr "Enregistrer &sous..."
@@ -1266,7 +1266,7 @@ msgid "Select Design"
 msgstr "Action"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "Rechercher &Précédent"
@@ -3220,7 +3220,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr " Pour les détails voir <a href=\"#console\">fenêtre de la Console</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3268,12 +3268,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Application"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3281,73 +3281,73 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Exporter le fichier %1"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Fichiers (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Exporter un fichier CSG"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "Fichiers CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Exporter une Image"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "Fichiers PNG (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 #, fuzzy
 msgid "&Editor"
 msgstr "Éditeur"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 #, fuzzy
 msgid "&Console"
 msgstr "Console"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Panneau de personnalisation"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Erreur"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "Animer"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "Liste des &polices"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Palette de couleurs:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Cacher les boîtes à outils"
@@ -3494,21 +3494,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "Conception"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "Conceptions OpenSCAD (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Fichiers (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3516,11 +3516,11 @@ msgstr ""
 "%1 existe déjà.\n"
 "Voulez-vous le remplacer?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3530,11 +3530,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3544,49 +3544,72 @@ msgstr ""
 "%1 existe déjà.\n"
 "Voulez-vous le remplacer?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Fichier"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 #, fuzzy
 msgid "Close Tab"
 msgstr "Fermer"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Voulez-vous enregistrer vos changements?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Ne plus afficher"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3596,7 +3619,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3605,48 +3628,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Échec d'ouverture de fichier en écriture"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Erreur lors de l'enregistrement de la conception"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Enregistrer le Fichier"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Enregistrer &sous..."

--- a/locale/hy.po
+++ b/locale/hy.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2020.02.01\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2020-04-20 17:00+0400\n"
 "Last-Translator: Sargis Malkonyan <melkonyansarg@gmail.com>\n"
 "Language-Team: Agarak Armath Engineering Laboratories\n"
@@ -531,7 +531,7 @@ msgid "Clear console"
 msgstr "Մաքրել հրամանների վահանակը"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 #, fuzzy
 msgid "Save As..."
 msgstr "Պահել &որպես..."
@@ -1260,7 +1260,7 @@ msgid "Select Design"
 msgstr "Գործողություն"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1325,7 +1325,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&Փնտրել նախորդը"
@@ -3203,7 +3203,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr "Տեսնել ավելին՝ <a href=\"#console\">վահանակի պատուհանը</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3251,12 +3251,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Ծրագիր"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3264,73 +3264,73 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Արտահանել նիշք %1"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Նիշքեր (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Արտահանել CSG նիշքը"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG Նիշքեր (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Արտահանել նկար"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG Նիշքեր (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 #, fuzzy
 msgid "&Editor"
 msgstr "Խմբագիր"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 #, fuzzy
 msgid "&Console"
 msgstr "Վահանակ"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Անհատական հարմարեցում"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Սխալմունք"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "Կենդանացնել"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "&Տառատեսակի ցանկ"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Գունային համակարգ։"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Թաքցնել գործիքների վահանակը"
@@ -3476,21 +3476,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "&Դիզայն"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "OpenSCAD֊ի դիզայն (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Նիշքեր (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3498,11 +3498,11 @@ msgstr ""
 "%1 արդեն գոյություն ունի.\n"
 "Ցանկանո՞ւմ եք փոխարինել այն։"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3512,11 +3512,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3526,49 +3526,72 @@ msgstr ""
 "%1 արդեն գոյություն ունի.\n"
 "Ցանկանո՞ւմ եք փոխարինել այն։"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Նիշք"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 #, fuzzy
 msgid "Close Tab"
 msgstr "Փակել"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Ցանկանում եք պահպանել կատարած փոփոխությունները?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Այլևս չցուցադրել"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3578,7 +3601,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3587,48 +3610,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Չհաջողվեց բացել նիշքը խմբագրելու համար"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Էսքիզը չհաջողվեց պահպանել"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Պահպանել նիշքը"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Պահպանել որպես՝"

--- a/locale/it.po
+++ b/locale/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2024.01.06\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2025-08-02 19:25+0200\n"
 "Last-Translator: \n"
 "Language-Team: Italian\n"
@@ -526,7 +526,7 @@ msgid "Clear console"
 msgstr "Pulisci console"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "Salva come..."
 
@@ -1272,7 +1272,7 @@ msgid "Select Design"
 msgstr "Azione"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1333,7 +1333,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&Finestra"
@@ -3181,7 +3181,7 @@ msgstr ""
 " Per i dettagli guardare la <a href=\"#errorlog\">finestra degli Errori</a> "
 "e <a href=\"#console\">la Console</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3230,12 +3230,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Applicazione"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3243,69 +3243,69 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Esportato %1 File"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Files (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Esporta file CSG"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "Files CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Esporta Immagine"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "Files PNG (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr "&Editor"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "&Console"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "&Configuratore"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Errori"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 msgid "&Animate"
 msgstr "&Animazione"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "&Caratteri usati"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Schema Colori:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Inquadratura"
@@ -3452,21 +3452,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "Files attendibili"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "Progetto OpenSCAD (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Files (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3474,11 +3474,11 @@ msgstr ""
 "%1 esiste già.\n"
 "Si desidera sovrascriverlo?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3488,11 +3488,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3502,48 +3502,71 @@ msgstr ""
 "%1 esiste già.\n"
 "Si desidera sovrascriverlo?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "Copia nome file"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "Copia intero percorso"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "Apri &cartella"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr "Chiudi Scheda"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Si desidera salvare le modifiche?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Non mostrare più"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3553,7 +3576,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3562,48 +3585,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Fallita apertura del file in scrittura"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Errore di salvataggio Progetto"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Salva File"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Salva una Copia"

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2022.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2023-02-14 16:47+0100\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <(nothing)>\n"
@@ -526,7 +526,7 @@ msgid "Clear console"
 msgstr "კონსოლის გასუფთავება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "შენახვა, როგორც..."
 
@@ -1253,7 +1253,7 @@ msgid "Select Design"
 msgstr "პარამეტრები"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1314,7 +1314,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&ფანჯარა"
@@ -3168,7 +3168,7 @@ msgstr ""
 " დეტალებისთვის იხილეთ <a href=\"#errorlog\">შეცდომების ჟურნალი</a> და <a "
 "href=\"#console\">კონსოლის ფანჯარა</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3216,12 +3216,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "აპლიკაცია"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3229,70 +3229,70 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "%1 ფაილის გატანა"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 ფაილი (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "CSG ფაილის გატანა"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG ფაილები (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "გამოსახულების გატანა"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG ფაილები (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr "&რედაქტორი"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "&კონსოლი"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "&მომრგები"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "შეცდომების-ჟურნალი"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "ან_იმაცია"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "&ფონტების სია"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "ფერების სქემა:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "3D ხელსაწყოთა ზოლის დამალვა"
@@ -3440,21 +3440,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "&დიზაინი"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "OpenSCAD-ის დიზაინები(*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 ფაილი (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3462,11 +3462,11 @@ msgstr ""
 "%1 უკვე არსებობს\n"
 "გნებავთ გადააწეროთ?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3476,11 +3476,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3490,48 +3490,71 @@ msgstr ""
 "%1 უკვე არსებობს\n"
 "გნებავთ გადააწეროთ?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "ფაილის სახელის კოპირება"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "სრული ბილიკის კოპირება"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "საქაღალდის გახსნა"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr "ჩანართის დახურვა"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "გნებავთ შეინახოთ თქვენი ცვლილებები?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "მეორედ არ მაჩვენო"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3541,7 +3564,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3550,48 +3573,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "ფაილის ჩასაწერად გახსნის შეცდომა"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "დიზაინის შენახვის შეცდომა"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "ფაილის შენახვა"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "ყველას შენახვა"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2021-06-19 19:07+0100\n"
 "Last-Translator: Jarosław Teterycz <openscad@jtk.com.pl>\n"
 "Language-Team: \n"
@@ -537,7 +537,7 @@ msgid "Clear console"
 msgstr "Wyczyść konsolę"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 #, fuzzy
 msgid "Save As..."
 msgstr "Zapisz &jako…"
@@ -1267,7 +1267,7 @@ msgid "Select Design"
 msgstr "Akcja"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1332,7 +1332,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "Okno"
@@ -3215,7 +3215,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr " Szczegóły w <a href=\"#console\">oknie konsoli</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3263,12 +3263,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Aplikacja"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3276,72 +3276,72 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Eksportuj plik %1"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "Pliki %1 (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Eksportuj plik CSG"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "Pliki CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Eksportuj obrazek"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "Pliki PNG (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 #, fuzzy
 msgid "&Editor"
 msgstr "Edytor"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 #, fuzzy
 msgid "&Console"
 msgstr "Konsola"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "Panel dostosowania"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Dziennik błędów"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "Animuj"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "Lista &czcionek"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Schemat kolorów:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Ukryj pasek narzędzi podglądu 3D"
@@ -3486,21 +3486,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "P&rojekt"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "Projekty OpenSCAD (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "Pliki %1 (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3508,11 +3508,11 @@ msgstr ""
 "%1 już istnieje.\n"
 "Czy chcesz nadpisać?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3522,11 +3522,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3536,49 +3536,72 @@ msgstr ""
 "%1 już istnieje.\n"
 "Czy chcesz nadpisać?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "Skopiuj nazwę pliku"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "Skopiuj pełną ścieżkę"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Otwórz plik"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 #, fuzzy
 msgid "Close Tab"
 msgstr "Zamknij zakładkę"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Czy chcesz zapisać zmiany?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Nie pokazuj ponownie"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3588,7 +3611,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3597,48 +3620,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Nie udało się otworzyć pliku do zapisu"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Błąd przy zapisie projektu"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Zapisz plik"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Zapisz &jako"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2025-04-10 09:02-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: \n"
@@ -529,7 +529,7 @@ msgid "Clear console"
 msgstr "Limpar console"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "Salvar Como..."
 
@@ -1276,7 +1276,7 @@ msgid "Select Design"
 msgstr "Ação"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1337,7 +1337,7 @@ msgid "Ctrl+R"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&Janela"
@@ -3191,7 +3191,7 @@ msgstr ""
 " Para mais detalhes veja o <a href=\"#errorlog\">log de erros</a> e a <a "
 "href=\"#console\">janela do console</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3240,12 +3240,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Aplicação"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3253,69 +3253,69 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Exportar o arquivo %1"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Arquivos (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Exportar arquivo CSG"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "Arquivos CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Exportar una imagen"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "Arquivos PNG (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr "&Editor"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "&Console"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "C&ustomizador"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "&Log de Erros"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 msgid "&Animate"
 msgstr "&Animar"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "Lista de &Fontes"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Esquema de colores:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Controle-Viewport"
@@ -3460,21 +3460,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "Arquivos Confiáveis"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "Designs OpenSCAD (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Arquivos (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3482,11 +3482,11 @@ msgstr ""
 "%1 já existe.\n"
 "Deseja substituí-lo?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3496,11 +3496,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3510,48 +3510,71 @@ msgstr ""
 "%1 já existe.\n"
 "Deseja substituí-lo?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "Copiar nome de arquivo"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "Copiar todo caminho"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "Abrir pasta"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr "Fechar Aba"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Deseja salvar as alterações?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Não mostrar novamente"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3561,7 +3584,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3570,48 +3593,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Falha abrindo arquivo para escrita"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Erro salvando design"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Salvar arquivo"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Salvar um Cópia"

--- a/locale/pythonscad.pot
+++ b/locale/pythonscad.pot
@@ -1,4 +1,4 @@
-# #-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.05.24)  #-#-#-#-#
+# #-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.06.01)  #-#-#-#-#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the OpenSCAD package.
@@ -7,10 +7,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"#-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.05.24)  #-#-#-#-#\n"
-"Project-Id-Version: OpenSCAD 2026.05.24\n"
+"#-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.06.01)  #-#-#-#-#\n"
+"Project-Id-Version: OpenSCAD 2026.06.01\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "#-#-#-#-#  appdata-strings.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -515,7 +515,7 @@ msgid "Clear console"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr ""
 
@@ -1204,7 +1204,7 @@ msgid "Select Design"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1265,7 +1265,7 @@ msgid "Ctrl+R"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 msgid "Close &Window"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr ""
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3098,12 +3098,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3111,67 +3111,67 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 msgid "Error-&Log"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 msgid "&Animate"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 msgid "C&olor List"
 msgstr ""
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 msgid "&Viewport-Control"
 msgstr ""
 
@@ -3297,29 +3297,29 @@ msgstr ""
 msgid "Trust Design"
 msgstr ""
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 msgid "OpenSCAD script (*.scad)"
 msgstr ""
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 msgid "All files (*)"
 msgstr ""
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
 msgstr ""
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3329,56 +3329,79 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 msgid ""
 "The file \"%1\" does not exist.\n"
 "\n"
 "Do you want to create it?"
 msgstr ""
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 msgid "Open Folder"
 msgstr ""
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 msgid "Do you want to save the changes you made to %1?"
 msgstr ""
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 msgid "Don't save"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3388,7 +3411,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3397,48 +3420,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr ""
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr ""
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 msgid "Save A Copy"
 msgstr ""
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2022-09-30 00:36+0300\n"
 "Last-Translator: Konstantin Podsvirov <konstantin@podsvirov.pro>\n"
 "Language-Team: \n"
@@ -528,7 +528,7 @@ msgid "Clear console"
 msgstr "Очистить консоль"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "Сохранить как..."
 
@@ -1255,7 +1255,7 @@ msgid "Select Design"
 msgstr "Действие"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&Окно"
@@ -3163,7 +3163,7 @@ msgstr ""
 "Подробнее см. в <a href=\"#errorlog\">журнале ошибок</a> и <a "
 "href=\"#console\">окне консоли</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3211,12 +3211,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Приложение"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3224,69 +3224,69 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Экспортировать файл %1"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "Файлы %1 (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Экспортировать файл CSG"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "Файлы CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Экспортировать изображение"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "Файлы PNG (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr "&Редактор"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "&Консоль"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "Настройщик"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Журнал ошибок"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 msgid "&Animate"
 msgstr "&Анимация"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "Список &шрифтов"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Цветовая схема:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Управление вьюпортом"
@@ -3432,21 +3432,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "&Модель"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "Модели OpenSCAD (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "Файлы %1 (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3454,11 +3454,11 @@ msgstr ""
 "%1 уже существует.\n"
 "Перезаписать?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3468,11 +3468,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3482,48 +3482,71 @@ msgstr ""
 "%1 уже существует.\n"
 "Перезаписать?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "Скопировать имя файла"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "Скопировать полный путь"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Сохранить изменения?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Больше не показывать"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3533,7 +3556,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3542,48 +3565,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Не удалось открыть файл для записи"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Ошибка при сохранении проекта"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Сохранить файл"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Сохранить как"

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2021.12.04\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2021-12-04 17:55+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: Turkish\n"
@@ -533,7 +533,7 @@ msgid "Clear console"
 msgstr "Konsolü temizle"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "Farklı Kaydet..."
 
@@ -1260,7 +1260,7 @@ msgid "Select Design"
 msgstr "Eylem"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "&Pencere"
@@ -3180,7 +3180,7 @@ msgstr ""
 " Ayrıntılar için <a href=\"#errorlog\">hata günlüğüne</a> ve <a "
 "href=\"#console\">konsol penceresine</a> bakın."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3228,12 +3228,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Uygulama"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3241,70 +3241,70 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "%1 Dosyasını Dışa Aktar"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 Dosya (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "CSG Dosyasını Dışa Aktar"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG Dosyaları (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Görüntüyü Dışa Aktar"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG Dosyaları (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr "&Düzenleyici"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "&Konsol"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "Ö&zelleştirici"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Hata-Günlüğü"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "Canlandır"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "&Yazı Tipi Listesi"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Renk şeması:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "3B Görünüm araç çubuğunu gizle"
@@ -3450,21 +3450,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "&Tasarım"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "OpenSCAD Tasarımları (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 Dosya (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3472,11 +3472,11 @@ msgstr ""
 "%1 zaten var.\n"
 "Değiştirmek istiyor musun?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3486,11 +3486,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3500,48 +3500,71 @@ msgstr ""
 "%1 zaten var.\n"
 "Değiştirmek istiyor musun?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "Dosya adını kopyala"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "Tam yolu kopyala"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Dosya Aç"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Değişiklikleri kaydetmek istiyor musunuz?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Bir daha gösterme"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3551,7 +3574,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3560,48 +3583,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Dosya yazmak için açılamadı"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Tasarım kaydedilirken hata oluştu"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Dosyayı Kaydet"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Hepsini Kaydet"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2018.08.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2018-11-11 13:00+0200\n"
 "Last-Translator: Kyrylo Romanenko <romanenko-kv@hotmail.com>\n"
 "Language-Team: Ukrainian\n"
@@ -531,7 +531,7 @@ msgid "Clear console"
 msgstr "Консоль"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 #, fuzzy
 msgid "Save As..."
 msgstr "Зберегти &як..."
@@ -1260,7 +1260,7 @@ msgid "Select Design"
 msgstr "Програма"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1325,7 +1325,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "Знайти &попереднє"
@@ -3189,7 +3189,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr " Для деталей дивіться <a href=\"#console\">вікно консолі</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3237,12 +3237,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "Програма"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3250,73 +3250,73 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "Експорт файлу %1"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 файли (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "Експорт CSG файлу"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG файли (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "Експорт зображення"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG файли (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 #, fuzzy
 msgid "&Editor"
 msgstr "Редактор"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 #, fuzzy
 msgid "&Console"
 msgstr "Консоль"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Кастомайзер"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "Сховати панелі інструментів"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "Анімувати"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "Список &шрифтів"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "Схема кольорів:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "Сховати панелі інструментів"
@@ -3463,21 +3463,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "&Дизайн"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "Дизайн OpenSCAD (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 файли (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3485,11 +3485,11 @@ msgstr ""
 "%1 вже існує.\n"
 "Перезаписати?"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3499,11 +3499,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3513,49 +3513,72 @@ msgstr ""
 "%1 вже існує.\n"
 "Перезаписати?"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Файл"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 #, fuzzy
 msgid "Close Tab"
 msgstr "Закрити"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Зберегти ваші зміни?"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "Не показувати знову"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3565,7 +3588,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3574,48 +3597,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "Неможливо відкрити файл для запису"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "Помилка при збереженні дизайну"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "Збереги файл"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Зберегти &як..."

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2021-02-26 14:17+0800\n"
 "Last-Translator: 玉堂白鹤 <yjwork@qq.com>\n"
 "Language-Team: \n"
@@ -535,7 +535,7 @@ msgid "Clear console"
 msgstr "清除控制台"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 msgid "Save As..."
 msgstr "另存为..."
 
@@ -1262,7 +1262,7 @@ msgid "Select Design"
 msgstr "动作"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "窗口(&W)"
@@ -3171,7 +3171,7 @@ msgstr ""
 " 详见 <a href=\"#errorlog\">错误日志</a>和<a href=\"#console\">控制台窗口</"
 "a>。"
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3219,12 +3219,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "应用程序"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3232,70 +3232,70 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "导出 %1 文件"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 文件 (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "导出 CSG 文件"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG 文件 (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "导出图像"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG 文件 (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 msgid "&Editor"
 msgstr "编辑器(&E)"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 msgid "&Console"
 msgstr "控制台(&C)"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 msgid "C&ustomizer"
 msgstr "定制器(&U)"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "错误日志"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "动画"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "字体列表(&F)"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "配色方案:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "隐藏 3D 视图工具栏"
@@ -3440,21 +3440,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "模型(&D)"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "OpenSCAD 设计文件 (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 文件 (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3462,11 +3462,11 @@ msgstr ""
 "%1 已经存在。\n"
 "您要替换它么？"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3476,11 +3476,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3490,48 +3490,71 @@ msgstr ""
 "%1 已经存在。\n"
 "您要替换它么？"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "复制文件名"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "复制完整路径"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "打开文件(&O)"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 msgid "Close Tab"
 msgstr "关闭标签"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "要保存更改吗？"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "不再显示"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3541,7 +3564,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3550,48 +3573,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "无法打开文件进行写入"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "保存设计时出错"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "保存文件"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "另存为"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2020.02.17\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-24 02:48+0200\n"
+"POT-Creation-Date: 2026-06-01 03:39+0200\n"
 "PO-Revision-Date: 2020-05-28 14:42+0200\n"
 "Last-Translator: Michael Tsao <cwtsao@sce.pccu.edu.tw>\n"
 "Language-Team: Distance Learning Center at the Chinese Culture University "
@@ -534,7 +534,7 @@ msgid "Clear console"
 msgstr "清除控制台"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1801
+#: src/gui/TabManager.cc:1840
 #, fuzzy
 msgid "Save As..."
 msgstr "另存為(&A)"
@@ -1264,7 +1264,7 @@ msgid "Select Design"
 msgstr "動作"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
-#: src/gui/MainWindow.cc:4442
+#: src/gui/MainWindow.cc:4443
 msgid "Welcome..."
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgid "Ctrl+R"
 msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1088
-#: src/gui/MainWindow.cc:4443
+#: src/gui/MainWindow.cc:4444
 #, fuzzy
 msgid "Close &Window"
 msgstr "新視窗"
@@ -3196,7 +3196,7 @@ msgid ""
 "href=\"#console\">console window</a>."
 msgstr "詳見<a href=\"#console\">控制台視窗</a>."
 
-#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:230
+#: src/gui/MainWindow.cc:1543 src/gui/TabManager.cc:232
 msgid "Session Save"
 msgstr ""
 
@@ -3244,12 +3244,12 @@ msgstr ""
 msgid "Select Virtual Environment"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2347 src/gui/TabManager.cc:197
-#: src/gui/TabManager.cc:295
+#: src/gui/MainWindow.cc:2348 src/gui/TabManager.cc:199
+#: src/gui/TabManager.cc:297
 msgid "Application"
 msgstr "套用"
 
-#: src/gui/MainWindow.cc:2348
+#: src/gui/MainWindow.cc:2349
 msgid ""
 "The file has changed on disk, but this tab has unsaved edits.\n"
 "Reloading will discard your changes.\n"
@@ -3257,73 +3257,73 @@ msgid ""
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2968
+#: src/gui/MainWindow.cc:2969
 msgid "Click to change language"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3013
+#: src/gui/MainWindow.cc:3014
 msgid "Auto-detect from file extension"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3412
+#: src/gui/MainWindow.cc:3413
 msgid "Export %1 File"
 msgstr "匯出 %1 檔案"
 
-#: src/gui/MainWindow.cc:3413
+#: src/gui/MainWindow.cc:3414
 msgid "%1 Files (*%2)"
 msgstr "%1 個檔案 (*%2)"
 
-#: src/gui/MainWindow.cc:3461
+#: src/gui/MainWindow.cc:3462
 msgid "Export CSG File"
 msgstr "匯出CSG檔案"
 
-#: src/gui/MainWindow.cc:3462
+#: src/gui/MainWindow.cc:3463
 msgid "CSG Files (*.csg)"
 msgstr "CSG檔案 (*.csg)"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "Export Image"
 msgstr "匯出圖片"
 
-#: src/gui/MainWindow.cc:3485
+#: src/gui/MainWindow.cc:3486
 msgid "PNG Files (*.png)"
 msgstr "PNG檔 (*.png)"
 
-#: src/gui/MainWindow.cc:4742
+#: src/gui/MainWindow.cc:4743
 #, fuzzy
 msgid "&Editor"
 msgstr "編輯器"
 
-#: src/gui/MainWindow.cc:4743
+#: src/gui/MainWindow.cc:4744
 #, fuzzy
 msgid "&Console"
 msgstr "控制台"
 
-#: src/gui/MainWindow.cc:4744
+#: src/gui/MainWindow.cc:4745
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "自訂"
 
-#: src/gui/MainWindow.cc:4745
+#: src/gui/MainWindow.cc:4746
 #, fuzzy
 msgid "Error-&Log"
 msgstr "錯誤日誌"
 
-#: src/gui/MainWindow.cc:4746
+#: src/gui/MainWindow.cc:4747
 #, fuzzy
 msgid "&Animate"
 msgstr "動畫"
 
-#: src/gui/MainWindow.cc:4747
+#: src/gui/MainWindow.cc:4748
 msgid "&Font List"
 msgstr "字型清單(&F)"
 
-#: src/gui/MainWindow.cc:4748
+#: src/gui/MainWindow.cc:4749
 #, fuzzy
 msgid "C&olor List"
 msgstr "色彩方案:"
 
-#: src/gui/MainWindow.cc:4749
+#: src/gui/MainWindow.cc:4750
 #, fuzzy
 msgid "&Viewport-Control"
 msgstr "隱藏3D檢視工具列"
@@ -3463,21 +3463,21 @@ msgstr ""
 msgid "Trust Design"
 msgstr "設計(&D)"
 
-#: src/gui/TabManager.cc:128
+#: src/gui/TabManager.cc:130
 msgid "Python script (*.py)"
 msgstr ""
 
-#: src/gui/TabManager.cc:131 src/gui/TabManager.cc:136
+#: src/gui/TabManager.cc:133 src/gui/TabManager.cc:138
 #, fuzzy
 msgid "OpenSCAD script (*.scad)"
 msgstr "OpenSCAD設計 (*.scad)"
 
-#: src/gui/TabManager.cc:139
+#: src/gui/TabManager.cc:141
 #, fuzzy
 msgid "All files (*)"
 msgstr "%1 個檔案 (*%2)"
 
-#: src/gui/TabManager.cc:161
+#: src/gui/TabManager.cc:163
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -3485,11 +3485,11 @@ msgstr ""
 "%1 已存在。\n"
 "是否要覆寫？"
 
-#: src/gui/TabManager.cc:198
+#: src/gui/TabManager.cc:200
 msgid "Cannot open design file \"%1\": path is a directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:231
+#: src/gui/TabManager.cc:233
 msgid ""
 "Could not write session file:\n"
 "%1\n"
@@ -3499,11 +3499,11 @@ msgid ""
 "Session changes may be lost."
 msgstr ""
 
-#: src/gui/TabManager.cc:240
+#: src/gui/TabManager.cc:242
 msgid "Unable to create the session directory."
 msgstr ""
 
-#: src/gui/TabManager.cc:296
+#: src/gui/TabManager.cc:298
 #, fuzzy
 msgid ""
 "The file \"%1\" does not exist.\n"
@@ -3513,49 +3513,72 @@ msgstr ""
 "%1 已存在。\n"
 "是否要覆寫？"
 
-#: src/gui/TabManager.cc:793
+#: src/gui/TabManager.cc:796
 msgid "Copy file name"
 msgstr "複製檔案名稱"
 
-#: src/gui/TabManager.cc:799
+#: src/gui/TabManager.cc:802
 msgid "Copy full path"
 msgstr "複製完整路徑"
 
-#: src/gui/TabManager.cc:805
+#: src/gui/TabManager.cc:808
 #, fuzzy
 msgid "Open Folder"
 msgstr "檔案(&F)"
 
-#: src/gui/TabManager.cc:810
+#: src/gui/TabManager.cc:813
 #, fuzzy
 msgid "Close Tab"
 msgstr "關閉分頁"
 
-#: src/gui/TabManager.cc:815
+#: src/gui/TabManager.cc:818
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1111
+#: src/gui/TabManager.cc:1114
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "是否要儲存你的變更？"
 
-#: src/gui/TabManager.cc:1112
+#: src/gui/TabManager.cc:1115
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1117
+#: src/gui/TabManager.cc:1120
 #, fuzzy
 msgid "Don't save"
 msgstr "不再顯示"
 
-#: src/gui/TabManager.cc:1583 src/gui/TabManager.cc:1590
-#: src/gui/TabManager.cc:1598 src/gui/TabManager.cc:1608
-#: src/gui/TabManager.cc:1796
+#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1619 src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1835
 msgid "Session Restore"
 msgstr ""
 
 #: src/gui/TabManager.cc:1584
+msgid ""
+"The session file was created by a newer version of PythonSCAD (session "
+"version %1, but this build only supports up to version %2)."
+msgstr ""
+
+#: src/gui/TabManager.cc:1589
+msgid ""
+"Exit to keep the session file for use with a newer PythonSCAD, or discard it "
+"to start fresh here.\n"
+"\n"
+"Session file:\n"
+"%1"
+msgstr ""
+
+#: src/gui/TabManager.cc:1592
+msgid "Exit"
+msgstr ""
+
+#: src/gui/TabManager.cc:1593
+msgid "Discard session"
+msgstr ""
+
+#: src/gui/TabManager.cc:1613
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3565,7 +3588,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1620
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3574,48 +3597,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1599
-msgid ""
-"The session file was created by a newer version of PythonSCAD (session "
-"version %1, but this build only supports up to version %2).\n"
-"\n"
-"Please upgrade PythonSCAD or delete the session file:\n"
-"%3"
-msgstr ""
-
-#: src/gui/TabManager.cc:1609
+#: src/gui/TabManager.cc:1648
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1797
+#: src/gui/TabManager.cc:1836
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1799
+#: src/gui/TabManager.cc:1838
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1802
+#: src/gui/TabManager.cc:1841
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1915 src/gui/TabManager.cc:2067
+#: src/gui/TabManager.cc:1954 src/gui/TabManager.cc:2106
 msgid "Failed to open file for writing"
 msgstr "寫入時開啟檔案錯誤"
 
-#: src/gui/TabManager.cc:1955 src/gui/TabManager.cc:2081
+#: src/gui/TabManager.cc:1994 src/gui/TabManager.cc:2120
 msgid "Error saving design"
 msgstr "儲存設計錯誤"
 
-#: src/gui/TabManager.cc:1967
+#: src/gui/TabManager.cc:2006
 msgid "Save File"
 msgstr "儲存檔案"
 
-#: src/gui/TabManager.cc:2044
+#: src/gui/TabManager.cc:2083
 #, fuzzy
 msgid "Save A Copy"
 msgstr "全部儲存"

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -18,6 +18,7 @@
 
 #include <QByteArray>
 #include <QClipboard>
+#include <QCoreApplication>
 #include <QDesktopServices>
 #include <QDialog>
 #include <QDir>
@@ -32,6 +33,7 @@
 #include <QStringList>
 #include <QTabBar>
 #include <QTextStream>
+#include <QTimer>
 #include <QWidget>
 #include <cassert>
 #include <cstddef>
@@ -1572,6 +1574,31 @@ TabManager::SessionFileReadStatus TabManager::readSessionFileRoot(const QString&
   return SessionFileReadStatus::Ok;
 }
 
+TabManager::TooNewSessionChoice TabManager::promptTooNewSession(const QString& path, int fileVersion,
+                                                                QWidget *parent)
+{
+  QMessageBox box(parent);
+  box.setIcon(QMessageBox::Warning);
+  box.setWindowTitle(_("Session Restore"));
+  box.setText(QString(_("The session file was created by a newer version of PythonSCAD "
+                        "(session version %1, but this build only supports up to version %2)."))
+                .arg(fileVersion)
+                .arg(SESSION_VERSION));
+  box.setInformativeText(
+    QString(_("Exit to keep the session file for use with a newer PythonSCAD, or discard it to "
+              "start fresh here.\n\nSession file:\n%1"))
+      .arg(path));
+  auto *exitButton = box.addButton(_("Exit"), QMessageBox::RejectRole);
+  auto *discardButton = box.addButton(_("Discard session"), QMessageBox::DestructiveRole);
+  box.setDefaultButton(exitButton);
+  box.exec();
+
+  if (box.clickedButton() == discardButton) {
+    return TooNewSessionChoice::DiscardAndContinue;
+  }
+  return TooNewSessionChoice::ExitKeepSession;
+}
+
 bool TabManager::restoreSession(const QString& path, int windowIndex)
 {
   QJsonObject root;
@@ -1595,15 +1622,25 @@ bool TabManager::restoreSession(const QString& path, int windowIndex)
                            .arg(path));
     return false;
   case SessionFileReadStatus::TooNew:
-    QMessageBox::critical(
-      parent, QString(_("Session Restore")),
-      QString(_("The session file was created by a newer version of PythonSCAD "
-                "(session version %1, but this build only supports up to version %2).\n\n"
-                "Please upgrade PythonSCAD or delete the session file:\n%3"))
-        .arg(tooNewVer)
-        .arg(SESSION_VERSION)
-        .arg(path));
-    return false;
+    switch (promptTooNewSession(path, tooNewVer, parent)) {
+    case TooNewSessionChoice::ExitKeepSession:
+      setSkipSessionSave(true);
+      QTimer::singleShot(0, QCoreApplication::instance(), []() {
+        if (scadApp) {
+          for (auto *win : scadApp->windowManager.getWindows()) {
+            win->markSessionQuitting();
+          }
+          scadApp->quit();
+        } else {
+          QCoreApplication::quit();
+        }
+      });
+      return false;
+    case TooNewSessionChoice::DiscardAndContinue:
+      removeSessionFile();
+      QFile::remove(getAutosaveFilePath());
+      return false;
+    }
   case SessionFileReadStatus::MigrateFailed:
     QMessageBox::warning(
       parent, QString(_("Session Restore")),

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -12,6 +12,7 @@
 #include "gui/Editor.h"
 
 class MainWindow;  // for circular dependency
+class QWidget;
 
 class TabManager : public QObject
 {
@@ -76,6 +77,26 @@ public:
   static void setSkipSessionSave(bool skip);
   static bool shouldSkipSessionSave();
 
+  enum class SessionFileReadStatus {
+    Ok,
+    OpenFailed,
+    InvalidJson,
+    TooNew,
+    MigrateFailed,
+  };
+  /// Read session JSON from disk; on \c Ok, \a outRoot holds the normalized object (migrated).
+  static SessionFileReadStatus readSessionFileRoot(const QString& path, QJsonObject *outRoot,
+                                                   QString *openError = nullptr,
+                                                   int *tooNewVersion = nullptr,
+                                                   int *migrateFailedAtVersion = nullptr);
+
+  enum class TooNewSessionChoice {
+    ExitKeepSession,
+    DiscardAndContinue,
+  };
+  static TooNewSessionChoice promptTooNewSession(const QString& path, int fileVersion,
+                                                 QWidget *parent = nullptr);
+
   // Session file schema version. Increment when the format changes and add a
   // migration step in migrateSession().  Old files without a version field are
   // treated as version 1.
@@ -114,19 +135,6 @@ private:
                          const QByteArray& customizerState = QByteArray(),
                          std::optional<int> sessionLanguage = std::nullopt, bool diskBacked = false);
   static bool migrateSession(QJsonObject& root, int fromVersion);
-
-  enum class SessionFileReadStatus {
-    Ok,
-    OpenFailed,
-    InvalidJson,
-    TooNew,
-    MigrateFailed,
-  };
-  /// Read session JSON from disk; on \c Ok, \a outRoot holds the normalized object (migrated).
-  static SessionFileReadStatus readSessionFileRoot(const QString& path, QJsonObject *outRoot,
-                                                   QString *openError = nullptr,
-                                                   int *tooNewVersion = nullptr,
-                                                   int *migrateFailedAtVersion = nullptr);
 
   QTabBar::ButtonPosition getClosingButtonPosition();
   void zoomIn();

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -987,7 +987,22 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
 
   if (sessionMgmtEnabled) {
     const QString sessionPath = TabManager::getSessionFilePath();
-    const bool sessionExists = QFileInfo(sessionPath).exists();
+    bool sessionExists = QFileInfo(sessionPath).exists();
+    if (sessionExists) {
+      QJsonObject root;
+      int tooNewVer = 0;
+      if (TabManager::readSessionFileRoot(sessionPath, &root, nullptr, &tooNewVer, nullptr) ==
+          TabManager::SessionFileReadStatus::TooNew) {
+        switch (TabManager::promptTooNewSession(sessionPath, tooNewVer, nullptr)) {
+        case TabManager::TooNewSessionChoice::ExitKeepSession: return 0;
+        case TabManager::TooNewSessionChoice::DiscardAndContinue:
+          TabManager::removeSessionFile();
+          QFile::remove(TabManager::getAutosaveFilePath());
+          sessionExists = false;
+          break;
+        }
+      }
+    }
     const bool shouldRestore = sessionExists && !TabManager::sessionHasOnlyEmptyTab(sessionPath);
     if (shouldRestore) {
       openedSessionWindows = true;


### PR DESCRIPTION
## Summary

- Replace the single-button "session too new" dialog with two explicit choices: **Exit** (keep the session file untouched so a newer PythonSCAD can resume it) and **Discard session** (remove the session file and start fresh).
- Detect the too-new session case during startup, before MainWindow creation, so users are not left with an empty editor that would overwrite the newer session on quit.
- Regenerate translation catalogs for the new dialog strings.

## Test plan

- [ ] With a newer PythonSCAD build, create a session (open tabs, quit normally).
- [ ] Start an older build with a lower `SESSION_VERSION`:
  - [ ] Choose **Exit** — app closes immediately; session file on disk is unchanged; newer build can resume.
  - [ ] Choose **Discard session** — app starts fresh; session file is removed; no overwrite of the newer session on subsequent quit.


Made with [Cursor](https://cursor.com)