### PR TITLE
ci: add cancel-in-progress concurrency to PR/push workflows

### DIFF
--- a/.github/workflows/beautify.yml
+++ b/.github/workflows/beautify.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Beautify:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pypi-wheels.yml
+++ b/.github/workflows/build-pypi-wheels.yml
@@ -31,7 +31,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: build-pypi-wheels-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-wasm:
     name: Build and test WebAssembly

--- a/.github/workflows/code-tidy.yml
+++ b/.github/workflows/code-tidy.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   RunClangTidy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     strategy:

--- a/.github/workflows/pip-build-and-test.yml
+++ b/.github/workflows/pip-build-and-test.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pip-build-and-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary

Adds `concurrency: cancel-in-progress: true` to all GitHub Actions
workflows that trigger on `pull_request` or `push` events, so pushing a
new commit to a branch automatically cancels the previous in-flight runs
for that branch/PR — no manual cancellation needed before each push.

### Concurrency group key

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

- **`github.workflow`** — isolates concurrency slots between different workflow files (e.g. linux-tests and macos-tests never cancel each other).
- **`github.event.pull_request.number`** — each open PR gets its own slot, so simultaneous work on PR #42 and PR #43 doesn't interfere.
- **`|| github.ref`** — fallback for pushes to `master` and `workflow_dispatch` triggers where no PR number exists.

### Workflows updated

| Workflow | Trigger |
|---|---|
| `beautify` | push + pull_request |
| `build-pypi-wheels` | push + pull_request + workflow_dispatch *(key normalised to consistent pattern)* |
| `build-wasm` | push + pull_request + release + workflow_dispatch |
| `code-tidy` | push + pull_request |
| `commitlint` | pull_request |
| `linux-tests` | push + pull_request + workflow_dispatch |
| `macos-tests` | push + pull_request + workflow_dispatch |
| `pip-build-and-test` | push + pull_request + workflow_dispatch |
| `pre-commit` | pull_request |
| `windows` | push + pull_request + workflow_dispatch |

### Workflows intentionally left unchanged

Release-only workflows (`build-appimage`, `build-debian-packages`,
`build-macos-release`, `build-rpm-packages`, `deploy-website`,
`notify-signing`, `publish-release`, `publish-to-pypi`,
`release-please`) and non-code-change workflows (`assign`, `stale_bot`)
are not touched — they never run on PR pushes so `cancel-in-progress`
would have no effect, and the publish/apt/yum repo workflows that
already carry `cancel-in-progress: false` deliberately serialise
releases.

## Test plan

- [ ] Open a PR, push a second commit before the first CI run finishes — verify the first run is cancelled automatically
- [ ] Verify two open PRs can run the same workflow in parallel without interfering
- [ ] Verify a push to `master` still triggers all workflows normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnV9AoBqZawr6wHSAo9hgg)_