### PR TITLE
fix(ci): sign bundled Python native extensions for macOS notarization

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -885,8 +885,8 @@ jobs:
           BUNDLE_PY="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           if [ -d "$BUNDLE_PY" ]; then
             echo "=== Signing bundled runtime Python deps ==="
-            while IFS= read -r f; do
-              [ -n "$f" ] || continue
+            while IFS= read -r -d '' f; do
+              file "$f" | grep -q Mach-O || continue
               if ! codesign_output=$(codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1); then
                 echo "$codesign_output"
                 exit 1
@@ -894,7 +894,7 @@ jobs:
               if [ -n "$codesign_output" ]; then
                 echo "$codesign_output" | grep -v "replacing existing signature" || true
               fi
-            done < <(find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0 | xargs -0 file | sed -n 's/: Mach-O.*//p')
+            done < <(find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0)
           fi
 
           # Step 3: Sign Qt frameworks (each framework as a bundle)

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -853,15 +853,24 @@ jobs:
           while IFS= read -r -d '' f; do
             sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
           done < <(find "$APP_BUNDLE/Contents/Frameworks" -name "*.dylib" -type f -print0)
-          while IFS= read -r -d '' f; do
-            sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
-          done < <(find "$APP_BUNDLE/Contents/PlugIns" -name "*.dylib" -type f -print0)
+          if [ -d "$APP_BUNDLE/Contents/PlugIns" ]; then
+            while IFS= read -r -d '' f; do
+              sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
+            done < <(find "$APP_BUNDLE/Contents/PlugIns" -name "*.dylib" -type f -print0)
+          fi
 
           # Step 2: Sign Python framework components (innermost first)
           if [ -d "$APP_BUNDLE/Contents/Frameworks/Python.framework" ]; then
             echo "=== Signing Python framework ==="
             PY_FW="$APP_BUNDLE/Contents/Frameworks/Python.framework"
-            PY_VER=$(find "$PY_FW/Versions/" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | grep -E "^[0-9]+\.[0-9]+$" | head -1)
+            PY_VER=
+            candidate=$(find "$PY_FW/Versions" -maxdepth 1 -mindepth 1 -type d ! -name 'Current' -print -quit)
+            if [ -n "$candidate" ]; then
+              ver=$(basename "$candidate")
+              if [[ "$ver" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                PY_VER=$ver
+              fi
+            fi
             if [ -n "$PY_VER" ]; then
               PY_ROOT="$PY_FW/Versions/$PY_VER"
               # Sign all .so extension modules (lib-dynload and any other Mach-O)

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -884,15 +884,17 @@ jobs:
           BUNDLE_PY="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           if [ -d "$BUNDLE_PY" ]; then
             echo "=== Signing bundled runtime Python deps ==="
-            find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0 | while IFS= read -r -d '' f; do
+            while IFS= read -r -d '' f; do
               if file "$f" | grep -q Mach-O; then
                 if ! codesign_output=$(codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1); then
                   echo "$codesign_output"
                   exit 1
                 fi
-                echo "$codesign_output" | grep -v "replacing existing signature" || true
+                if [ -n "$codesign_output" ]; then
+                  echo "$codesign_output" | grep -v "replacing existing signature" || true
+                fi
               fi
-            done
+            done < <(find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0)
           fi
 
           # Step 3: Sign Qt frameworks (each framework as a bundle)

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -884,9 +884,13 @@ jobs:
           BUNDLE_PY="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           if [ -d "$BUNDLE_PY" ]; then
             echo "=== Signing bundled runtime Python deps ==="
-            find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) 2>/dev/null | while IFS= read -r f; do
+            find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0 2>/dev/null | while IFS= read -r -d '' f; do
               if file "$f" | grep -q Mach-O; then
-                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1 | grep -v "replacing existing signature" || true
+                if ! codesign_output=$(codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1); then
+                  echo "$codesign_output"
+                  exit 1
+                fi
+                echo "$codesign_output" | grep -v "replacing existing signature" || true
               fi
             done
           fi

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -880,6 +880,17 @@ jobs:
             fi
           fi
 
+          # Step 2b: Sign bundled runtime Python deps (e.g. psutil .so from IPython)
+          BUNDLE_PY="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
+          if [ -d "$BUNDLE_PY" ]; then
+            echo "=== Signing bundled runtime Python deps ==="
+            find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) 2>/dev/null | while IFS= read -r f; do
+              if file "$f" | grep -q Mach-O; then
+                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1 | grep -v "replacing existing signature" || true
+              fi
+            done
+          fi
+
           # Step 3: Sign Qt frameworks (each framework as a bundle)
           echo "=== Signing Qt frameworks ==="
           for fw in "$APP_BUNDLE/Contents/Frameworks"/Qt*.framework; do

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -849,7 +849,7 @@ jobs:
           done
 
           echo "=== Signing all binaries (inside-out approach) ==="
