### PR TITLE
feat(packaging): bundle IPython 9.x with MSYS2 psutil vendoring

### DIFF
--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -141,7 +141,7 @@ jobs:
           cmake --build . -j4
 
       - name: Install MSYS2 psutil for IPython 9 bundle
-        run: pacboy -S python-psutil:p
+        run: pacboy -S --noconfirm python-psutil:p
 
       - name: Bundle runtime Python deps (IPython) into build tree
         run: |

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -140,6 +140,9 @@ jobs:
             "${EXTRA_CMAKE[@]}"
           cmake --build . -j4
 
+      - name: Install MSYS2 psutil for IPython 9 bundle
+        run: pacboy -S python-psutil:p
+
       - name: Bundle runtime Python deps (IPython) into build tree
         run: |
           # Bundle into ${CMAKE_BINARY_DIR}/pythonscad-bundled-py BEFORE

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -141,7 +141,7 @@ jobs:
           cmake --build . -j4
 
       - name: Install MSYS2 psutil for IPython 9 bundle
-        run: pacboy -S --noconfirm python-psutil:p
+        run: pacboy -S --noconfirm --needed python-psutil:p
 
       - name: Bundle runtime Python deps (IPython) into build tree
         run: |

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -52,14 +52,13 @@ jobs:
         # standard PEP 668 escape hatch on Ubuntu 24.04+; pre-PEP-668
         # runners just ignore it and install normally.
         #
-        # `ipython<9` matches the cap in `requirements/runtime.txt`
+        # `ipython>=9,<10` matches the pin in `requirements/runtime.txt`
         # and `pyproject.toml`. We deliberately exercise the same
         # major version that binary bundles (AppImage / .app /
         # Windows installer) and the published pip wheel ship, so
         # CI catches regressions in the version users actually run.
-        # See requirements/runtime.txt for the rationale on why <9.
-        python3 -m pip install --break-system-packages --upgrade 'ipython<9' pexpect \
-          || python3 -m pip install --upgrade 'ipython<9' pexpect
+        python3 -m pip install --break-system-packages --upgrade 'ipython>=9,<10' pexpect \
+          || python3 -m pip install --upgrade 'ipython>=9,<10' pexpect
     - name: Build and test
       run: ./scripts/github-ci.sh experimental enable_python enable_libfive ${{ matrix.qt }} build test coverage
     - name: Upload Test Result Report

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -56,7 +56,8 @@ jobs:
         # still ship Python 3.10, so skip the IPython install there; the
         # --ipython smoke tests exercise the fallback REPL on that leg.
         # pexpect is installed unconditionally so ipython-pty can run.
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --break-system-packages --upgrade pip \
+          || python3 -m pip install --upgrade pip
         if python3 -c 'import sys; sys.exit(0 if sys.version_info < (3, 11) else 1)'; then
           echo "SKIP: IPython 9.x requires Python 3.11+; this runner has $(python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')."
           echo "Installing pexpect only; --ipython tests will exercise the fallback REPL path."

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -53,18 +53,17 @@ jobs:
         # runners just ignore it and install normally.
         #
         # IPython 9.x requires Python 3.11+. ubuntu-22.04 runners
-        # still ship Python 3.10, so skip the install there; the
+        # still ship Python 3.10, so skip the IPython install there; the
         # --ipython smoke tests exercise the fallback REPL on that leg.
-        #
-        # `ipython>=9,<10` matches the pin in `requirements/runtime.txt`
-        # for bundled binaries. On Python 3.11+ runners we install that
-        # same major version; ubuntu-22.04 (Python 3.10) skips below.
+        # pexpect is installed unconditionally so ipython-pty can run.
+        python3 -m pip install --upgrade pip
         if python3 -c 'import sys; sys.exit(0 if sys.version_info < (3, 11) else 1)'; then
           echo "SKIP: IPython 9.x requires Python 3.11+; this runner has $(python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')."
-          echo "--ipython tests will exercise the fallback REPL path."
+          echo "Installing pexpect only; --ipython tests will exercise the fallback REPL path."
+          python3 -m pip install --break-system-packages --upgrade pexpect \
+            || python3 -m pip install --upgrade pexpect
           exit 0
         fi
