### PR TITLE
refactor: update imports from openscad to pythonscad and improve code…

### DIFF
--- a/examples/GCode/colormap_gcode_color_derived.py
+++ b/examples/GCode/colormap_gcode_color_derived.py
@@ -1,4 +1,4 @@
-from openscad import *
+from pythonscad import *
 from pymachineconfig import *
 
 # read in the machine configuration file.
@@ -10,7 +10,7 @@ from pymachineconfig import *
 import define_machine
 
 mc = MachineConfig()
-print("\nConfigfile:",mc.configfile())
+print("\nConfigfile:", mc.configfile())
 
 # overwrite the init-/exit-Codes (with comments)
 mc.set_property_value("default", "initCode", "; Testing initCode\r\nG90\r\n")
@@ -21,7 +21,7 @@ print("\n############")
 working = mc.working_config()
 print("The default machine set to:")
 for k in working.keys():
-    print("  ",k,working[k])
+    print("  ", k, working[k])
 print("############")
 
 # Define parameters for the part
@@ -35,20 +35,28 @@ font_size = 8
 # Create the Base Plate
 plate = cube([base_width, base_height, base_thickness])
 
-# Create the Text (using linear_extrude to give it 
-text_3d = text(text_string, size=font_size, font="Arial:style=Bold", halign="center", valign="center").linear_extrude(height=base_thickness)
+# Create the Text (using linear_extrude to give it
+text_3d = text(
+    text_string,
+    size=font_size,
+    font="Arial:style=Bold",
+    halign="center",
+    valign="center",
+).linear_extrude(height=base_thickness)
 
 # Position the text
 # We need to move the text into the center of the plate and slightly
 # above the bottom surface to avoid rendering artifacts (z-fighting)
-positioned_text = text_3d.translate([base_width/2, base_height/2, base_thickness - engrave_depth])
+positioned_text = text_3d.translate(
+    [base_width / 2, base_height / 2, base_thickness - engrave_depth]
+)
 
 # Perform the Engraving (Difference)
 #   Subtract the text shape from the base plate
 engraved_object = plate - positioned_text
 
 # Render in 3D (commented out to test ExportGCode
-#engraved_object.show()
+# engraved_object.show()
 
 #############################
 # Since the GCode generated for the laser cutter does not utilize
@@ -58,11 +66,11 @@ engraved_object = plate - positioned_text
 # Use the direct power/feed method.
 #
 # for cut (power=100% and feed=401mm/min):
-cut_color = mc.gen_color2str(power=1000,feed=401)
-print("cut color:",cut_color)
+cut_color = mc.gen_color2str(power=1000, feed=401)
+print("cut color:", cut_color)
 # for engrave (power=55.0% and feed=6000mm/min)
-engrave_color = mc.gen_color2str(power=550,feed=6000)
-print("engrave color:",engrave_color)
+engrave_color = mc.gen_color2str(power=550, feed=6000)
+print("engrave color:", engrave_color)
 # Note: the colors are specifically generated to encode the power and
 #   feed into the RGB representation.  Since LaserGRBL and LightBurn
 #   use 0..1000 to represent 0 to 100% power, the first 8 bits of the
@@ -76,7 +84,7 @@ print("engrave color:",engrave_color)
 text_3d_2 = text_3d
 text_3d_2 = text_3d_2.projection(cut=True)
 text_3d_2 = text_3d_2.color(engrave_color)
-text_3d_2 = text_3d_2.translate([38,10,10])
+text_3d_2 = text_3d_2.translate([38, 10, 10])
 text_3d_2.show()
 
 # now cut it out

--- a/examples/GCode/colormap_gcode_colormapped.py
+++ b/examples/GCode/colormap_gcode_colormapped.py
@@ -93,8 +93,8 @@ print("cut color (%s): %s" % ("L02", cut_color))
 print("engrave color (%s): %s" % ("L01", engrave_color))
 
 # Note: the working machine's config is cached and sent to
-#   export_gcode so that any unszaved colormap modifications are
-#   avialable at runtime.  Also, the actual saved colormap does not
+#   export_gcode so that any unsaved colormap modifications are
+#   available at runtime.  Also, the actual saved colormap does not
 #   require modification for each use.
 
 model = text_3d_3 | plate_3

