### PR TITLE
fix(python): make nimport() work on Windows and report errors

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -196,26 +196,45 @@ static size_t curl_download_write(void *ptr, size_t size, size_t nmemb, void *st
 
 int curl_download(const std::string& url, const std::string& path)
 {
-  CURLcode status;
+  CURLcode status = CURLE_FAILED_INIT;
   QFile fh((path).c_str());
   if (!fh.open(QIODevice::WriteOnly)) {
     LOG(message_group::Error, "Cannot open file %1$s", path.c_str());
     return -1;
   }
   LOG(message_group::Warning, "Downloading to %1$s", path.c_str());
+  char errbuf[CURL_ERROR_SIZE] = {0};
   CURL *curl = curl_easy_init();
   if (curl) {
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &fh);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_download_write);
     curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10L);
+    curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "PythonSCAD libcurl");
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
+#if defined(_WIN32) && defined(CURLSSLOPT_NATIVE_CA)
+    // Use the Windows certificate store for HTTPS verification. Without
+    // this, libcurl builds linked against OpenSSL/wolfSSL on Windows
+    // have no CA bundle and every HTTPS request fails with
+    // CURLE_PEER_FAILED_VERIFICATION. Harmless on Schannel builds where
+    // it is already the default behavior.
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_NATIVE_CA);
+#endif
 
     status = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
   fh.close();
   if (status != CURLE_OK) {
-    LOG(message_group::Error, "Could not download!");
+    const char *detail = (errbuf[0] != '\0') ? errbuf : curl_easy_strerror(status);
+    LOG(message_group::Error, "Could not download %1$s: %2$s", url.c_str(), detail);
+    QFile::remove(path.c_str());
+    return -1;
   }
   return 0;
 }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -190,8 +190,9 @@
 static size_t curl_download_write(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   QFile *fh = (QFile *)stream;
-  fh->write(QByteArray((const char *)ptr, size * nmemb));
-  return size * nmemb;
+  qint64 written = fh->write(QByteArray((const char *)ptr, size * nmemb));
+  if (written < 0) return 0;
+  return (size_t)written;
 }
 
 int curl_download(const std::string& url, const std::string& path, std::string *errmsg)

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -194,12 +194,15 @@ static size_t curl_download_write(void *ptr, size_t size, size_t nmemb, void *st
   return size * nmemb;
 }
 
-int curl_download(const std::string& url, const std::string& path)
+int curl_download(const std::string& url, const std::string& path, std::string *errmsg)
 {
+  const std::string useragent =
+    std::string("PythonSCAD/") + std::string(openscad_versionnumber) + " libcurl/" LIBCURL_VERSION;
   CURLcode status = CURLE_FAILED_INIT;
   QFile fh((path).c_str());
   if (!fh.open(QIODevice::WriteOnly)) {
     LOG(message_group::Error, "Cannot open file %1$s", path.c_str());
+    if (errmsg) *errmsg = std::string("cannot open destination file: ") + path;
     return -1;
   }
   LOG(message_group::Warning, "Downloading to %1$s", path.c_str());
@@ -212,8 +215,15 @@ int curl_download(const std::string& url, const std::string& path)
     curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10L);
+#if CURL_AT_LEAST_VERSION(7, 85, 0)
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#else
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
     curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, "PythonSCAD libcurl");
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, useragent.c_str());
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
@@ -233,6 +243,7 @@ int curl_download(const std::string& url, const std::string& path)
   if (status != CURLE_OK) {
     const char *detail = (errbuf[0] != '\0') ? errbuf : curl_easy_strerror(status);
     LOG(message_group::Error, "Could not download %1$s: %2$s", url.c_str(), detail);
+    if (errmsg) *errmsg = detail;
     QFile::remove(path.c_str());
     return -1;
   }

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -606,8 +606,7 @@ PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs)
   bool already_downloaded =
     std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) != nimport_downloaded.end();
 
-  std::ifstream f(path.c_str());
-  bool do_download = !already_downloaded || !f.good();
+  bool do_download = !already_downloaded || !std::ifstream(path.c_str()).good();
 
   if (do_download) {
     std::string errmsg;

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -586,7 +586,7 @@ PyObject *python_import(PyObject *self, PyObject *args, PyObject *kwargs)
 #ifndef OPENSCAD_NOGUI
 std::vector<std::string> nimport_downloaded;
 
-extern int curl_download(const std::string& url, const std::string& path);
+extern int curl_download(const std::string& url, const std::string& path, std::string *errmsg);
 PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   char *kwlist[] = {"url", NULL};
@@ -603,21 +603,20 @@ PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs)
   importcode = "from " + filename.substr(0, filename.find_last_of(".")) + " import *";
 
   path = PlatformUtils::userLibraryPath() + "/" + filename;
-  bool do_download =
-    std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) == nimport_downloaded.end();
+  bool already_downloaded =
+    std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) != nimport_downloaded.end();
 
   std::ifstream f(path.c_str());
-  if (!f.good()) {
-    do_download = true;
-  }
+  bool do_download = !already_downloaded || !f.good();
 
   if (do_download) {
-    if (curl_download(url, path) != 0) {
-      PyErr_Format(PyExc_RuntimeError, "nimport: failed to download %s", url.c_str());
+    std::string errmsg;
+    if (curl_download(url, path, &errmsg) != 0) {
+      PyErr_Format(PyExc_RuntimeError, "nimport: failed to download %s to %s: %s", url.c_str(),
+                   path.c_str(), errmsg.c_str());
       return NULL;
     }
-    if (std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) ==
-        nimport_downloaded.end()) {
+    if (!already_downloaded) {
       nimport_downloaded.push_back(url);
     }
   }

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -603,11 +603,8 @@ PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs)
   importcode = "from " + filename.substr(0, filename.find_last_of(".")) + " import *";
 
   path = PlatformUtils::userLibraryPath() + "/" + filename;
-  bool do_download = false;
-  if (std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) == nimport_downloaded.end()) {
-    do_download = true;
-    nimport_downloaded.push_back(url);
-  }
+  bool do_download =
+    std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) == nimport_downloaded.end();
 
   std::ifstream f(path.c_str());
   if (!f.good()) {
@@ -615,7 +612,14 @@ PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs)
   }
 
   if (do_download) {
-    curl_download(url, path);
+    if (curl_download(url, path) != 0) {
+      PyErr_Format(PyExc_RuntimeError, "nimport: failed to download %s", url.c_str());
+      return NULL;
+    }
+    if (std::find(nimport_downloaded.begin(), nimport_downloaded.end(), url) ==
+        nimport_downloaded.end()) {
+      nimport_downloaded.push_back(url);
+    }
   }
 
   PyRun_SimpleString(importcode.c_str());


### PR DESCRIPTION
Fixes https://github.com/pythonscad/pythonscad/issues/727

I tested the fix on my Windows machine from github action compiled github binaries. See https://github.com/wiw-msft-copilot-test/pythonscad/actions/runs/27480673911

I installed with `PythonSCAD-1.0.0-windows-x86-64-Installer ` to my Windows 11 machine. nimport() will successfully download py files from github now.