### PR TITLE
fix(ci): resolve zizmor 1.26 high-severity workflow findings

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -72,6 +72,8 @@ jobs:
         sudo apt-get install -y wget file libfuse2
 
     - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        enable-cache: false
 
     - name: Build AppImage (x86_64)
       if: matrix.arch == 'x86_64'

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -90,7 +90,9 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     # Note: Don't use container field for ARM64 - it pulls amd64 images
     # ARM64 builds use explicit docker run with --platform flag
-    container: ${{ matrix.arch == 'amd64' && matrix.docker_image || null }}
+    # Images are digest-pinned in supported-distributions.json; zizmor
+    # cannot see through the matrix indirection.
+    container: ${{ matrix.arch == 'amd64' && matrix.docker_image || null }} # zizmor: ignore[unpinned-images]
 
     steps:
       - name: Ensure git and gh CLI are available (amd64 container)

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -57,6 +57,8 @@ jobs:
           ./scripts/get-dependencies.py --yes --profile pythonscad-qt6
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Build x86_64 Application
         env:
@@ -211,6 +213,8 @@ jobs:
           ./scripts/get-dependencies.py --yes --profile pythonscad-qt6
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Build arm64 Application
         env:
@@ -762,6 +766,8 @@ jobs:
           otool -L "$FRAMEWORKS_DIR/QtCore.framework/Versions/A/QtCore" | grep -E "icu|brotli" || echo "No ICU or brotli references found"
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Bundle runtime Python deps (IPython) into merged .app
         env:

--- a/.github/workflows/build-rpm-packages.yml
+++ b/.github/workflows/build-rpm-packages.yml
@@ -90,7 +90,9 @@ jobs:
 
     # Note: Don't use container field for ARM64 - it pulls amd64 images
     # ARM64 builds use explicit docker run with --platform flag
-    container: ${{ matrix.arch == 'amd64' && matrix.container || null }}
+    # Images are digest-pinned in supported-distributions.json; zizmor
+    # cannot see through the matrix indirection.
+    container: ${{ matrix.arch == 'amd64' && matrix.container || null }} # zizmor: ignore[unpinned-images]
 
     steps:
       - name: Install git, basic tools, and gh CLI (amd64 container)

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -85,6 +85,8 @@ jobs:
           python-version: '3.x'
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Install docs dependencies
         run: uv sync --frozen --only-group docs --no-install-project

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -52,6 +52,8 @@ jobs:
           python-version: "3.12"
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Install build tooling
         run: uv sync --frozen --only-group build --no-install-project
@@ -92,6 +94,8 @@ jobs:
           python-version: "3.12"
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Install build frontend
         run: uv sync --frozen --only-group build --no-install-project

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
             args: ["--severity=warning"]
             exclude: ^(submodules|tests/data)/
     - repo: https://github.com/zizmorcore/zizmor-pre-commit
-      rev: v1.24.1
+      rev: v1.26.1
       hooks:
           # Security audits for GitHub Actions workflows and composite
           # actions. Catches template/expression injection from


### PR DESCRIPTION
## Summary

- Disable `setup-uv` caching (`enable-cache: false`) in release/publish workflows flagged by zizmor's `cache-poisoning` audit (`build-appimage`, `build-macos-release`, `deploy-website`, `publish-to-pypi`).
- Add targeted `zizmor: ignore[unpinned-images]` on matrix-driven `container:` fields in Debian/RPM package workflows — images are already digest-pinned in `supported-distributions.json`, but zizmor cannot see through the matrix indirection.
- Bump the zizmor pre-commit hook to 1.26.1 so the Dependabot pre-commit bump (#769) can merge once this lands.

Unblocks #769 / #613.

## Test plan

- [x] `SKIP=trailing-whitespace,end-of-file-fixer,clang-format,markdownlint-cli2,shellcheck pre-commit run --all-files` passes locally with zizmor 1.26.1
- [ ] pre-commit CI job passes (diff + `--all-files` pass)
- [ ] actionlint / zizmor hooks green on workflow edits


Made with [Cursor](https://cursor.com)