--- a/examples/GCode/colormap_gcode_colormapped.py
+++ b/examples/GCode/colormap_gcode_colormapped.py
@@ -1,4 +1,4 @@
-from openscad import *
+from pythonscad import *
 from pymachineconfig import *
 
 # FIXME: overwrite the machine config file with the default for testing
@@ -9,7 +9,7 @@ import define_machine
 #   to work from, but does not save the file.  The end user
 #   needs to do that explicitly.
 mc = MachineConfig()
-print("\nConfigfile:",mc.configfile())
+print("\nConfigfile:", mc.configfile())
 
 # overwrite the init-/exit-Codes (with comments)
 mc.set_property_value("default", "initCode", "; Testing initCode\r\nG90\r\n")
@@ -20,7 +20,7 @@ print("\n############")
 working = mc.working_config()
 print("The default machine set to:")
 for k in working.keys():
-    print("  ",k,working[k])
+    print("  ", k, working[k])
 print("############")
 
 # Define parameters for the part
@@ -34,20 +34,28 @@ font_size = 8
 # Create the Base Plate
 plate = cube([base_width, base_height, base_thickness])
 
-# Create the Text (using linear_extrude to give it 
-text_3d = text(text_string, size=font_size, font="Arial:style=Bold", halign="center", valign="center").linear_extrude(height=base_thickness)
+# Create the Text (using linear_extrude to give it
+text_3d = text(
+    text_string,
+    size=font_size,
+    font="Arial:style=Bold",
+    halign="center",
+    valign="center",
+).linear_extrude(height=base_thickness)
 
 # Position the text
 # We need to move the text into the center of the plate and slightly
 # above the bottom surface to avoid rendering artifacts (z-fighting)
-positioned_text = text_3d.translate([base_width/2, base_height/2, base_thickness - engrave_depth])
+positioned_text = text_3d.translate(
+    [base_width / 2, base_height / 2, base_thickness - engrave_depth]
+)
 
 # Perform the Engraving (Difference)
 #   Subtract the text shape from the base plate
 engraved_object = plate - positioned_text
 
 # Render in 3D (commented out to test ExportGCode
-#engraved_object.show()
+# engraved_object.show()
 
 #############################
 # Since the GCode generated for the laser cutter does not utilize
@@ -57,11 +65,11 @@ engraved_object = plate - positioned_text
 # Use the color-table power/feed method.  First modify the parameters
 #
 # for cut:
-mc.set_power("L02",900)
-mc.set_feed("L02",4000)
+mc.set_power("L02", 900)
+mc.set_feed("L02", 4000)
 # for engrave:
-mc.set_power("L01",350)
-mc.set_feed("L01",6000)
+mc.set_power("L01", 350)
+mc.set_feed("L01", 6000)
 # Note: the default colors named L01 and L02 are Blue and Red
 #   respectively.  The color Red is often associated with cutting,
 #   and Blue with engraving.
@@ -71,7 +79,7 @@ engrave_color = mc.color2str("L01")
 text_3d_3 = text_3d
 text_3d_3 = text_3d_3.projection(cut=True)
 text_3d_3 = text_3d_3.color(engrave_color)
-text_3d_3 = text_3d_3.translate([38,10,10])
+text_3d_3 = text_3d_3.translate([38, 10, 10])
 text_3d_3.show()
 
 # cut the second part
@@ -81,8 +89,8 @@ plate_3 = plate_3.projection(cut=True)
 plate_3 = plate_3.color(cut_color)
 plate_3.show()
 
-print("cut color (%s): %s"%("L02",cut_color))
-print("engrave color (%s): %s"%("L01",engrave_color))
+print("cut color (%s): %s" % ("L02", cut_color))
+print("engrave color (%s): %s" % ("L01", engrave_color))
 
 # Note: the working machine's config is cached and sent to
 #   export_gcode so that any unszaved colormap modifications are

--- a/examples/GCode/define_machine.py
+++ b/examples/GCode/define_machine.py
@@ -110,7 +110,7 @@ mc.write()
 ###############
 # verify the configuration was saved by reading in and printing
 mc2 = MachineConfig()
