### PR TITLE
fix(pip): ship all lib3mf source variants in PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,14 @@ include ./src/*.h
 include ./src/platform/*.h
 include ./src/python/*.h
 include ./src/io/*.h
+# All lib3mf API variants must ship in the sdist; detect_lib3mf() picks one at
+# pip install time based on the host's lib3mf version (see setup.py).
+include ./src/io/export_3mf_dummy.cc
+include ./src/io/export_3mf_v1.cc
+include ./src/io/export_3mf_v2.cc
+include ./src/io/import_3mf_dummy.cc
+include ./src/io/import_3mf_v1.cc
+include ./src/io/import_3mf_v2.cc
 include ./src/libsvg/*.h
 include ./src/core/*.h
 include ./src/core/*.hxx


### PR DESCRIPTION
## Summary

- Include `export_3mf_v1.cc`, `export_3mf_v2.cc`, `import_3mf_v1.cc`, and `import_3mf_v2.cc` in the PyPI source distribution via `MANIFEST.in`.
- Fixes `pip install pythonscad` on systems with `lib3mf-dev` installed (e.g. Ubuntu 24.04 after `get-dependencies.py`), where `setup.py` selects the v1 or v2 API at compile time but the published sdist previously only contained the dummy stubs (because the sdist is built on CI without `lib3mf-dev`).

## Test plan

- [x] Local `python -m build --sdist` and verify all six `*3mf*.cc` files are in the tarball
- [ ] After the next PyPI release: `pip install pythonscad` on Ubuntu 24.04 with `pythonscad` build deps


Made with [Cursor](https://cursor.com)