### PR TITLE
ci(linux): install libcatch2-dev so unit tests build in CI

### DIFF
--- a/scripts/deps/profiles/base.json
+++ b/scripts/deps/profiles/base.json
@@ -76,7 +76,9 @@
       "extends": "debian",
       "version_overrides": {
         "24": {
-          "add": [],
+          "add": [
+            "catch2"
+          ],
           "remove": []
         }
       }


### PR DESCRIPTION
## Summary
Install Catch2 v3 on Ubuntu 24.04 CI runners by adding the `catch2` apt package via `ubuntu.version_overrides`. Ubuntu ships Catch2 3 as `catch2` (universe), not `libcatch2-dev`.

Ubuntu 22.04 only provides Catch2 v2 in apt and is left unchanged (CMake will still warn that Catch2 3 was not found on that leg).

## Issues
Fixes #759

## Test plan
- [ ] Ubuntu 24.04 Linux Experimental / Tidy / Pip legs install dependencies successfully
- [ ] Ubuntu 24.04 CMake finds Catch2 3 (`Configuring OpenSCAD Unit Tests` in logs)
- [ ] Ubuntu 22.04 legs still pass (Catch2 warning acceptable)