### PR TITLE
fix(python): make nimport() work on Windows and report errors

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -196,26 +196,45 @@ static size_t curl_download_write(void *ptr, size_t size, size_t nmemb, void *st
 
 int curl_download(const std::string& url, const std::string& path)
 {
-  CURLcode status;
+  CURLcode status = CURLE_FAILED_INIT;
   QFile fh((path).c_str());
   if (!fh.open(QIODevice::WriteOnly)) {
     LOG(message_group::Error, "Cannot open file %1$s", path.c_str());
     return -1;
   }
   LOG(message_group::Warning, "Downloading to %1$s", path.c_str());
+  char errbuf[CURL_ERROR_SIZE] = {0};
   CURL *curl = curl_easy_init();
   if (curl) {
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &fh);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_download_write);
     curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10L);
+    curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "PythonSCAD libcurl");
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
+#if defined(_WIN32) && defined(CURLSSLOPT_NATIVE_CA)
+    // Use the Windows certificate store for HTTPS verification. Without
+    // this, libcurl builds linked against OpenSSL/wolfSSL on Windows
+    // have no CA bundle and every HTTPS request fails with
+    // CURLE_PEER_FAILED_VERIFICATION. Harmless on Schannel builds where
+    // it is already the default behavior.
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_NATIVE_CA);
+#endif
 
     status = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
   fh.close();
   if (status != CURLE_OK) {
-    LOG(message_group::Error, "Could not download!");
+    const char *detail = (errbuf[0] != '\0') ? errbuf : curl_easy_strerror(status);
+    LOG(message_group::Error, "Could not download %1$s: %2$s", url.c_str(), detail);
+    QFile::remove(path.c_str());
+    return -1;
   }
   return 0;
 }

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -603,11 +603,8 @@ PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs)
   importcode = "from " + filename.substr(0, filename.find_last_of(".")) + " import *";
 
   path = PlatformUtils::userLibraryPath() + "/" + filename;
-  bool do_download = false;
-  if (std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) == nimport_downloaded.end()) {
-    do_download = true;
-    nimport_downloaded.push_back(url);
-  }
+  bool do_download =
+    std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) == nimport_downloaded.end();
 
   std::ifstream f(path.c_str());
   if (!f.good()) {
@@ -615,7 +612,13 @@ PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs)
   }
 
   if (do_download) {
-    curl_download(url, path);
+    if (curl_download(url, path) != 0) {
+      PyErr_Format(PyExc_RuntimeError, "nimport: failed to download %s", url.c_str());
+      return NULL;
+    }
+    if (std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) == nimport_downloaded.end()) {
+      nimport_downloaded.push_back(url);
+    }
   }
 
   PyRun_SimpleString(importcode.c_str());


### PR DESCRIPTION
curl_download() in MainWindow.cc was missing several libcurl options that broke nimport() in practice, with the Windows-fatal one being the missing TLS/CA configuration:

* CURLcode status was uninitialized; if curl_easy_init() returned NULL, the error branch was taken with an indeterminate value.
* No CURLOPT_FOLLOWLOCATION, so any redirect (e.g. github -> raw. githubusercontent.com) silently 'succeeded' with HTML in the file.
* No CA bundle / native-CA configuration on Windows. libcurl builds linked against OpenSSL/wolfSSL on Windows have no default CA store, so every HTTPS request failed with CURLE_PEER_FAILED_VERIFICATION and surfaced as 'Could not download!' with no further detail. Fixed by setting CURLOPT_SSL_OPTIONS = CURLSSLOPT_NATIVE_CA on Windows so libcurl uses the Windows certificate store. Guarded on the macro for libcurl < 7.71 and harmless on Schannel builds.
* No CURLOPT_FAILONERROR, so 4xx/5xx bodies were written to the destination file as if they were the requested model.
* No CURLOPT_ERRORBUFFER and no URL in the log line, making the failure impossible to diagnose.
* No connect/total timeouts; a stalled server hung the GUI thread.
* The partially-written file was left on disk on failure.

python_nimport() also had two bugs that compounded the curl ones:

* The URL was inserted into nimport_downloaded before the download was attempted, so a single failure poisoned the in-memory cache for the rest of the session with no retry path.
* curl_download()'s return value was ignored and PyRun_SimpleString ran 'from <module> import *' against the empty/garbage file, masking the real error behind a confusing ImportError.

Now curl_download() returns -1 on failure, removes the partial file, and logs the URL plus libcurl's detail string. python_nimport() only caches successful downloads and raises a Python RuntimeError on failure.