-        python3 -m pip install --upgrade pip
         python3 -m pip install --break-system-packages --upgrade 'ipython>=9,<10' pexpect \
           || python3 -m pip install --upgrade 'ipython>=9,<10' pexpect
     - name: Build and test

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -57,20 +57,13 @@ jobs:
         # --ipython smoke tests exercise the fallback REPL on that leg.
         #
         # `ipython>=9,<10` matches the pin in `requirements/runtime.txt`
-        # and `pyproject.toml`. We deliberately exercise the same
-        # major version that binary bundles (AppImage / .app /
-        # Windows installer) and the published pip wheel ship, so
-        # CI catches regressions in the version users actually run.
-        python3 - <<'PY'
-        import sys
-        if sys.version_info < (3, 11):
-            print(
-                f"SKIP: IPython 9.x requires Python 3.11+; this runner has "
-                f"{sys.version_info.major}.{sys.version_info.minor}. "
-                "--ipython tests will exercise the fallback REPL path."
-            )
-            raise SystemExit(0)
-        PY
+        # for bundled binaries. On Python 3.11+ runners we install that
+        # same major version; ubuntu-22.04 (Python 3.10) skips below.
+        if python3 -c 'import sys; sys.exit(0 if sys.version_info < (3, 11) else 1)'; then
+          echo "SKIP: IPython 9.x requires Python 3.11+; this runner has $(python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')."
+          echo "--ipython tests will exercise the fallback REPL path."
+          exit 0
+        fi
         python3 -m pip install --upgrade pip
         python3 -m pip install --break-system-packages --upgrade 'ipython>=9,<10' pexpect \
           || python3 -m pip install --upgrade 'ipython>=9,<10' pexpect

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -52,11 +52,26 @@ jobs:
         # standard PEP 668 escape hatch on Ubuntu 24.04+; pre-PEP-668
         # runners just ignore it and install normally.
         #
+        # IPython 9.x requires Python 3.11+. ubuntu-22.04 runners
+        # still ship Python 3.10, so skip the install there; the
+        # --ipython smoke tests exercise the fallback REPL on that leg.
+        #
         # `ipython>=9,<10` matches the pin in `requirements/runtime.txt`
         # and `pyproject.toml`. We deliberately exercise the same
         # major version that binary bundles (AppImage / .app /
         # Windows installer) and the published pip wheel ship, so
         # CI catches regressions in the version users actually run.
+        python3 - <<'PY'
+        import sys
+        if sys.version_info < (3, 11):
+            print(
+                f"SKIP: IPython 9.x requires Python 3.11+; this runner has "
+                f"{sys.version_info.major}.{sys.version_info.minor}. "
+                "--ipython tests will exercise the fallback REPL path."
+            )
+            raise SystemExit(0)
+        PY
+        python3 -m pip install --upgrade pip
         python3 -m pip install --break-system-packages --upgrade 'ipython>=9,<10' pexpect \
           || python3 -m pip install --upgrade 'ipython>=9,<10' pexpect
     - name: Build and test

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -59,7 +59,8 @@ jobs:
         python3 -m pip install --break-system-packages --upgrade pip \
           || python3 -m pip install --upgrade pip
         if python3 -c 'import sys; sys.exit(0 if sys.version_info < (3, 11) else 1)'; then
-          echo "SKIP: IPython 9.x requires Python 3.11+; this runner has $(python3 -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')."
+          py_ver=$(python3 -c 'import sys; print("%d.%d" % (sys.version_info.major, sys.version_info.minor))')
+          echo "SKIP: IPython 9.x requires Python 3.11+; this runner has ${py_ver}."
           echo "Installing pexpect only; --ipython tests will exercise the fallback REPL path."
           python3 -m pip install --break-system-packages --upgrade pexpect \
             || python3 -m pip install --upgrade pexpect

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -61,14 +61,13 @@ jobs:
         # need to be importable by the *system* python3 because that
         # is what the embedded interpreter resolves at runtime.
         #
-        # `ipython<9` matches the cap in `requirements/runtime.txt`
+        # `ipython>=9,<10` matches the pin in `requirements/runtime.txt`
         # and `pyproject.toml`. We deliberately exercise the same
         # major version that binary bundles (AppImage / .app /
         # Windows installer) and the published pip wheel ship, so
         # CI catches regressions in the version users actually run.
