### PR TITLE
fix(ci): Dependabot commitlint and graph manifest fixes

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -47,6 +47,11 @@ rules:
     - always
     - 100
 
+  # Dependabot commit bodies contain long URLs/metadata; disabling this
+  # rule avoids false failures on machine-generated dependency bumps.
+  body-max-line-length:
+    - 0
+
   # Body should have blank line after subject
   body-leading-blank:
     - 1  # level: warning

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,3 @@
+# Dependabot dependency-graph updates expect a requirements.txt in this
+# directory. Runtime pins live in runtime.txt; keep both in sync.
+-r runtime.txt


### PR DESCRIPTION
## Summary
- Disable commitlint `body-max-line-length` so Dependabot dependency bump bodies (long URLs/metadata) no longer fail Commit Message Lint.
- Add `requirements/requirements.txt` (`-r runtime.txt`) so Dependabot dependency-graph updates recognize the `/requirements` directory manifest.

## Issues
Fixes #757
Fixes #758

## Test plan
- [ ] Commit Message Lint passes on this PR
- [ ] pre-commit / other CI checks green
- [ ] Post-merge: Dependabot graph update for `/requirements` succeeds (may need a follow-up bump to trigger)


Made with [Cursor](https://cursor.com)