-          # Step 1: Sign all standalone dylibs (not in frameworks)
+          # Step 1: Sign dylibs under Contents/Frameworks (includes nested framework dylibs)
           while IFS= read -r -d '' f; do
             sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
           done < <(find "$APP_BUNDLE/Contents/Frameworks" -name "*.dylib" -type f -print0)
@@ -922,7 +922,11 @@ jobs:
 
             # Find the actual version directory (usually 'A')
             if [ -d "$fw/Versions" ]; then
-              ACTUAL_VERSION=$(find "$fw/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" -exec basename {} \; 2>/dev/null | head -1)
+              ACTUAL_VERSION=
+              candidate=$(find "$fw/Versions" -maxdepth 1 -mindepth 1 -type d ! -name 'Current' -print -quit)
+              if [ -n "$candidate" ]; then
+                ACTUAL_VERSION=$(basename "$candidate")
+              fi
               if [ -n "$ACTUAL_VERSION" ]; then
                 # Sign any dylibs within the framework version
                 while IFS= read -r -d '' lib; do

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -818,6 +818,16 @@ jobs:
             CODESIGN_EXTRA=()
           fi
 
+          sign_target() {
+            if ! codesign_output=$(codesign "$@" 2>&1); then
+              echo "$codesign_output"
+              exit 1
+            fi
+            if [ -n "$codesign_output" ]; then
+              echo "$codesign_output" | grep -v "replacing existing signature" || true
+            fi
+          }
+
           echo "=== Fixing executable permissions ==="
           chmod +x "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME"
           if [ -f "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME-python" ]; then
@@ -840,8 +850,12 @@ jobs:
 
           echo "=== Signing all binaries (inside-out approach) ==="
           # Step 1: Sign all standalone dylibs (not in frameworks)
-          find "$APP_BUNDLE/Contents/Frameworks" -name "*.dylib" -type f -exec codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" {} \; 2>&1 | grep -v "replacing existing signature" || true
-          find "$APP_BUNDLE/Contents/PlugIns" -name "*.dylib" -type f -exec codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" {} \; 2>&1 | grep -v "replacing existing signature" || true
+          while IFS= read -r -d '' f; do
+            sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
+          done < <(find "$APP_BUNDLE/Contents/Frameworks" -name "*.dylib" -type f -print0)
+          while IFS= read -r -d '' f; do
+            sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
+          done < <(find "$APP_BUNDLE/Contents/PlugIns" -name "*.dylib" -type f -print0)
 
           # Step 2: Sign Python framework components (innermost first)
           if [ -d "$APP_BUNDLE/Contents/Frameworks/Python.framework" ]; then
@@ -852,32 +866,31 @@ jobs:
               PY_ROOT="$PY_FW/Versions/$PY_VER"
               # Sign all .so extension modules (lib-dynload and any other Mach-O)
               echo "Signing Python .so modules..."
