### PR TITLE
refactor(python): use pythonscad imports in helper libraries

### DIFF
--- a/libraries/python/pybuild123d.py
+++ b/libraries/python/pybuild123d.py
@@ -1,15 +1,13 @@
 from build123d import *
-from openscad import *
+from pythonscad import *
 from functools import wraps
 
 def build123d(obj):
     @wraps(obj)
-    def wrapTheFunction():
-        print("I am doing some boring work before executing a_func()")
-        a=obj()
-        tsl = a.part.tessellate(tolerance=.001)
+    def wrapTheFunction(*args, **kwargs):
+        result = obj(*args, **kwargs)
+        tsl = result.part.tessellate(tolerance=.001)
         points = [list(vector) for vector in tsl[0]]
         faces = [list(face[::-1]) for face in tsl[1]]
         return polyhedron(points, faces)
     return wrapTheFunction
-

--- a/libraries/python/pylaser.py
+++ b/libraries/python/pylaser.py
@@ -1,4 +1,4 @@
-from openscad import *
+from pythonscad import *
 from random import *
 
 """
@@ -77,7 +77,7 @@ class LaserCutter:
             while True:
                 try:
                     newmat=iter.matrix
-                except:
+                except AttributeError:
                     break
                 mat = multmatrix(mat, newmat)
                 iter, = iter.children()

--- a/libraries/python/pymachineconfig.py
+++ b/libraries/python/pymachineconfig.py
@@ -1,6 +1,6 @@
 import os
 import json
-from openscad import *
+from pythonscad import *
 
 """
 MachineConfig class which can be used to read lasercutter and 3D
@@ -32,8 +32,8 @@ class MachineConfig:
     def _check_lasermode(self, value):
         try:
             if self._config["default"]["property"]["lasermode"] != value:
-                print("Error: lasermode masmatch.  Ignoring overwrite.")
-        except:
+                print("Error: lasermode mismatch.  Ignoring overwrite.")
+        except (KeyError, TypeError):
             self._config["default"]["property"]["lasermode"] = value
             self.write_settings()
 
@@ -113,7 +113,7 @@ class MachineConfig:
         with open(name, 'r', encoding='utf-8') as f:
             cfg = json.loads(f.read())
             return cfg
-        
+
     def write(self, config=None, name="PythonSCAD.json", backup=None):
         name = self.configfile(name)
 
@@ -129,7 +129,7 @@ class MachineConfig:
         if jstr is not None:
             with open(name,'w') as fout:
                 fout.write(jstr)
-        
+
         return
 
     def write_settings(self, config=None):
@@ -137,7 +137,7 @@ class MachineConfig:
             config = self._config
 
         mc = machineconfig(config)
-        
+
     def set_config(self, config):
         self._config = config
         self.write_settings()
@@ -166,7 +166,7 @@ class MachineConfig:
         except ValueError as e:
             print(f"An error occurred: {e}")
             return None