-        # See requirements/runtime.txt for the rationale on why <9.
-        python3 -m pip install --break-system-packages --upgrade 'ipython<9' pexpect \
-          || python3 -m pip install --upgrade 'ipython<9' pexpect
+        python3 -m pip install --break-system-packages --upgrade 'ipython>=9,<10' pexpect \
+          || python3 -m pip install --upgrade 'ipython>=9,<10' pexpect
     - name: Build OpenSCAD
       run: |
         mkdir build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,6 +84,13 @@ jobs:
           cd build
           ctest -j4
 
+      - name: Smoke test runtime Python bundle (IPython 9 + MSYS2 psutil)
+        run: |
+          pacboy -S python-psutil:p
+          chmod +x ./scripts/bundle-runtime-python.sh
+          BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
+            ./scripts/bundle-runtime-python.sh /tmp/pythonscad-bundled-py-test --python python
+
       - name: Upload Test Result Report
         uses: actions/upload-artifact@v7
         if: ${{ always() }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Smoke test runtime Python bundle (IPython 9 + MSYS2 psutil)
         run: |
-          pacboy -S python-psutil:p
+          pacboy -S --noconfirm python-psutil:p
           chmod +x ./scripts/bundle-runtime-python.sh
           BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
             ./scripts/bundle-runtime-python.sh /tmp/pythonscad-bundled-py-test --python python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Smoke test runtime Python bundle (IPython 9 + MSYS2 psutil)
         run: |
-          pacboy -S --noconfirm python-psutil:p
+          pacboy -S --noconfirm --needed python-psutil:p
           chmod +x ./scripts/bundle-runtime-python.sh
           BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
             ./scripts/bundle-runtime-python.sh /tmp/pythonscad-bundled-py-test --python python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2203,7 +2203,7 @@ if(NOT APPLE OR APPLE_UNIX)
       install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pythonscad-python DESTINATION "${OPENSCAD_BINDIR}")
     endif()
 
-    # On Windows, the runtime Python deps (currently: IPython 8.x and its
+    # On Windows, the runtime Python deps (currently: IPython 9.x and its
     # transitive deps) are populated into ${CMAKE_BINARY_DIR}/pythonscad-bundled-py
     # by scripts/bundle-runtime-python.sh, invoked from the Windows build
     # workflow ahead of `cmake --install`. CPack then picks the directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,14 @@ skip = ["*-musllinux*", "*-win32*", "*-win_arm64*", "cp*t-*", "pp*"]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 build-frontend = "build"
-test-requires = [
-    "ipython>=9,<10; python_version>='3.11'",
-    "ipython>=8,<9; python_version<'3.11'",
-]
+# cibuildwheel splits test-requires on ';', so PEP 508 markers must
+# use [[tool.cibuildwheel.overrides]] instead of inline markers here.
+test-requires = ["ipython>=9,<10"]
 test-command = "python {project}/scripts/smoke-test-pip.py"
+
+[[tool.cibuildwheel.overrides]]
+select = "cp310-*"
+test-requires = ["ipython>=8,<9"]
 
 [tool.cibuildwheel.linux]
 before-all = "bash scripts/cibuildwheel/install-deps-manylinux.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,10 @@ classifiers = [
 # installer) consume requirements/runtime.txt directly via
 # `pip install --target=...`.
 #
-# IPython is capped at <9 to avoid IPython 9.x's hard `psutil>=7`
-# dependency, which has no prebuilt MSYS2/UCRT64 wheel and fails to
-# build from source against MSYS2's `winternl.h`. See the longer
-# rationale in requirements/runtime.txt.
+# IPython 9.x requires `psutil>=7`. Windows native bundles vend
+# psutil from MSYS2 pacman; see requirements/runtime.txt.
 dependencies = [
-    "ipython>=8,<9",
+    "ipython>=9,<10",
 ]
 
 [project.urls]