-working = mc.working_config()
+working = mc2.working_config()
 print("\nRead in saved config file")
 print("============")
 print("working:", working)

--- a/examples/GCode/define_machine.py
+++ b/examples/GCode/define_machine.py
@@ -1,62 +1,88 @@
-from openscad import *
+from pythonscad import *
 from pymachineconfig import *
 
-# Create a blank machine config with only a  
+# Create a blank machine config with only a
 mc = MachineConfig(None)
 
 # define a default configuration
-mc.register("default","default",
-              {"machine":"Creality-Falcon2",
-               "head":"LED-40",
-               "material":"3mm_ply_LED-40"})
+mc.register(
+    "default",
+    "default",
+    {"machine": "Creality-Falcon2", "head": "LED-40", "material": "3mm_ply_LED-40"},
+)
 
 # different machine configurations
-mc.register("Creality-Falcon2","machine",
-              {"max_feed":25000, #(mm/min)
-               "max_width":400, #(mm)
-               "max_len":415, #(mm)
-               "has_camera":False})
-mc.register("XTool-S1","machine",
-              {"max_feed":36000, #(mm/min)
-               "max_width":319, #(mm)
-               "max_len":498, #(mm)
-               "has_camera":False})
+mc.register(
+    "Creality-Falcon2",
+    "machine",
+    {
+        "max_feed": 25000,  # (mm/min)
+        "max_width": 400,  # (mm)
+        "max_len": 415,  # (mm)
+        "has_camera": False,
+    },
+)
+mc.register(
+    "XTool-S1",
+    "machine",
+    {
+        "max_feed": 36000,  # (mm/min)
+        "max_width": 319,  # (mm)
+        "max_len": 498,  # (mm)
+        "has_camera": False,
+    },
+)
 
 # different heads which can be independent
 # of a given machine
-mc.register("LED-40","head",
-              {"max_power":40.0,
-               "wavelength":455,
-               "has_air":True,
-               "kerf": 0.075})
-mc.register("LED-20","head",
-              {"max_power":20.0,
-               "wavelength":455,
-               "has_air":True,
-               "kerf": 0.075})
+mc.register(
+    "LED-40",
+    "head",
+    {"max_power": 40.0, "wavelength": 455, "has_air": True, "kerf": 0.075},
+)
+mc.register(
+    "LED-20",
+    "head",
+    {"max_power": 20.0, "wavelength": 455, "has_air": True, "kerf": 0.075},
+)
 
 # materials which are dependent on the head
 # characteristics. The machines assume units
 # in mm and minutes.
-mc.register("3mm_ply_LED-40","material",
-              {"thickness":3.0,
-               "cut_power":1000,
-               "cut_feed":400,
-               "engrave_power":300,
-               "engrave_feed":6000})
-mc.register("0.25in_ply_LED-40","material",
-              {"thickness":6.35,
-               "cut_power":1000,
-               "cut_feed":200,
-               "engrave_power":300,
-               "engrave_feed":6000})
-mc.register("0.75in_pine_LED-40","material",
-              {"thickness":19.05,
-               "cut_power":1000,
-               "cut_feed":200,
-               "engrave_power":300,
-               "engrave_feed":6000})
-               
+mc.register(
+    "3mm_ply_LED-40",
+    "material",
+    {
+        "thickness": 3.0,
+        "cut_power": 1000,
+        "cut_feed": 400,
+        "engrave_power": 300,
+        "engrave_feed": 6000,
+    },
+)
+mc.register(
+    "0.25in_ply_LED-40",
+    "material",
+    {
+        "thickness": 6.35,
+        "cut_power": 1000,
+        "cut_feed": 200,
+        "engrave_power": 300,
+        "engrave_feed": 6000,
+    },
+)
+mc.register(
+    "0.75in_pine_LED-40",
+    "material",
+    {
+        "thickness": 19.05,
+        "cut_power": 1000,
+        "cut_feed": 200,
+        "engrave_power": 300,
+        "engrave_feed": 6000,
+    },
+)
+
 # generate a working variable set from the default config.
 mc.gen_working()
 
@@ -64,16 +90,16 @@ mc.gen_working()
 working = mc.working_config()
 print("\nHand created configuration.")
 print("############")