-              find "$PY_ROOT" -name "*.so" -type f 2>/dev/null | while IFS= read -r f; do
-                if file "$f" | grep -q Mach-O; then
-                  codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1 | grep -v "replacing existing signature" || true
-                fi
-              done
+              while IFS= read -r -d '' f; do
+                file "$f" | grep -q Mach-O || continue
+                sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
+              done < <(find "$PY_ROOT" -name "*.so" -type f -print0)
               # Sign bin/python3.x and any other Mach-O in bin
               echo "Signing Python binaries..."
               for bin in "$PY_ROOT/bin"/*; do
                 if [ -f "$bin" ] && file "$bin" | grep -q Mach-O; then
-                  codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$bin" 2>&1 | grep -v "replacing existing signature" || true
+                  sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$bin"
                 fi
               done
               # Sign nested Python.app: executable first, then the app bundle
               if [ -f "$PY_ROOT/Resources/Python.app/Contents/MacOS/Python" ]; then
                 echo "Signing nested Python.app..."
-                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Resources/Python.app/Contents/MacOS/Python" 2>&1 | grep -v "replacing existing signature" || true
-                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Resources/Python.app" 2>&1 | grep -v "replacing existing signature" || true
+                sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Resources/Python.app/Contents/MacOS/Python"
+                sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Resources/Python.app"
               fi
               # Sign main Python framework binary
               if [ -f "$PY_ROOT/Python" ]; then
                 echo "Signing Python framework binary..."
-                codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Python" 2>&1 | grep -v "replacing existing signature" || true
+                sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_ROOT/Python"
               fi
               # Sign the Python framework itself as a bundle
               echo "Signing Python.framework as a bundle..."
-              codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_FW" 2>&1 | grep -v "replacing existing signature" || true
+              sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$PY_FW"
             fi
           fi
 
@@ -887,13 +900,7 @@ jobs:
             echo "=== Signing bundled runtime Python deps ==="
             while IFS= read -r -d '' f; do
               file "$f" | grep -q Mach-O || continue
-              if ! codesign_output=$(codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1); then
-                echo "$codesign_output"
-                exit 1
-              fi
-              if [ -n "$codesign_output" ]; then
-                echo "$codesign_output" | grep -v "replacing existing signature" || true
-              fi
+              sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f"
             done < <(find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0)
           fi
 
@@ -909,21 +916,20 @@ jobs:
               ACTUAL_VERSION=$(find "$fw/Versions/" -maxdepth 1 -mindepth 1 -type d ! -name "Current" -exec basename {} \; 2>/dev/null | head -1)
               if [ -n "$ACTUAL_VERSION" ]; then
                 # Sign any dylibs within the framework version
-                find "$fw/Versions/$ACTUAL_VERSION" -name "*.dylib" -type f 2>/dev/null | while IFS= read -r lib; do
-                  if file "$lib" | grep -q "Mach-O"; then
-                    codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$lib" 2>&1 | grep -v "replacing existing signature" || true
-                  fi
-                done
+                while IFS= read -r -d '' lib; do
+                  file "$lib" | grep -q Mach-O || continue
+                  sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$lib"
+                done < <(find "$fw/Versions/$ACTUAL_VERSION" -name "*.dylib" -type f -print0)
 
                 # Sign the main framework binary if it exists
                 if [ -f "$fw/Versions/$ACTUAL_VERSION/$fw_name" ]; then
-                  codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$fw/Versions/$ACTUAL_VERSION/$fw_name" 2>&1 | grep -v "replacing existing signature" || true
+                  sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$fw/Versions/$ACTUAL_VERSION/$fw_name"
                 fi
               fi
             fi
 
             # Sign the framework itself as a bundle (this is critical for spctl validation)
-            codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$fw" 2>&1 | grep -v "replacing existing signature" || true
+            sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$fw"
           done
 
           # Diagnose framework structure before signing
@@ -957,14 +963,14 @@ jobs:
           # Step 4: Sign the main executable
           echo "=== Signing main executable ==="
           if [ -f "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME" ]; then
-            codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME" 2>&1 | grep -v "replacing existing signature" || true
+            sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$APP_BUNDLE/Contents/MacOS/$EXEC_NAME"
           fi
 
           # Step 5: Sign the app bundle itself (NOT with --deep, since we already signed components)
           # This is the proper way to sign bundles according to Apple's guidelines
           # CODESIGN_EXTRA adds --timestamp --options runtime for notarization when using Developer ID
           echo "=== Signing app bundle ==="
-          codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" --verbose=4 "$APP_BUNDLE" 2>&1 || true
+          sign_target --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" --verbose=4 "$APP_BUNDLE"
 
           # Remove quarantine attributes
           xattr -cr "$APP_BUNDLE" 2>/dev/null || true

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -884,7 +884,7 @@ jobs:
           BUNDLE_PY="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           if [ -d "$BUNDLE_PY" ]; then
             echo "=== Signing bundled runtime Python deps ==="
-            find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0 2>/dev/null | while IFS= read -r -d '' f; do
+            find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0 | while IFS= read -r -d '' f; do
               if file "$f" | grep -q Mach-O; then
                 if ! codesign_output=$(codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1); then
                   echo "$codesign_output"

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -802,6 +802,7 @@ jobs:
           echo "Apple code signing certificate installed."
 
       - name: Fix app bundle for macOS distribution
+        shell: bash
         env:
           SIGNING_IDENTITY: ${{ secrets.SIGNING_IDENTITY }}
           STEPS_MERGE_OUTPUTS_APP_BUNDLE: ${{ steps.merge.outputs.app_bundle }}
@@ -884,17 +885,16 @@ jobs:
           BUNDLE_PY="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
           if [ -d "$BUNDLE_PY" ]; then
             echo "=== Signing bundled runtime Python deps ==="
-            while IFS= read -r -d '' f; do
-              if file "$f" | grep -q Mach-O; then
-                if ! codesign_output=$(codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1); then
-                  echo "$codesign_output"
-                  exit 1
-                fi
-                if [ -n "$codesign_output" ]; then
-                  echo "$codesign_output" | grep -v "replacing existing signature" || true
-                fi
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              if ! codesign_output=$(codesign --force --sign "$SIGN_ID" "${CODESIGN_EXTRA[@]}" "$f" 2>&1); then
+                echo "$codesign_output"
+                exit 1
               fi
-            done < <(find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0)
+              if [ -n "$codesign_output" ]; then
+                echo "$codesign_output" | grep -v "replacing existing signature" || true
+              fi
+            done < <(find "$BUNDLE_PY" -type f \( -name "*.so" -o -name "*.dylib" \) -print0 | xargs -0 file | sed -n 's/: Mach-O.*//p')
           fi
 
           # Step 3: Sign Qt frameworks (each framework as a bundle)


### PR DESCRIPTION
## Summary

- Sign Mach-O `.so`/`.dylib` files under `Contents/Resources/pythonscad-bundled-py` during the macOS release build
- Fixes Apple notarization rejection for `psutil/_psutil_osx.abi3.so` (unsigned bundled IPython dependency)

Supersedes #774, which was rebased onto master after #771 landed the uv lockfile work.

## Test plan

- [x] PR CI checks pass
- [x] Manual macOS release build completes notarization successfully


Made with [Cursor](https://cursor.com)