@@ -59,7 +57,7 @@ skip = ["*-musllinux*", "*-win32*", "*-win_arm64*", "cp*t-*", "pp*"]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 build-frontend = "build"
-test-requires = ["ipython>=8,<9"]
+test-requires = ["ipython>=9,<10"]
 test-command = "python {project}/scripts/smoke-test-pip.py"
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,13 @@ classifiers = [
 #
 # IPython 9.x requires `psutil>=7`. Windows native bundles vend
 # psutil from MSYS2 pacman; see requirements/runtime.txt.
+#
+# IPython 9.x itself requires Python 3.11+. Binary bundles always
+# ship IPython 9 (see requirements/runtime.txt). The pip wheel keeps
+# IPython 8.x on Python 3.10 via environment markers below.
 dependencies = [
-    "ipython>=9,<10",
+    "ipython>=9,<10; python_version>='3.11'",
+    "ipython>=8,<9; python_version<'3.11'",
 ]
 
 [project.urls]
@@ -57,7 +62,10 @@ skip = ["*-musllinux*", "*-win32*", "*-win_arm64*", "cp*t-*", "pp*"]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 build-frontend = "build"
-test-requires = ["ipython>=9,<10"]
+test-requires = [
+    "ipython>=9,<10; python_version>='3.11'",
+    "ipython>=8,<9; python_version<'3.11'",
+]
 test-command = "python {project}/scripts/smoke-test-pip.py"
 
 [tool.cibuildwheel.linux]

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -26,15 +26,12 @@
 # `pythonscad --ipython`. The basic embedded REPL launched by
 # `pythonscad --repl` works without any optional packages.
 #
-# Capped at <9 deliberately: IPython 9.x added a hard runtime
-# dependency on `psutil>=7`, and there is no prebuilt psutil wheel
-# for the MSYS2/UCRT64 ABI tag (`mingw_x86_64_ucrt_gnu-cpython-3xx`)
-# that the Windows native build uses. pip then falls back to building
-# psutil from source, where psutil's bundled `ntextapi.h` collides
-# with MSYS2 UCRT64's `winternl.h` (`MaximumWaitReason` /
-# `KWAIT_REASON` redefinition) and the build aborts. IPython 8.x has
-# no psutil dependency, covers every PythonSCAD `--ipython` use case
-# (rich `In [N]:` prompt, history, tab completion), and produces a
-# smaller bundle. Revisit when IPython 10 ships or when MSYS2 has a
-# usable psutil wheel for the build's Python version.
-ipython>=8,<9
+# IPython 9.x added a hard runtime dependency on `psutil>=7`. On
+# Linux/macOS/PyPI, pip resolves psutil from prebuilt wheels. On
+# Windows native (MSYS2 UCRT64), PyPI has no psutil wheel for the
+# `mingw_x86_64_ucrt_gnu-cpython-3xx` ABI and source builds fail
+# against MSYS2's `winternl.h`. scripts/bundle-runtime-python.sh
+# therefore vendors psutil from the MSYS2 pacman package
+# (`pacboy -S python-psutil:p`) on that platform; see
+# scripts/bundle-ipython-msys2.py.
+ipython>=9,<10

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -32,6 +32,6 @@
 # `mingw_x86_64_ucrt_gnu-cpython-3xx` ABI and source builds fail
 # against MSYS2's `winternl.h`. scripts/bundle-runtime-python.sh
 # therefore vendors psutil from the MSYS2 pacman package
-# (`pacboy -S python-psutil:p`) on that platform; see
+# (`pacboy -S --noconfirm python-psutil:p`) on that platform; see
 # scripts/bundle-ipython-msys2.py.
 ipython>=9,<10

--- a/scripts/bundle-ipython-msys2.py
+++ b/scripts/bundle-ipython-msys2.py
@@ -16,7 +16,6 @@ import email
 import pathlib
 import shutil
 import subprocess
-import sys
 import tempfile
 import zipfile
 

--- a/scripts/bundle-ipython-msys2.py
+++ b/scripts/bundle-ipython-msys2.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Install IPython 9.x into a --target directory on MSYS2 UCRT64.
+
+IPython 9.x requires psutil>=7, but PyPI has no prebuilt psutil wheel
+for the mingw_x86_64_ucrt_gnu-cpython ABI and source builds fail against
+MSYS2's winternl.h. MSYS2 ships a pacman-built psutil; this script
+installs IPython's other dependencies via pip, copies psutil from the
+system site-packages into the bundle, then installs IPython itself with
+--no-deps from the downloaded wheel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import email
+import pathlib
+import shutil
+import site
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
+
+
+def _run(cmd: list[str]) -> None:
+    print(f"[bundle-ipython-msys2] running: {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def _download_ipython_wheel(
+    python: str, requirements_file: pathlib.Path, dest_dir: pathlib.Path
+) -> pathlib.Path:
+    _run(
+        [
+            python,
+            "-m",
+            "pip",
+            "download",
+            "--no-deps",
+            "-r",
+            str(requirements_file),
+            "-d",
+            str(dest_dir),
+        ]
+    )
+    wheels = sorted(dest_dir.glob("ipython-*.whl"), key=lambda p: p.name, reverse=True)
+    if not wheels:
+        raise SystemExit(f"no ipython wheel downloaded to {dest_dir}")
+    return wheels[0]
+
+
+def _read_requires_dist(wheel_path: pathlib.Path) -> list[Requirement]:
+    with zipfile.ZipFile(wheel_path) as zf:
+        meta_name = next(n for n in zf.namelist() if n.endswith(".dist-info/METADATA"))
+        meta_text = zf.read(meta_name).decode("utf-8")
+    msg = email.message_from_string(meta_text)
+    return [Requirement(val) for key, val in msg.items() if key.lower() == "requires-dist"]
+
+
+def _filter_requirements(
+    requires_dist: list[Requirement], exclude_names: set[str]
+) -> list[str]:
+    env = default_environment()
+    exclude = {name.lower() for name in exclude_names}
+    selected: list[str] = []
+    for req in requires_dist:
+        if req.name.lower() in exclude:
+            continue
+        if req.marker is not None and not req.marker.evaluate(env):
+            continue
+        selected.append(str(req).split(";")[0])
+    return selected
+
+
+def _install_deps(python: str, target: pathlib.Path, req_strings: list[str]) -> None:
+    if not req_strings:
+        return
+    _run(
+        [
+            python,
+            "-m",
+            "pip",
+            "install",
+            "--target",
+            str(target),
+            "--upgrade",
+            "--no-compile",
+            *req_strings,
+        ]
+    )
+
+
+def _vend_psutil_from_system(target: pathlib.Path) -> None:
+    import importlib.metadata
+
+    import psutil
+
+    src_pkg = pathlib.Path(psutil.__file__).parent
+    dest_pkg = target / src_pkg.name
+    if dest_pkg.exists():
+        shutil.rmtree(dest_pkg)
+    shutil.copytree(src_pkg, dest_pkg)
+
+    for sp in [*site.getsitepackages(), site.getusersitepackages()]:
+        if not sp:
+            continue
+        sp_path = pathlib.Path(sp)
+        if not sp_path.is_dir():
+            continue
+        for meta in sp_path.glob("psutil-*.dist-info"):
+            dest_meta = target / meta.name
+            if dest_meta.exists():
+                shutil.rmtree(dest_meta)
+            shutil.copytree(meta, dest_meta)
+            return
+
+    version = importlib.metadata.version("psutil")
+    raise SystemExit(f"psutil-{version} dist-info not found in site-packages")
+
+
+def _install_ipython_wheel(python: str, target: pathlib.Path, wheel_path: pathlib.Path) -> None:
+    _run(
+        [
+            python,
+            "-m",
+            "pip",
+            "install",
+            "--target",
+            str(target),
+            "--no-deps",
+            "--no-compile",
+            str(wheel_path),
+        ]
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python", required=True, help="Python interpreter to drive pip")
+    parser.add_argument("--target", required=True, type=pathlib.Path, help="Bundle staging dir")
+    parser.add_argument(
+        "--requirements", required=True, type=pathlib.Path, help="requirements/runtime.txt"
+    )
+    args = parser.parse_args()
+
+    try:
+        subprocess.run([args.python, "-c", "import psutil"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        raise SystemExit(
+            "psutil is not importable in the build Python. "
+            "On MSYS2 UCRT64, run: pacboy -S python-psutil:p"
+        ) from None
+
+    args.target.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="ipython-wheel.") as tmp:
+        wheel_dir = pathlib.Path(tmp)
+        wheel = _download_ipython_wheel(args.python, args.requirements, wheel_dir)
+        deps = _filter_requirements(_read_requires_dist(wheel), exclude_names={"psutil"})
+        _install_deps(args.python, args.target, deps)
+        _vend_psutil_from_system(args.target)
+        _install_ipython_wheel(args.python, args.target, wheel)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bundle-ipython-msys2.py
+++ b/scripts/bundle-ipython-msys2.py
@@ -30,9 +30,30 @@ def _run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
 
 
+def _parse_runtime_requirements(requirements_file: pathlib.Path) -> tuple[list[str], list[str]]:
+    """Split a requirements file into IPython specs and all other runtime deps."""
+    ipython_specs: list[str] = []
+    other_specs: list[str] = []
+    for raw_line in requirements_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        req = Requirement(line)
+        if req.name.lower() == "ipython":
+            ipython_specs.append(line)
+        elif req.name.lower() == "psutil":
+            # Vendored from MSYS2 pacman on this code path.
+            continue
+        else:
+            other_specs.append(line)
+    return ipython_specs, other_specs
+
+
 def _download_ipython_wheel(
-    python: str, requirements_file: pathlib.Path, dest_dir: pathlib.Path
+    python: str, ipython_specs: list[str], dest_dir: pathlib.Path
 ) -> pathlib.Path:
+    if not ipython_specs:
+        raise SystemExit("requirements file contains no ipython entry")
     _run(
         [
             python,
@@ -40,8 +61,7 @@ def _download_ipython_wheel(
             "pip",
             "download",
             "--no-deps",
-            "-r",
-            str(requirements_file),
+            *ipython_specs,
             "-d",
             str(dest_dir),
         ]
@@ -71,7 +91,7 @@ def _filter_requirements(
             continue
         if req.marker is not None and not req.marker.evaluate(env):
             continue
-        selected.append(str(req).split(";")[0])
+        selected.append(str(req).split(";", 1)[0].strip())
     return selected
 
 
@@ -156,9 +176,12 @@ def main() -> None:
 
     args.target.mkdir(parents=True, exist_ok=True)
 
+    ipython_specs, other_specs = _parse_runtime_requirements(args.requirements)
+    _install_deps(args.python, args.target, other_specs)
+
     with tempfile.TemporaryDirectory(prefix="ipython-wheel.") as tmp:
         wheel_dir = pathlib.Path(tmp)
-        wheel = _download_ipython_wheel(args.python, args.requirements, wheel_dir)
+        wheel = _download_ipython_wheel(args.python, ipython_specs, wheel_dir)
         deps = _filter_requirements(_read_requires_dist(wheel), exclude_names={"psutil"})
         _install_deps(args.python, args.target, deps)
         _vend_psutil_from_system(args.target)

--- a/scripts/bundle-ipython-msys2.py
+++ b/scripts/bundle-ipython-msys2.py
@@ -24,9 +24,11 @@ import zipfile
 try:
     from packaging.markers import default_environment
     from packaging.requirements import Requirement
+    from packaging.utils import parse_wheel_filename
 except ModuleNotFoundError:  # minimal/MSYS2 build Pythons may lack packaging
     from pip._vendor.packaging.markers import default_environment
     from pip._vendor.packaging.requirements import Requirement
+    from pip._vendor.packaging.utils import parse_wheel_filename
 
 
 def _run(cmd: list[str]) -> None:
@@ -70,10 +72,10 @@ def _download_ipython_wheel(
             str(dest_dir),
         ]
     )
-    wheels = sorted(dest_dir.glob("ipython-*.whl"), key=lambda p: p.name, reverse=True)
+    wheels = list(dest_dir.glob("ipython-*.whl"))
     if not wheels:
         raise SystemExit(f"no ipython wheel downloaded to {dest_dir}")
-    return wheels[0]
+    return max(wheels, key=lambda path: parse_wheel_filename(path.name)[1])
 
 
 def _read_requires_dist(wheel_path: pathlib.Path) -> list[Requirement]:

--- a/scripts/bundle-ipython-msys2.py
+++ b/scripts/bundle-ipython-msys2.py
@@ -15,7 +15,6 @@ import argparse
 import email
 import pathlib
 import shutil
-import site
 import subprocess
 import sys
 import tempfile
@@ -130,21 +129,17 @@ def _vend_psutil_from_system(target: pathlib.Path) -> None:
         shutil.rmtree(dest_pkg)
     shutil.copytree(src_pkg, dest_pkg)
 
-    for sp in [*site.getsitepackages(), site.getusersitepackages()]:
-        if not sp:
-            continue
-        sp_path = pathlib.Path(sp)
-        if not sp_path.is_dir():
-            continue
-        for meta in sp_path.glob("psutil-*.dist-info"):
-            dest_meta = target / meta.name
-            if dest_meta.exists():
-                shutil.rmtree(dest_meta)
-            shutil.copytree(meta, dest_meta)
-            return
+    dist = importlib.metadata.distribution("psutil")
+    dist_info = pathlib.Path(getattr(dist, "_path", ""))
+    if not dist_info.is_dir():
+        dist_info = src_pkg.parent / f"psutil-{dist.version}.dist-info"
+    if not dist_info.is_dir():
+        raise SystemExit(f"psutil dist-info not found for psutil {dist.version}")
 
-    version = importlib.metadata.version("psutil")
-    raise SystemExit(f"psutil-{version} dist-info not found in site-packages")
+    dest_meta = target / dist_info.name
+    if dest_meta.exists():
+        shutil.rmtree(dest_meta)
+    shutil.copytree(dist_info, dest_meta)
 
 
 def _install_ipython_wheel(python: str, target: pathlib.Path, wheel_path: pathlib.Path) -> None:

--- a/scripts/bundle-ipython-msys2.py
+++ b/scripts/bundle-ipython-msys2.py
@@ -21,8 +21,12 @@ import sys
 import tempfile
 import zipfile
 
-from packaging.markers import default_environment
-from packaging.requirements import Requirement
+try:
+    from packaging.markers import default_environment
+    from packaging.requirements import Requirement
+except ModuleNotFoundError:  # minimal/MSYS2 build Pythons may lack packaging
+    from pip._vendor.packaging.markers import default_environment
+    from pip._vendor.packaging.requirements import Requirement
 
 
 def _run(cmd: list[str]) -> None:

--- a/scripts/bundle-ipython-msys2.py
+++ b/scripts/bundle-ipython-msys2.py
@@ -151,7 +151,7 @@ def main() -> None:
     except subprocess.CalledProcessError:
         raise SystemExit(
             "psutil is not importable in the build Python. "
-            "On MSYS2 UCRT64, run: pacboy -S python-psutil:p"
+            "On MSYS2 UCRT64, run: pacboy -S --noconfirm python-psutil:p"
         ) from None
 
     args.target.mkdir(parents=True, exist_ok=True)

--- a/scripts/bundle-runtime-python.sh
+++ b/scripts/bundle-runtime-python.sh
@@ -199,7 +199,15 @@ cleanup_staging() {
 trap cleanup_staging EXIT
 
 is_msys2_python() {
-    "${PYTHON_BIN}" -c 'import os, sys; raise SystemExit(0 if sys.platform == "win32" and os.environ.get("MSYSTEM") else 1)' 2>/dev/null
+    # Detect MSYS2/UCRT64 CPython by platform tag, not only MSYSTEM:
+    # bundle steps may invoke python from a non-MSYS2 shell.
+    "${PYTHON_BIN}" -c '
+import os, sys, sysconfig
+is_msys2 = sys.platform == "win32" and (
+    bool(os.environ.get("MSYSTEM")) or "mingw" in sysconfig.get_platform()
+)
+raise SystemExit(0 if is_msys2 else 1)
+' 2>/dev/null
 }
 
 if is_msys2_python; then

--- a/scripts/bundle-runtime-python.sh
+++ b/scripts/bundle-runtime-python.sh
@@ -199,14 +199,12 @@ cleanup_staging() {
 trap cleanup_staging EXIT
 
 is_msys2_python() {
-    # Detect MSYS2/UCRT64 CPython by platform tag, not only MSYSTEM:
-    # bundle steps may invoke python from a non-MSYS2 shell.
+    # Key off the interpreter's platform tag (mingw_* on MSYS2 builds),
+    # not MSYSTEM, so a python.org CPython invoked inside an MSYS2 shell
+    # still takes the normal pip install path.
     "${PYTHON_BIN}" -c '
-import os, sys, sysconfig
-is_msys2 = sys.platform == "win32" and (
-    bool(os.environ.get("MSYSTEM")) or "mingw" in sysconfig.get_platform()
-)
-raise SystemExit(0 if is_msys2 else 1)
+import sys, sysconfig
+raise SystemExit(0 if sys.platform == "win32" and "mingw" in sysconfig.get_platform() else 1)
 ' 2>/dev/null
 }
 

--- a/scripts/bundle-runtime-python.sh
+++ b/scripts/bundle-runtime-python.sh
@@ -198,13 +198,26 @@ cleanup_staging() {
 }
 trap cleanup_staging EXIT
 
-info "Running pip install --target=${STAGING_DEST} -r ${REQUIREMENTS}"
-"${PYTHON_BIN}" -m pip install \
-    --target "${STAGING_DEST}" \
-    --upgrade \
-    --no-compile \
-    -r "${REQUIREMENTS}" \
-    || die "pip install into ${STAGING_DEST} failed"
+is_msys2_python() {
+    "${PYTHON_BIN}" -c 'import os, sys; raise SystemExit(0 if sys.platform == "win32" and os.environ.get("MSYSTEM") else 1)' 2>/dev/null
+}
+
+if is_msys2_python; then
+    info "MSYS2 detected; using pacman-vendored psutil path for IPython 9+"
+    "${PYTHON_BIN}" "${SCRIPT_DIR}/bundle-ipython-msys2.py" \
+        --python "${PYTHON_BIN}" \
+        --target "${STAGING_DEST}" \
+        --requirements "${REQUIREMENTS}" \
+        || die "MSYS2 IPython bundle install into ${STAGING_DEST} failed"
+else
+    info "Running pip install --target=${STAGING_DEST} -r ${REQUIREMENTS}"
+    "${PYTHON_BIN}" -m pip install \
+        --target "${STAGING_DEST}" \
+        --upgrade \
+        --no-compile \
+        -r "${REQUIREMENTS}" \
+        || die "pip install into ${STAGING_DEST} failed"
+fi
 
 # Prune jedi's bundled third-party type stubs.
 #
@@ -440,12 +453,14 @@ fi
 # PYTHONPATH uses `:` as the separator on POSIX and `;` on Windows
 # native Python; doing the path-mutation in Python makes the call
 # site cross-platform without any per-host quoting tricks.
-info "Smoke-checking bundle (import IPython)"
+info "Smoke-checking bundle (import IPython, psutil)"
 "${PYTHON_BIN}" - "${DEST}" <<'PY' || die "bundle smoke check failed"
 import sys
 sys.path.insert(0, sys.argv[1])
 import IPython
+import psutil
 print("[bundle-py] bundled IPython:", IPython.__version__, "from", IPython.__file__)
+print("[bundle-py] bundled psutil:", psutil.__version__, "from", psutil.__file__)
 PY
 
 info "Bundle complete: $(du -sh "${DEST}" | cut -f1) at ${DEST}"


### PR DESCRIPTION
## Summary

- Upgrade bundled/declared IPython from 8.x to 9.x (`ipython>=9,<10`) across `requirements/runtime.txt`, binary bundle pipelines, and CI on Python 3.11+ runners.
- Add `scripts/bundle-ipython-msys2.py` to install IPython 9 on MSYS2 UCRT64 by vendoring `psutil` from the pacman package (`python-psutil`) and installing IPython via pip without triggering a failing source build.
- Keep pip/cibuildwheel compatibility on Python 3.10 via PEP 508 markers (`[project.dependencies]`) and a `cp310-*` cibuildwheel override for test deps.
- ubuntu-22.04 CI skips IPython 9 install (Python 3.10) but still installs `pexpect` for PTY tests.

Closes #742

## Test plan

- [x] Local Linux: `./scripts/bundle-runtime-python.sh` — IPython 9.14.1 + psutil 7.2.2 import successfully
- [x] Linux CI: `ipython-smoke`, `ipython-pty`, `ipython-fallback`, `ipython-precedence` (ubuntu-24.04; ubuntu-22.04 exercises fallback)
- [x] macOS CI: same IPython tests
- [x] Windows CI: bundle smoke step + full test suite
- [x] PyPI wheel smoke (cp312 manylinux)
- [ ] Optional pre-merge: `workflow_dispatch` on `build-windows-native.yml`