-print("working:",working)
+print("working:", working)
 print("############")
 print("The default machine set to:")
 for k in working.keys():
-    print("    ",k,working[k])
+    print("    ", k, working[k])
 print("############")
 
 ###############
 # What is the name of the default config file.
-print("Configfile:",mc.configfile())
+print("Configfile:", mc.configfile())
 
 ###############
 # save the configuration
@@ -87,12 +113,11 @@ mc2 = MachineConfig()
 working = mc.working_config()
 print("\nRead in saved config file")
 print("============")
-print("working:",working)
+print("working:", working)
 print("============")
 print("The default machine set to:")
 for k in working.keys():
-    print("    ",k,working[k])
+    print("    ", k, working[k])
 print("============")
 print("end user defined machine")
 print("\n\n")
-

--- a/examples/GCode/define_machine.py
+++ b/examples/GCode/define_machine.py
@@ -1,4 +1,3 @@
-from pythonscad import *
 from pymachineconfig import *
 
 # Create a blank machine config with only a

--- a/examples/GCode/machine_config.py
+++ b/examples/GCode/machine_config.py
@@ -32,13 +32,13 @@ print("cut scale:", cut_scale)
 engrave_scale = mc.scale_value("engrave_feed", "max_feed")
 print("engrave scale:", engrave_scale)
 
-test_power = mc.get_property_value("Creality-Falcon2", "max_feed")
-print("max_power =", test_power)
+max_feed = mc.get_property_value("Creality-Falcon2", "max_feed")
+print("max_feed =", max_feed)
 
 mc.set_property_value("Creality-Falcon2", "max_feed", 12000)
 
-test_power = mc.get_property_value("Creality-Falcon2", "max_feed")
-print("max_power =", test_power)
+max_feed = mc.get_property_value("Creality-Falcon2", "max_feed")
+print("max_feed =", max_feed)
 
 ###############
 

--- a/examples/GCode/machine_config.py
+++ b/examples/GCode/machine_config.py
@@ -1,8 +1,8 @@
 from pythonscad import *
 from pymachineconfig import *
 
-# set up a machine definition fron scratch.
-# WARNING: excuting this can overwrite your config
+# set up a machine definition from scratch.
+# WARNING: executing this can overwrite your config
 import define_machine
 
 # read in the machine config.  If it does not exist, generate a default

--- a/examples/GCode/machine_config.py
+++ b/examples/GCode/machine_config.py
@@ -1,5 +1,6 @@
-from openscad import *
+from pythonscad import *
 from pymachineconfig import *
+
 # set up a machine definition fron scratch.
 # WARNING: excuting this can overwrite your config
 import define_machine
@@ -8,52 +9,52 @@ import define_machine
 mc = MachineConfig()
 
 # find the full path of the config file it wants to work with.
-print("\nConfigfile:",mc.configfile())
+print("\nConfigfile:", mc.configfile())
 
 working = mc.working_config()
-print("working:",working)
+print("working:", working)
 print("\n############")
 print("The default machine set to:")
 for k in working.keys():
-    print("  ",k,working[k])
+    print("  ", k, working[k])
 print("############")
 
 # test code
 types = mc.get_types()
-print("Types = ",str(types))
+print("Types = ", str(types))
 for t in types:
     ret = mc.get_label_by_type(t)
-    print("    type: '%s'  values: %s"%(t,str(ret)))
+    print("    type: '%s'  values: %s" % (t, str(ret)))
 
-cut_scale = mc.scale_value("cut_feed","max_feed")
-print("cut scale:",cut_scale)
+cut_scale = mc.scale_value("cut_feed", "max_feed")
+print("cut scale:", cut_scale)
 
-engrave_scale = mc.scale_value("engrave_feed","max_feed")
-print("engrave scale:",engrave_scale)
-
-test_power = mc.get_property_value("Creality-Falcon2", "max_feed")
-print("max_power =",test_power)
-
-mc.set_property_value("Creality-Falcon2",  "max_feed", 12000)
+engrave_scale = mc.scale_value("engrave_feed", "max_feed")
+print("engrave scale:", engrave_scale)
 
 test_power = mc.get_property_value("Creality-Falcon2", "max_feed")
