### PR TITLE
fix(ci): install pip-licenses before bundle step on Windows and macOS

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -154,9 +154,10 @@ jobs:
           # `*.dist-info` metadata directories.
           APP_BUNDLE="${STEPS_APPNAME_OUTPUTS_APP_BUNDLE}"
           BUNDLE_DEST="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
+          python3 -m pip install --break-system-packages --quiet pip-licenses \
+            || python3 -m pip install --quiet pip-licenses
           chmod +x ./scripts/bundle-runtime-python.sh
-          BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
-            ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python3
+          ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python3
 
       - name: Create x86_64 app archive
         run: |
@@ -310,9 +311,10 @@ jobs:
           # `*.dist-info` metadata directories.
           APP_BUNDLE="${STEPS_APPNAME_OUTPUTS_APP_BUNDLE}"
           BUNDLE_DEST="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
+          python3 -m pip install --break-system-packages --quiet pip-licenses \
+            || python3 -m pip install --quiet pip-licenses
           chmod +x ./scripts/bundle-runtime-python.sh
-          BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
-            ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python3
+          ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python3
 
       - name: Create arm64 app archive
         run: |
@@ -779,9 +781,10 @@ jobs:
           # installed by the per-arch jobs gets overwritten by --upgrade.
           APP_BUNDLE="${STEPS_MERGE_OUTPUTS_APP_BUNDLE}"
           BUNDLE_DEST="${APP_BUNDLE}/Contents/Resources/pythonscad-bundled-py"
+          python3 -m pip install --break-system-packages --quiet pip-licenses \
+            || python3 -m pip install --quiet pip-licenses
           chmod +x ./scripts/bundle-runtime-python.sh
-          BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
-            ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python3
+          ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python3
 
       - name: Install Apple code signing certificate
         id: install_cert

--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Install MSYS2 psutil and uv for IPython 9 bundle
         run: |
           pacboy -S --noconfirm --needed python-psutil:p uv:p
+          python -m pip install --quiet pip-licenses
 
       - name: Bundle runtime Python deps (IPython) into build tree
         run: |
@@ -159,8 +160,7 @@ jobs:
           # so the bundle silently failed to ship in the artifact.
           BUNDLE_DEST="build/pythonscad-bundled-py"
           chmod +x ./scripts/bundle-runtime-python.sh
-          BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
-            ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python
+          ./scripts/bundle-runtime-python.sh "${BUNDLE_DEST}" --python python
 
       - name: Install to staging directory
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,9 +91,9 @@ jobs:
       - name: Smoke test runtime Python bundle (IPython 9 + MSYS2 psutil)
         run: |
           pacboy -S --noconfirm --needed python-psutil:p uv:p
+          python -m pip install --quiet pip-licenses
           chmod +x ./scripts/bundle-runtime-python.sh
-          BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
-            ./scripts/bundle-runtime-python.sh /tmp/pythonscad-bundled-py-test --python python
+          ./scripts/bundle-runtime-python.sh /tmp/pythonscad-bundled-py-test --python python
 
       - name: Upload Test Result Report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Install `pip-licenses` upfront in Windows and macOS CI workflows before calling `bundle-runtime-python.sh`
- Remove `BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1` from affected workflow steps
- Eliminates the `[bundle-py] pip-licenses missing; auto-installing` warning in Windows test runs

Closes #788

## Test plan
- [x] Windows (`windows.yml`) CI run completes without pip-licenses auto-install warning
- [ ] macOS release bundle steps verified on next release/workflow_dispatch run

Made with [Cursor](https://cursor.com)