-    
+
     def get_label_by_type(self, label):
         try:
             values = set([x for x in self._config
@@ -175,7 +175,7 @@ class MachineConfig:
         except ValueError as e:
             print(f"An error occurred: {e}")
             return None
-    
+
     def get_property(self, label):
         try:
             return self._config[label]["property"]
@@ -185,7 +185,7 @@ class MachineConfig:
 
     def working_config(self):
         return self._working
-    
+
     def gen_working(self, label="default"):
         """
         Create a flat representation of all variables associated with
@@ -212,8 +212,8 @@ class MachineConfig:
             # FIXME: need to also handle 'C:' naming
             return name
 
-        if (xdg is not None) and (os.path.exists(os.path.join(xgd,name))):
-            return os.path.join(xgd,name)
+        if xdg and os.path.exists(os.path.join(xdg, name)):
+            return os.path.join(xdg, name)
 
         if home is not None:
             return os.path.join(home,".config","PythonSCAD",name)
@@ -320,4 +320,3 @@ class MachineConfig:
     def gen_color2hex(self, power=-1,feed=-1):
         color = self.gen_color(power,feed)
         return f"0x{color:08X}"
-

--- a/libraries/python/pytexture.py
+++ b/libraries/python/pytexture.py
@@ -1,9 +1,9 @@
-from openscad import *
+from pythonscad import *
 from math import *
 
 def find_face(faces, n):
     return max(faces, key = lambda  f : f.matrix[0][2]*n[0]+f.matrix[1][2]*n[1]+f.matrix[2][2]*n[2])
-    
+
 
 def face_bbox(face):
     pts=face.mesh()[0]
@@ -22,7 +22,7 @@ def solid_bbox(solid):
     maxy=max(pts, key = lambda pt:pt[1])
     maxz=max(pts, key = lambda pt:pt[2])
     return minx[0], miny[1], minz[2], maxx[0], maxy[1], maxz[2]
-    
+
 def load_texture(texturefile, tilesize, eff_thick,inv=False):
     tile = surface(texturefile,color=True, invert=inv)
     tileminx, tileminy, tileminz, tilemaxx, tilemaxy, tilemaxz= solid_bbox(tile)
@@ -32,7 +32,7 @@ def load_texture(texturefile, tilesize, eff_thick,inv=False):
     texscale=tilesize/tilespanx
     tile = tile.scale([texscale,texscale,eff_thick/tilespanz])
     if inv:
-        tile=tile.up(eff_thick)                
+        tile=tile.up(eff_thick)
     return [tile, tilespanx*texscale, tilespany*texscale]
 
 def add_texture(face, tile ,align_ang=0, patch_ang=90):
@@ -48,4 +48,3 @@ def add_texture(face, tile ,align_ang=0, patch_ang=90):
     texturemask = faceflat.offset(tileheight).roof().scale([1,1,-tanval]).up(tileheight*tanval)
     texture= (union(tiles) + [faceminx-0.2,faceminy-0.2]) & texturemask
     texture.rotz(-align_ang).multmatrix(face.matrix).show()
-

--- a/libraries/python/pyutil.py
+++ b/libraries/python/pyutil.py
@@ -1,11 +1,11 @@
-from openscad import *
+from pythonscad import *
 from math import *
 
 def loft_prepare(solid1, solid2,n, rot ):
     loft_pts1=solid1.mesh()[0] # TODO fix
     loft_pts2=solid2.mesh()[0]
     loft_ang = []
-    
+
     for pt in loft_pts1:
         ang=atan2(pt[1], pt[0])
         if ang not in loft_ang:
@@ -19,21 +19,21 @@ def loft_prepare(solid1, solid2,n, rot ):
     for i in range(n):
          ang=3.14159265359*(2*i/n-1)
          if ang not in loft_ang:
-             loft_ang.append(ang)               
+             loft_ang.append(ang)
     loft_ang.sort()
-    
+
     loft_data= [loft_ang]
     rnd=0
     for set in  loft_pts1, loft_pts2:
         mags = []
-        
+
         for ang in loft_ang:
             if rnd == 1:
                 ang=ang+rot
                 if ang > 3.1415926:
                     ang=ang-2*3.1415926
             v=[cos(ang),sin(ang)]
-        
+
             oldpt=set[-1]
             # where does it cut
             mag=1
@@ -41,7 +41,7 @@ def loft_prepare(solid1, solid2,n, rot ):
                 tail=set[i]
                 head=set[(i+1)%len(set)]
                 d= [head[0]-tail[0],head[1]-tail[1]]
-                
+
                 det=d[1]*v[0]-d[0]*v[1]
                 if det != 0:
                     a=(tail[0]*v[1] - tail[1]*v[0])/det
@@ -55,11 +55,11 @@ def loft_prepare(solid1, solid2,n, rot ):
                     if b < 0:
                         continue
                     mag=sqrt(cut[0]*cut[0] + cut[1] * cut[1])
-            mags.append(mag)    
+            mags.append(mag)
         rnd=rnd+1
-        loft_data.append(mags) 
-    return loft_data            
-                
+        loft_data.append(mags)
+    return loft_data
+
 def loft_func(loft_data, loft_height, h, rot):
     f=h/loft_height
     pts=[]
@@ -73,4 +73,3 @@ def loft(shape1, shape2,loft_height,n=20, rot=0):
     rot=rot*3.14/180.0
     loft_data = loft_prepare(shape1, shape2,n, rot)
     return lambda h: loft_func(loft_data, loft_height, h, rot)
-    

--- a/scripts/cancel-branch-ci.sh
+++ b/scripts/cancel-branch-ci.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Cancel in-progress GitHub Actions workflow runs for a branch.
+#
+# By default uses the current git branch. You can also pass --pr to target
+# the head branch of an open pull request (defaults to the PR for the
+# current branch when no number is given).
+#
+# Requires: gh (https://cli.github.com/), authenticated for the repo remote.
+#
+# Examples:
+#   ./scripts/cancel-branch-ci.sh
+#   ./scripts/cancel-branch-ci.sh --dry-run
+#   ./scripts/cancel-branch-ci.sh --branch fix/my-feature
+#   ./scripts/cancel-branch-ci.sh --pr 711
+#   ./scripts/cancel-branch-ci.sh --pr
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: cancel-branch-ci.sh [OPTIONS]
+
+Cancel queued or in-progress GitHub Actions runs for a branch.
+
+Options:
+  -b, --branch NAME   Branch to cancel runs for (default: current branch)
+  -p, --pr [NUMBER]   Use the PR head branch (NUMBER optional on a PR branch)
+  -n, --dry-run       Print runs that would be cancelled, do not cancel
+  -h, --help          Show this help
+
+EOF
+}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+BRANCH=""
+PR_MODE=0
+PR_NUMBER=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-n | --dry-run)
+		DRY_RUN=1
+		shift
+		;;
+	-b | --branch)
+		[[ $# -ge 2 ]] || {
+			echo "error: --branch requires a value" >&2
+			exit 1
+		}
+		BRANCH="$2"
+		shift 2
+		;;
+	-p | --pr)
+		PR_MODE=1
+		if [[ $# -ge 2 && "$2" != -* ]]; then
+			PR_NUMBER="$2"
+			shift 2
+		else
+			shift
+		fi
+		;;
+	*)
+		echo "error: unknown option: $1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+	echo "error: gh CLI not found (install https://cli.github.com/)" >&2
+	exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+	echo "error: gh is not authenticated (run: gh auth login)" >&2
+	exit 1
+fi
+
+OWNER_REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+
+if [[ "$PR_MODE" -eq 1 ]]; then
+	if [[ -n "$PR_NUMBER" ]]; then
+		BRANCH="$(gh pr view "$PR_NUMBER" --repo "$OWNER_REPO" --json headRefName --jq .headRefName)"
+	else
+		BRANCH="$(gh pr view --repo "$OWNER_REPO" --json headRefName --jq .headRefName)"
+	fi
+elif [[ -z "$BRANCH" ]]; then
+	if ! git rev-parse --git-dir >/dev/null 2>&1; then
+		echo "error: not inside a git repository" >&2
+		exit 1
+	fi
+	BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+	if [[ "$BRANCH" == "HEAD" ]]; then
+		echo "error: detached HEAD; use --branch NAME or --pr" >&2
+		exit 1
+	fi
+fi
+
+mapfile -t RUNS < <(
+	gh run list \
+		--repo "$OWNER_REPO" \
+		--branch "$BRANCH" \
+		--limit 50 \
+		--json databaseId,status,workflowName,displayTitle,headSha,createdAt \
+		--jq '.[] | select(.status != "completed" and .status != "cancelled") |
+			[.databaseId, .status, .workflowName, .displayTitle] | @tsv'
+)
+
+if [[ ${#RUNS[@]} -eq 0 ]]; then
+	echo "No active workflow runs on branch '$BRANCH' ($OWNER_REPO)."
+	exit 0
+fi
+
+echo "Branch: $BRANCH"
+echo "Repo:   $OWNER_REPO"
+echo "Active runs: ${#RUNS[@]}"
+echo
+
+cancelled=0
+for entry in "${RUNS[@]}"; do
+	IFS=$'\t' read -r run_id status workflow title <<<"$entry"
+	printf '  [%s] %s — %s (run %s)\n' "$status" "$workflow" "$title" "$run_id"
+	if [[ "$DRY_RUN" -eq 1 ]]; then
+		continue
+	fi
+	if gh api --silent -X POST "/repos/${OWNER_REPO}/actions/runs/${run_id}/cancel" >/dev/null; then
+		((cancelled += 1)) || true
+	else
+		echo "warning: failed to cancel run $run_id" >&2
+	fi
+done
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+	echo
+	echo "Dry run: no runs were cancelled."
+else
+	echo
+	echo "Cancelled $cancelled run(s)."
+fi


### PR DESCRIPTION
## Summary

- Switch bundled Python helper libraries (`pylaser`, `pymachineconfig`, `pytexture`, `pyutil`, `pybuild123d`) from `openscad` to `pythonscad` imports so they align with the three-module layout and can use PythonSCAD-only APIs.
- Fix `MachineConfig.configfile()` XDG path lookup (`xgd` → `xdg` typo that broke config resolution under `XDG_CONFIG_HOME`).
- Improve `build123d` decorator: forward `*args`/`**kwargs` and remove debug print.
- Narrow bare `except` in `LaserCutter.normalize()` to `AttributeError`.
- Add `scripts/cancel-branch-ci.sh` to cancel in-progress GitHub Actions runs on a branch (supports `--pr` and `--dry-run`).

## Test plan

- [ ] Run GCode examples that import `pymachineconfig` (e.g. `examples/GCode/machine_config.py`)
- [x] Run laser regression scripts under `tests/data/pythonscad-laser/`
- [x] Verify `./scripts/cancel-branch-ci.sh --dry-run` on this branch


Made with [Cursor](https://cursor.com)