-print("max_power =",test_power)
+print("max_power =", test_power)
+
+mc.set_property_value("Creality-Falcon2", "max_feed", 12000)
+
+test_power = mc.get_property_value("Creality-Falcon2", "max_feed")
+print("max_power =", test_power)
 
 ###############
 
-#color_table = mc.get_property_value("ColorTable", "L03")
+# color_table = mc.get_property_value("ColorTable", "L03")
 feed = mc.feed("L03")
-print("color_table['L03']['feed']=",feed)
+print("color_table['L03']['feed']=", feed)
 
-mc.set_feed("L03",450)
+mc.set_feed("L03", 450)
 
 color_table = mc.feed("L03")
-print("color_table['L03'] =",color_table)
-print("   modified feed:",mc.feed("L03"))
+print("color_table['L03'] =", color_table)
+print("   modified feed:", mc.feed("L03"))
 
 ###############
 
 mc.reset_colormap()
-print("   reset feed:",mc.feed("L03"))
+print("   reset feed:", mc.feed("L03"))
 
-print("L03 color:",mc.color2str("L03"))
+print("L03 color:", mc.color2str("L03"))

--- a/examples/GCode/machine_config.py
+++ b/examples/GCode/machine_config.py
@@ -1,4 +1,3 @@
-from pythonscad import *
 from pymachineconfig import *
 
 # set up a machine definition from scratch.

--- a/examples/Python/csg.py
+++ b/examples/Python/csg.py
@@ -1,7 +1,8 @@
-from openscad import *
+from pythonscad import *
+
 # Create a cube and a cylinder
-cu = cube([5,5,5])
-cy = cylinder(r=5,h=2)
+cu = cube([5, 5, 5])
+cy = cylinder(r=5, h=2)
 
 # | for union
 # - for difference
@@ -10,4 +11,3 @@ fusion = cu | cy
 
 
 fusion.show()
-

--- a/examples/Python/handles.py
+++ b/examples/Python/handles.py
@@ -1,21 +1,22 @@
-from openscad import *
-c=cube([10,10,10])
+from pythonscad import *
+
+c = cube([10, 10, 10])
 
 # translate the origin with an offset, so top_center sits on top of the cube
-c.top_center=translate(c.origin,[5,5,10])
+c.top_center = translate(c.origin, [5, 5, 10])
 
 # This one even points to the right side
-c.right_center=translate(roty(c.origin,90),[10,5,5])
+c.right_center = translate(roty(c.origin, 90), [10, 5, 5])
 
 # The handles can be used with align
-cyl = cylinder(d=3,h=5,fn=10)
+cyl = cylinder(d=3, h=5, fn=10)
 
-# This placecs cyl onto the top and right side of the cube 
+# This places cyl onto the top and right side of the cube
 #    obj       source handle  dest handle
 
-c |= cyl.align(c.top_center,cyl.origin)
-c |= cyl.align(c.right_center,cyl.origin)
+c |= cyl.align(c.top_center, cyl.origin)
+c |= cyl.align(c.right_center, cyl.origin)
 
 c.show()
 
-#of course, any data can be stored and retrieved  with objects , not only handles
+# of course, any data can be stored and retrieved with objects, not only handles

--- a/examples/Python/mesh.py
+++ b/examples/Python/mesh.py
@@ -1,14 +1,13 @@
-from openscad import *
+from pythonscad import *
 
-u=sphere(r=10,fn=30)
+u = sphere(r=10, fn=30)
 
 pts, tris = u.mesh()
 # Now you could use the pts for further processing or even manipulate them and do this ...
 
 for pt in pts:
     if pt[0] > 0:
-        pt[0] = pt[0]*pt[0]/10 #alter in place
+        pt[0] = pt[0] * pt[0] / 10  # alter in place
 
 v = polyhedron(pts, tris)
 v.show()
-

--- a/examples/Python/offset.py
+++ b/examples/Python/offset.py
@@ -1,6 +1,7 @@
-from openscad import *
-c = cube(10) + [[0,0,0], [5,5,5]] # multiple translation
+from pythonscad import *
+
+c = cube(10) + [[0, 0, 0], [5, 5, 5]]  # multiple translation
 
 # Fillets can easily be created by downsizing concave edges
-c = c.offset(-2,fa=5)
+c = c.offset(-2, fa=5)
 c.show()

--- a/examples/Python/path_extrude.py
+++ b/examples/Python/path_extrude.py
@@ -1,6 +1,5 @@
-from openscad import *
+from pythonscad import *
 
-p=path_extrude(square(1),[[0,0,0],[0,0,10,3], [10,0,10,3],[10,10,10]]);
-#arguments are cross-section and points in space
+p = path_extrude(square(1), [[0, 0, 0], [0, 0, 10, 3], [10, 0, 10, 3], [10, 10, 10]])
+# arguments are cross-section and points in space
 p.show()
-

--- a/examples/Python/sdf.py
+++ b/examples/Python/sdf.py
@@ -1,7 +1,7 @@
 from pythonscad import *
 from pylibfive import *
 
-# Just assemble you libfive object first
+# Just assemble your libfive object first
 c = lv_coord()
 s1 = lv_sphere(lv_trans(c, [2, 2, 2]), 2)
 b1 = lv_box(c, [2, 2, 2])

--- a/examples/Python/sdf.py
+++ b/examples/Python/sdf.py
@@ -1,13 +1,12 @@
-from openscad import *
+from pythonscad import *
 from pylibfive import *
 
 # Just assemble you libfive object first
-c=lv_coord()
-s1=lv_sphere(lv_trans(c,[2,2,2]),2)
-b1=lv_box(c,[2,2,2])
-sdf=lv_union_smooth(s1,b1,0.6)
+c = lv_coord()
+s1 = lv_sphere(lv_trans(c, [2, 2, 2]), 2)
+b1 = lv_box(c, [2, 2, 2])
+sdf = lv_union_smooth(s1, b1, 0.6)
 
 # And mesh it finally to get something, that openSCAD can display
-fobj=frep(sdf,[-4,-4,-4],[4,4,4],20)
+fobj = frep(sdf, [-4, -4, -4], [4, 4, 4], 20)
 fobj.show()
-

--- a/examples/Python/simple.py
+++ b/examples/Python/simple.py
@@ -1,11 +1,10 @@
-# getting openscad functions into namespace
-from openscad import *
+# getting pythonscad functions into namespace
+from pythonscad import *
 
 # Create the cube object, and store it in variable "c"
 c = cube(5)
 # Or, more explicitely
-c = cube([5,5,5])
+c = cube([5, 5, 5])
 
 # Display the cube
 show(c)
-

--- a/examples/Python/simple.py
+++ b/examples/Python/simple.py
@@ -3,7 +3,7 @@ from pythonscad import *
 
 # Create the cube object, and store it in variable "c"
 c = cube(5)
-# Or, more explicitely
+# Or, more explicitly
 c = cube([5, 5, 5])
 
 # Display the cube

--- a/examples/Python/transformations.py
+++ b/examples/Python/transformations.py
@@ -1,16 +1,15 @@
-from openscad import *
+from pythonscad import *
 
-c=cube([1,2,2]) + [10,0,1] # 10 to the right, 1 up
+c = cube([1, 2, 2]) + [10, 0, 1]  # 10 to the right, 1 up
 
-s=sphere(r=3) * [1,1,0.1]  # squeeze it to 10% in z
+s = sphere(r=3) * [1, 1, 0.1]  # squeeze it to 10% in z
 
-cyl = cylinder(r=1,h=5)
+cyl = cylinder(r=1, h=5)
 
-show( [ #several objects at once  
-       s.rotx(45) , # rot on the x axis
-       c + [4,0,1], # 10 to the right, 1 up
-       cyl.translate([0,10,0]).color("green") 
-       ])
-
-
-
+show(
+    [  # several objects at once
+        s.rotx(45),  # rot on the x axis
+        c + [4, 0, 1],  # 4 to the right, 1 up
+        cyl.translate([0, 10, 0]).color("green"),
+    ]
+)


### PR DESCRIPTION
This PR updates example Python scripts to import from `pythonscad` instead of `openscad`, and improves formatting for readability.

A few example scripts also had small correctness fixes (e.g. validating reloaded machine config via `mc2`, clearer `max_feed` output labels, comment typo fixes). No changes to the core library/API.