### PR TITLE
refactor(modinst): make modinst a shared ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,7 +679,15 @@ if(ENABLE_PYTHON)
     src/python/py_analysis.cc
     src/python/py_ops.cc
     src/python/py_io.cc
-    src/python/pyconversion.cc)
+    src/python/pyconversion.cc
+    src/core/node_clone.cc
+    src/core/PullNode.cc
+    src/core/WrapNode.cc
+    src/core/SheetNode.cc
+    src/core/DebugNode.cc
+    src/core/RepairNode.cc
+    src/core/OversampleNode.cc
+)
   if(ENABLE_LIBFIVE)
     list(APPEND PYTHON_SOURCES
       src/python/FrepNode.cc)
@@ -1432,8 +1440,6 @@ set(CORE_SOURCES
   src/core/CgalAdvNode.cc
   src/core/Children.cc
   src/core/ColorNode.cc
-  src/core/PullNode.cc
-  src/core/WrapNode.cc
   src/core/ColorUtil.cc
   src/core/Context.cc
   src/core/ContextFrame.cc
@@ -1450,12 +1456,8 @@ set(CORE_SOURCES
   src/core/ImportNode.cc
   src/core/LinearExtrudeNode.cc
   src/core/PathExtrudeNode.cc
-  src/core/OversampleNode.cc
-  src/core/DebugNode.cc
-  src/core/RepairNode.cc
   src/core/FilletNode.cc
   src/core/LocalScope.cc
-  src/core/node_clone.cc
   src/core/ModuleInstantiation.cc
   src/core/NodeDumper.cc
   src/core/NodeVisitor.cc
@@ -1473,7 +1475,6 @@ set(CORE_SOURCES
   src/core/StatCache.cc
   src/utils/png_util.cc
   src/core/SurfaceNode.cc
-  src/core/SheetNode.cc
   src/core/TextNode.cc
   src/core/TransformNode.cc
   src/core/Tree.cc

--- a/src/core/CSGTreeEvaluator.cc
+++ b/src/core/CSGTreeEvaluator.cc
@@ -252,8 +252,8 @@ std::shared_ptr<const PolySet> polygon2dToPolySet(Polygon2d p2d)
 }
 
 std::shared_ptr<CSGNode> CSGTreeEvaluator::evaluateCSGNodeFromGeometry(
-  State& state, const std::shared_ptr<const Geometry>& geom, const ModuleInstantiation *modinst,
-  const AbstractNode& node)
+  State& state, const std::shared_ptr<const Geometry>& geom,
+  const std::shared_ptr<const ModuleInstantiation>& modinst, const AbstractNode& node)
 {
   assert(geom);
   bool is_2d = false;

--- a/src/core/CSGTreeEvaluator.h
+++ b/src/core/CSGTreeEvaluator.h
@@ -51,10 +51,9 @@ public:
 private:
   void addToParent(const State& state, const AbstractNode& node);
   void applyToChildren(State& state, const AbstractNode& node, OpenSCADOperator op);
-  std::shared_ptr<CSGNode> evaluateCSGNodeFromGeometry(State& state,
-                                                       const std::shared_ptr<const Geometry>& geom,
-                                                       const ModuleInstantiation *modinst,
-                                                       const AbstractNode& node);
+  std::shared_ptr<CSGNode> evaluateCSGNodeFromGeometry(
+    State& state, const std::shared_ptr<const Geometry>& geom,
+    const std::shared_ptr<const ModuleInstantiation>& modinst, const AbstractNode& node);
   void applyBackgroundAndHighlight(State& state, const AbstractNode& node);
 
   using ChildList = std::list<std::shared_ptr<const AbstractNode>>;

--- a/src/core/CgalAdvNode.cc
+++ b/src/core/CgalAdvNode.cc
@@ -39,8 +39,8 @@
 #include "core/module.h"
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
-static std::shared_ptr<AbstractNode> builtin_minkowski(const ModuleInstantiation *inst,
-                                                       Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_minkowski(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<CgalAdvNode>(inst, CgalAdvType::MINKOWSKI);
 
@@ -50,8 +50,8 @@ static std::shared_ptr<AbstractNode> builtin_minkowski(const ModuleInstantiation
   return children.instantiate(node);
 }
 
-static std::shared_ptr<AbstractNode> builtin_hull(const ModuleInstantiation *inst, Arguments arguments,
-                                                  const Children& children)
+static std::shared_ptr<AbstractNode> builtin_hull(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                  Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<CgalAdvNode>(inst, CgalAdvType::HULL);
 
@@ -61,8 +61,8 @@ static std::shared_ptr<AbstractNode> builtin_hull(const ModuleInstantiation *ins
   return children.instantiate(node);
 }
 
-static std::shared_ptr<AbstractNode> builtin_fill(const ModuleInstantiation *inst, Arguments arguments,
-                                                  const Children& children)
+static std::shared_ptr<AbstractNode> builtin_fill(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                  Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<CgalAdvNode>(inst, CgalAdvType::FILL);
 
@@ -71,8 +71,8 @@ static std::shared_ptr<AbstractNode> builtin_fill(const ModuleInstantiation *ins
   return children.instantiate(node);
 }
 
-static std::shared_ptr<AbstractNode> builtin_resize(const ModuleInstantiation *inst, Arguments arguments,
-                                                    const Children& children)
+static std::shared_ptr<AbstractNode> builtin_resize(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<CgalAdvNode>(inst, CgalAdvType::RESIZE);
 

--- a/src/core/CgalAdvNode.h
+++ b/src/core/CgalAdvNode.h
@@ -13,7 +13,7 @@ class CgalAdvNode : public AbstractNode
 public:
   VISITABLE();
   CgalAdvNode(std::shared_ptr<const ModuleInstantiation> mi, CgalAdvType type)
-    : AbstractNode(mi), type(type)
+    : AbstractNode(std::move(mi)), type(type)
   {
   }
   std::string toString() const override;

--- a/src/core/CgalAdvNode.h
+++ b/src/core/CgalAdvNode.h
@@ -12,7 +12,10 @@ class CgalAdvNode : public AbstractNode
 {
 public:
   VISITABLE();
-  CgalAdvNode(const ModuleInstantiation *mi, CgalAdvType type) : AbstractNode(mi), type(type) {}
+  CgalAdvNode(std::shared_ptr<const ModuleInstantiation> mi, CgalAdvType type)
+    : AbstractNode(mi), type(type)
+  {
+  }
   std::string toString() const override;
   std::string name() const override;
 

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -46,8 +46,8 @@
 
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
-static std::shared_ptr<AbstractNode> builtin_color(const ModuleInstantiation *inst, Arguments arguments,
-                                                   const Children& children)
+static std::shared_ptr<AbstractNode> builtin_color(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<ColorNode>(inst);
 

--- a/src/core/ColorNode.h
+++ b/src/core/ColorNode.h
@@ -11,7 +11,7 @@ class ColorNode : public AbstractNode
 {
 public:
   VISITABLE();
-  ColorNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(mi) {}
+  ColorNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override;
 

--- a/src/core/ColorNode.h
+++ b/src/core/ColorNode.h
@@ -11,7 +11,7 @@ class ColorNode : public AbstractNode
 {
 public:
   VISITABLE();
-  ColorNode(const ModuleInstantiation *mi) : AbstractNode(mi) {}
+  ColorNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(mi) {}
   std::string toString() const override;
   std::string name() const override;
 

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -39,22 +39,22 @@
 #include "core/enums.h"
 #include "core/module.h"
 
-static std::shared_ptr<AbstractNode> builtin_union(const ModuleInstantiation *inst, Arguments arguments,
-                                                   const Children& children)
+static std::shared_ptr<AbstractNode> builtin_union(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
   return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::UNION));
 }
 
-static std::shared_ptr<AbstractNode> builtin_difference(const ModuleInstantiation *inst,
-                                                        Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_difference(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
   return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::DIFFERENCE));
 }
 
-static std::shared_ptr<AbstractNode> builtin_intersection(const ModuleInstantiation *inst,
-                                                          Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_intersection(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
   return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::INTERSECTION));

--- a/src/core/CsgOpNode.h
+++ b/src/core/CsgOpNode.h
@@ -14,7 +14,7 @@ public:
   double r = 0.0;  // Radius for fillets
   int fn = 2;
   CsgOpNode(std::shared_ptr<const ModuleInstantiation> mi, OpenSCADOperator type)
-    : AbstractNode(mi), type(type)
+    : AbstractNode(std::move(mi)), type(type)
   {
   }
   std::string toString() const override;

--- a/src/core/CsgOpNode.h
+++ b/src/core/CsgOpNode.h
@@ -13,7 +13,10 @@ public:
   OpenSCADOperator type;
   double r = 0.0;  // Radius for fillets
   int fn = 2;
-  CsgOpNode(const ModuleInstantiation *mi, OpenSCADOperator type) : AbstractNode(mi), type(type) {}
+  CsgOpNode(std::shared_ptr<const ModuleInstantiation> mi, OpenSCADOperator type)
+    : AbstractNode(mi), type(type)
+  {
+  }
   std::string toString() const override;
   std::string name() const override;
   virtual std::shared_ptr<const Geometry> dragPoint(const Vector3d& pt, const Vector3d& delta,

--- a/src/core/DebugNode.h
+++ b/src/core/DebugNode.h
@@ -7,7 +7,7 @@ class DebugNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  DebugNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  DebugNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "debug"; }
   std::vector<int> faces;

--- a/src/core/DebugNode.h
+++ b/src/core/DebugNode.h
@@ -7,7 +7,7 @@ class DebugNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  DebugNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
+  DebugNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "debug"; }
   std::vector<int> faces;

--- a/src/core/FilletNode.h
+++ b/src/core/FilletNode.h
@@ -8,7 +8,7 @@
 class FilletNode : public LeafNode
 {
 public:
-  FilletNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
+  FilletNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override
   {
     std::ostringstream stream;

--- a/src/core/FilletNode.h
+++ b/src/core/FilletNode.h
@@ -8,7 +8,7 @@
 class FilletNode : public LeafNode
 {
 public:
-  FilletNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  FilletNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
   std::string toString() const override
   {
     std::ostringstream stream;

--- a/src/core/GroupModule.cc
+++ b/src/core/GroupModule.cc
@@ -34,8 +34,8 @@
 #include "core/module.h"
 #include "core/node.h"
 
-std::shared_ptr<AbstractNode> builtin_group(const ModuleInstantiation *inst, Arguments arguments,
-                                            const Children& children)
+std::shared_ptr<AbstractNode> builtin_group(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                            Arguments arguments, const Children& children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
   return children.instantiate(std::make_shared<GroupNode>(inst));

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -62,8 +62,8 @@ namespace fs = std::filesystem;
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
-static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, Arguments arguments,
-                                               ImportType type)
+static std::shared_ptr<AbstractNode> do_import(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                               Arguments arguments, ImportType type)
 {
   Parameters parameters = Parameters::parse(
     std::move(arguments), inst->location(), {"file", "layer", "convexity", "origin", "scale"},
@@ -163,7 +163,8 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
   return node;
 }
 
-static std::shared_ptr<AbstractNode> builtin_import(const ModuleInstantiation *inst, Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_import(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   return do_import(inst, std::move(arguments), ImportType::UNKNOWN);
 }

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -29,8 +29,9 @@ public:
   constexpr static double SVG_DEFAULT_DPI = 72.0;
 
   VISITABLE();
-  ImportNode(const ModuleInstantiation *mi, ImportType type, CurveDiscretizer discretizer)
-    : LeafNode(mi), type(type), discretizer(discretizer)
+  ImportNode(std::shared_ptr<const ModuleInstantiation> mi, ImportType type,
+             CurveDiscretizer discretizer)
+    : LeafNode(std::move(mi)), type(type), discretizer(discretizer)
   {
   }
   std::string toString() const override;

--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -42,8 +42,8 @@
 #include "utils/printutils.h"
 
 namespace {
-std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstantiation *inst,
-                                                     Arguments arguments, const Children& children)
+std::shared_ptr<AbstractNode> builtin_linear_extrude(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   Parameters parameters = Parameters::parse(
     std::move(arguments), inst->location(),

--- a/src/core/LinearExtrudeNode.h
+++ b/src/core/LinearExtrudeNode.h
@@ -16,8 +16,8 @@ class LinearExtrudeNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  LinearExtrudeNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : AbstractPolyNode(mi), discretizer(std::move(discretizer))
+  LinearExtrudeNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : AbstractPolyNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -129,7 +129,8 @@ std::shared_ptr<AbstractNode> ModuleInstantiation::evaluate(
     std::shared_ptr<AbstractNode> result = nullptr;
     std::string error;
 #ifdef ENABLE_PYTHON
-    result = python_modulefunc(this, context, error);
+    result = python_modulefunc(std::const_pointer_cast<const ModuleInstantiation>(shared_from_this()),
+                               context, error);
     if (!error.empty() && result == nullptr) {
       LOG(message_group::Warning, loc, context->documentRoot(), "Python: '%1$s'", error);
       return nullptr;
@@ -142,7 +143,7 @@ std::shared_ptr<AbstractNode> ModuleInstantiation::evaluate(
   }
 
   try {
-    auto node = module->module->instantiate(module->defining_context, this, context);
+    auto node = module->module->instantiate(module->defining_context, shared_from_this(), context);
     return node;
   } catch (EvaluationException& e) {
     print_trace(e, this, context);

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -129,8 +129,7 @@ std::shared_ptr<AbstractNode> ModuleInstantiation::evaluate(
     std::shared_ptr<AbstractNode> result = nullptr;
     std::string error;
 #ifdef ENABLE_PYTHON
-    result = python_modulefunc(std::const_pointer_cast<const ModuleInstantiation>(shared_from_this()),
-                               context, error);
+    result = python_modulefunc(shared_from_this(), context, error);
     if (!error.empty() && result == nullptr) {
       LOG(message_group::Warning, loc, context->documentRoot(), "Python: '%1$s'", error);
       return nullptr;

--- a/src/core/ModuleInstantiation.h
+++ b/src/core/ModuleInstantiation.h
@@ -12,7 +12,7 @@
 
 using ModuleInstantiationList = std::vector<class ModuleInstantiation *>;
 
-class ModuleInstantiation : public ASTNode
+class ModuleInstantiation : public ASTNode, public std::enable_shared_from_this<ModuleInstantiation>
 {
 public:
   ModuleInstantiation(std::string name, AssignmentList args = AssignmentList(),

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -43,8 +43,8 @@
 #include "utils/printutils.h"
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
-static std::shared_ptr<AbstractNode> builtin_offset(const ModuleInstantiation *inst, Arguments arguments,
-                                                    const Children& children)
+static std::shared_ptr<AbstractNode> builtin_offset(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"delta", "chamfer"});

--- a/src/core/OffsetNode.h
+++ b/src/core/OffsetNode.h
@@ -13,8 +13,8 @@ class OffsetNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  OffsetNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : AbstractPolyNode(mi), discretizer(std::move(discretizer))
+  OffsetNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : AbstractPolyNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
 

--- a/src/core/OversampleNode.h
+++ b/src/core/OversampleNode.h
@@ -128,7 +128,7 @@ public:
 class OversampleNode : public LeafNode
 {
 public:
-  OversampleNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
+  OversampleNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override
   {
     std::ostringstream stream;

--- a/src/core/OversampleNode.h
+++ b/src/core/OversampleNode.h
@@ -128,7 +128,7 @@ public:
 class OversampleNode : public LeafNode
 {
 public:
-  OversampleNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  OversampleNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
   std::string toString() const override
   {
     std::ostringstream stream;

--- a/src/core/PathExtrudeNode.cc
+++ b/src/core/PathExtrudeNode.cc
@@ -65,8 +65,8 @@ Parameters parse_parameters_path(Arguments arguments, const Location& location)
     {"origin", "scale", "closed", "allow_intersect", "twist", "slices", "segments"}, {"convexity"});
 }
 
-static std::shared_ptr<AbstractNode> builtin_path_extrude(const ModuleInstantiation *inst,
-                                                          Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_path_extrude(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<PathExtrudeNode>(inst);
 

--- a/src/core/PathExtrudeNode.h
+++ b/src/core/PathExtrudeNode.h
@@ -11,7 +11,7 @@ class PathExtrudeNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  PathExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  PathExtrudeNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "linear_extrude"; }
 

--- a/src/core/PathExtrudeNode.h
+++ b/src/core/PathExtrudeNode.h
@@ -11,7 +11,7 @@ class PathExtrudeNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  PathExtrudeNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
+  PathExtrudeNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "linear_extrude"; }
 

--- a/src/core/ProjectionNode.cc
+++ b/src/core/ProjectionNode.cc
@@ -38,8 +38,8 @@
 #include "core/module.h"
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
-static std::shared_ptr<AbstractNode> builtin_projection(const ModuleInstantiation *inst,
-                                                        Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_projection(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<ProjectionNode>(inst);
 

--- a/src/core/ProjectionNode.h
+++ b/src/core/ProjectionNode.h
@@ -9,7 +9,7 @@ class ProjectionNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  ProjectionNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
+  ProjectionNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "projection"; }
 

--- a/src/core/ProjectionNode.h
+++ b/src/core/ProjectionNode.h
@@ -9,7 +9,7 @@ class ProjectionNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  ProjectionNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  ProjectionNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "projection"; }
 

--- a/src/core/PullNode.h
+++ b/src/core/PullNode.h
@@ -8,7 +8,7 @@ class PullNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  PullNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  PullNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "pull"; }
   Vector3d anchor;

--- a/src/core/PullNode.h
+++ b/src/core/PullNode.h
@@ -8,7 +8,7 @@ class PullNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  PullNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
+  PullNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "pull"; }
   Vector3d anchor;

--- a/src/core/RenderNode.cc
+++ b/src/core/RenderNode.cc
@@ -37,8 +37,8 @@
 #include "core/module.h"
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
-static std::shared_ptr<AbstractNode> builtin_render(const ModuleInstantiation *inst, Arguments arguments,
-                                                    const Children& children)
+static std::shared_ptr<AbstractNode> builtin_render(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<RenderNode>(inst);
 

--- a/src/core/RenderNode.h
+++ b/src/core/RenderNode.h
@@ -9,7 +9,7 @@ class RenderNode : public AbstractNode
 {
 public:
   VISITABLE();
-  RenderNode(const ModuleInstantiation *mi) : AbstractNode(mi) {}
+  RenderNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "render"; }
 

--- a/src/core/RenderNode.h
+++ b/src/core/RenderNode.h
@@ -9,7 +9,7 @@ class RenderNode : public AbstractNode
 {
 public:
   VISITABLE();
-  RenderNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(mi) {}
+  RenderNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "render"; }
 

--- a/src/core/RepairNode.h
+++ b/src/core/RepairNode.h
@@ -7,7 +7,7 @@ class RepairNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  RepairNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  RepairNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "repair"; }
   Color4f color;

--- a/src/core/RepairNode.h
+++ b/src/core/RepairNode.h
@@ -7,7 +7,7 @@ class RepairNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  RepairNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
+  RepairNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "repair"; }
   Color4f color;

--- a/src/core/RoofNode.cc
+++ b/src/core/RoofNode.cc
@@ -16,8 +16,8 @@
 #include "core/module.h"
 #include "utils/printutils.h"
 
-static std::shared_ptr<AbstractNode> builtin_roof(const ModuleInstantiation *inst, Arguments arguments,
-                                                  const Children& children)
+static std::shared_ptr<AbstractNode> builtin_roof(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                  Arguments arguments, const Children& children)
 {
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"method"}, {"convexity"});

--- a/src/core/RoofNode.h
+++ b/src/core/RoofNode.h
@@ -16,8 +16,8 @@ class RoofNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  RoofNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : AbstractPolyNode(mi), discretizer(std::move(discretizer))
+  RoofNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : AbstractPolyNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -44,8 +44,8 @@
 
 namespace {
 
-std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *inst,
-                                                     Arguments arguments, const Children& children)
+std::shared_ptr<AbstractNode> builtin_rotate_extrude(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments, const Children& children)
 {
   const Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"angle", "start", "origin", "scale"},

--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -19,8 +19,8 @@ class RotateExtrudeNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  RotateExtrudeNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : AbstractPolyNode(mi), discretizer(std::move(discretizer))
+  RotateExtrudeNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : AbstractPolyNode(std::move(mi)), discretizer(std::move(discretizer))
   {
     convexity = 0;
     origin_x = origin_y = scale = offset_x = offset_y = 0;

--- a/src/core/SkinNode.cc
+++ b/src/core/SkinNode.cc
@@ -41,8 +41,8 @@
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
 namespace {
-std::shared_ptr<AbstractNode> builtin_skin(const ModuleInstantiation *inst, Arguments arguments,
-                                           const Children& children)
+std::shared_ptr<AbstractNode> builtin_skin(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                           Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<SkinNode>(inst);
 

--- a/src/core/SkinNode.h
+++ b/src/core/SkinNode.h
@@ -7,7 +7,7 @@ class SkinNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  SkinNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) { convexity = 0; }
+  SkinNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) { convexity = 0; }
   std::string toString() const override;
   std::string name() const override { return "skin"; }
 

--- a/src/core/SkinNode.h
+++ b/src/core/SkinNode.h
@@ -7,7 +7,10 @@ class SkinNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  SkinNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) { convexity = 0; }
+  SkinNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi))
+  {
+    convexity = 0;
+  }
   std::string toString() const override;
   std::string name() const override { return "skin"; }
 

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -61,8 +61,8 @@ using namespace boost::assign;  // bring 'operator+=()' into scope
 #include <filesystem>
 namespace fs = std::filesystem;
 
-static std::shared_ptr<AbstractNode> builtin_surface(const ModuleInstantiation *inst,
-                                                     Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_surface(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   auto node = std::make_shared<SurfaceNode>(inst);
 

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -39,7 +39,7 @@ class SurfaceNode : public LeafNode
 {
 public:
   VISITABLE();
-  SurfaceNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
+  SurfaceNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "surface"; }
 

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -39,7 +39,7 @@ class SurfaceNode : public LeafNode
 {
 public:
   VISITABLE();
-  SurfaceNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  SurfaceNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "surface"; }
 

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -39,7 +39,8 @@
 #include "core/module.h"
 #include "utils/printutils.h"
 
-static std::shared_ptr<AbstractNode> builtin_text(const ModuleInstantiation *inst, Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_text(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                  Arguments arguments)
 {
   auto *session = arguments.session();
   Parameters parameters =

--- a/src/core/TextNode.h
+++ b/src/core/TextNode.h
@@ -16,8 +16,8 @@ class TextNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  TextNode(const ModuleInstantiation *mi, FreetypeRenderer::Params&& p)
-    : AbstractPolyNode(mi), params(std::move(p))
+  TextNode(std::shared_ptr<const ModuleInstantiation> mi, FreetypeRenderer::Params&& p)
+    : AbstractPolyNode(std::move(mi)), params(std::move(p))
   {
   }
 

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -49,8 +49,8 @@ using namespace boost::assign;  // bring 'operator+=()' into scope
 
 enum class transform_type_e { SCALE, ROTATE, MIRROR, TRANSLATE, MULTMATRIX };
 
-std::shared_ptr<AbstractNode> builtin_scale(const ModuleInstantiation *inst, Arguments arguments,
-                                            const Children& children)
+std::shared_ptr<AbstractNode> builtin_scale(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                            Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<TransformNode>(inst, "scale");
 
@@ -79,8 +79,8 @@ std::shared_ptr<AbstractNode> builtin_scale(const ModuleInstantiation *inst, Arg
   return children.instantiate(node);
 }
 
-std::shared_ptr<AbstractNode> builtin_rotate(const ModuleInstantiation *inst, Arguments arguments,
-                                             const Children& children)
+std::shared_ptr<AbstractNode> builtin_rotate(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                             Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<TransformNode>(inst, "rotate");
 
@@ -164,8 +164,8 @@ std::shared_ptr<AbstractNode> builtin_rotate(const ModuleInstantiation *inst, Ar
   return children.instantiate(node);
 }
 
-std::shared_ptr<AbstractNode> builtin_mirror(const ModuleInstantiation *inst, Arguments arguments,
-                                             const Children& children)
+std::shared_ptr<AbstractNode> builtin_mirror(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                             Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<TransformNode>(inst, "mirror");
 
@@ -196,8 +196,8 @@ std::shared_ptr<AbstractNode> builtin_mirror(const ModuleInstantiation *inst, Ar
   return children.instantiate(node);
 }
 
-std::shared_ptr<AbstractNode> builtin_translate(const ModuleInstantiation *inst, Arguments arguments,
-                                                const Children& children)
+std::shared_ptr<AbstractNode> builtin_translate(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<TransformNode>(inst, "translate");
 
@@ -218,8 +218,8 @@ std::shared_ptr<AbstractNode> builtin_translate(const ModuleInstantiation *inst,
   return children.instantiate(node);
 }
 
-std::shared_ptr<AbstractNode> builtin_multmatrix(const ModuleInstantiation *inst, Arguments arguments,
-                                                 const Children& children)
+std::shared_ptr<AbstractNode> builtin_multmatrix(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                 Arguments arguments, const Children& children)
 {
   auto node = std::make_shared<TransformNode>(inst, "multmatrix");
 
@@ -261,8 +261,8 @@ std::string TransformNode::toString() const
   return stream.str();
 }
 
-TransformNode::TransformNode(const ModuleInstantiation *mi, std::string verbose_name)
-  : AbstractNode(mi), matrix(Transform3d::Identity()), _name(std::move(verbose_name))
+TransformNode::TransformNode(std::shared_ptr<const ModuleInstantiation> mi, std::string verbose_name)
+  : AbstractNode(std::move(mi)), matrix(Transform3d::Identity()), _name(std::move(verbose_name))
 {
 }
 

--- a/src/core/TransformNode.h
+++ b/src/core/TransformNode.h
@@ -12,7 +12,7 @@ class TransformNode : public AbstractNode
 public:
   VISITABLE();
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  TransformNode(const ModuleInstantiation *mi, std::string verbose_name);
+  TransformNode(std::shared_ptr<const ModuleInstantiation> mi, std::string verbose_name);
   std::string toString() const override;
   std::string name() const override;
   std::string verbose_name() const override;

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -88,7 +88,8 @@ static void NOINLINE print_trace(EvaluationException& e, const UserModule *mod,
 }
 
 std::shared_ptr<AbstractNode> UserModule::instantiate(
-  const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst,
+  const std::shared_ptr<const Context>& defining_context,
+  const std::shared_ptr<const ModuleInstantiation>& inst,
   const std::shared_ptr<const Context>& context) const
 {
   if (StackCheck::inst().check()) {

--- a/src/core/UserModule.h
+++ b/src/core/UserModule.h
@@ -38,7 +38,8 @@ public:
   }
 
   std::shared_ptr<AbstractNode> instantiate(
-    const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst,
+    const std::shared_ptr<const Context>& defining_context,
+    const std::shared_ptr<const ModuleInstantiation>& inst,
     const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
   void print_python(std::ostream& stream, std::ostream& stream_def,

--- a/src/core/WrapNode.h
+++ b/src/core/WrapNode.h
@@ -9,7 +9,7 @@ class WrapNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  WrapNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  WrapNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "wrap"; }
   double r;

--- a/src/core/WrapNode.h
+++ b/src/core/WrapNode.h
@@ -9,7 +9,7 @@ class WrapNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  WrapNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(mi) {}
+  WrapNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "wrap"; }
   double r;

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -43,7 +43,8 @@
 #include "core/node.h"
 #include "utils/printutils.h"
 
-static std::shared_ptr<AbstractNode> lazyUnionNode(const ModuleInstantiation *inst)
+static std::shared_ptr<AbstractNode> lazyUnionNode(
+  const std::shared_ptr<const ModuleInstantiation>& inst)
 {
   if (Feature::ExperimentalLazyUnion.is_enabled()) {
     return std::make_shared<ListNode>(inst);
@@ -53,7 +54,7 @@ static std::shared_ptr<AbstractNode> lazyUnionNode(const ModuleInstantiation *in
 }
 
 static boost::optional<size_t> validChildIndex(int n, const Children *children,
-                                               const ModuleInstantiation *inst,
+                                               const std::shared_ptr<const ModuleInstantiation>& inst,
                                                const std::shared_ptr<const Context>& context)
 {
   if (n < 0 || n >= static_cast<int>(children->size())) {
@@ -65,7 +66,7 @@ static boost::optional<size_t> validChildIndex(int n, const Children *children,
 }
 
 static boost::optional<size_t> validChildIndex(const Value& value, const Children *children,
-                                               const ModuleInstantiation *inst,
+                                               const std::shared_ptr<const ModuleInstantiation>& inst,
                                                const std::shared_ptr<const Context>& context)
 {
   if (value.type() != Value::Type::NUMBER) {
@@ -77,8 +78,8 @@ static boost::optional<size_t> validChildIndex(const Value& value, const Childre
   return validChildIndex(static_cast<int>(value.toDouble()), children, inst, context);
 }
 
-static std::shared_ptr<AbstractNode> builtin_children(const ModuleInstantiation *inst,
-                                                      const std::shared_ptr<const Context>& context)
+static std::shared_ptr<AbstractNode> builtin_children(
+  const std::shared_ptr<const ModuleInstantiation>& inst, const std::shared_ptr<const Context>& context)
 {
   Arguments arguments{inst->arguments, context};
 
@@ -138,8 +139,8 @@ static std::shared_ptr<AbstractNode> builtin_children(const ModuleInstantiation 
   }
 }
 
-static std::shared_ptr<AbstractNode> builtin_echo(const ModuleInstantiation *inst, Arguments arguments,
-                                                  const Children& children)
+static std::shared_ptr<AbstractNode> builtin_echo(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                  Arguments arguments, const Children& children)
 {
   LOG(message_group::Echo, "%1$s", STR(arguments));
 
@@ -151,8 +152,8 @@ static std::shared_ptr<AbstractNode> builtin_echo(const ModuleInstantiation *ins
   return node;
 }
 
-static std::shared_ptr<AbstractNode> builtin_assert(const ModuleInstantiation *inst,
-                                                    const std::shared_ptr<const Context>& context)
+static std::shared_ptr<AbstractNode> builtin_assert(
+  const std::shared_ptr<const ModuleInstantiation>& inst, const std::shared_ptr<const Context>& context)
 {
   Assert::performAssert(inst->arguments, inst->location(), context);
 
@@ -164,7 +165,7 @@ static std::shared_ptr<AbstractNode> builtin_assert(const ModuleInstantiation *i
   return node;
 }
 
-static std::shared_ptr<AbstractNode> builtin_let(const ModuleInstantiation *inst,
+static std::shared_ptr<AbstractNode> builtin_let(const std::shared_ptr<const ModuleInstantiation>& inst,
                                                  const std::shared_ptr<const Context>& context)
 {
   return Children(inst->scope,
@@ -172,7 +173,7 @@ static std::shared_ptr<AbstractNode> builtin_let(const ModuleInstantiation *inst
     .instantiate(lazyUnionNode(inst));
 }
 
-static std::shared_ptr<AbstractNode> builtin_for(const ModuleInstantiation *inst,
+static std::shared_ptr<AbstractNode> builtin_for(const std::shared_ptr<const ModuleInstantiation>& inst,
                                                  const std::shared_ptr<const Context>& context)
 {
   auto node = lazyUnionNode(inst);
@@ -194,7 +195,7 @@ static std::shared_ptr<AbstractNode> builtin_for(const ModuleInstantiation *inst
 }
 
 static std::shared_ptr<AbstractNode> builtin_intersection_for(
-  const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context)
+  const std::shared_ptr<const ModuleInstantiation>& inst, const std::shared_ptr<const Context>& context)
 {
   auto node = std::make_shared<AbstractIntersectionNode>(inst);
   if (!inst->arguments.empty()) {
@@ -206,11 +207,11 @@ static std::shared_ptr<AbstractNode> builtin_intersection_for(
   return node;
 }
 
-static std::shared_ptr<AbstractNode> builtin_if(const ModuleInstantiation *inst,
+static std::shared_ptr<AbstractNode> builtin_if(const std::shared_ptr<const ModuleInstantiation>& inst,
                                                 const std::shared_ptr<const Context>& context)
 {
   Arguments arguments{inst->arguments, context};
-  const auto *ifelse = dynamic_cast<const IfElseModuleInstantiation *>(inst);
+  const auto *ifelse = dynamic_cast<const IfElseModuleInstantiation *>(inst.get());
   if (arguments.size() > 0 && arguments[0]->toBool()) {
     return Children(inst->scope, context).instantiate(lazyUnionNode(inst));
   } else if (ifelse->getElseScope()) {

--- a/src/core/module.cc
+++ b/src/core/module.cc
@@ -36,30 +36,32 @@
 #include "core/ModuleInstantiation.h"
 #include "utils/printutils.h"
 
-BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(
-                               const ModuleInstantiation *, const std::shared_ptr<const Context>&),
-                             const Feature *feature)
+BuiltinModule::BuiltinModule(
+  std::shared_ptr<AbstractNode> (*instantiate)(const std::shared_ptr<const ModuleInstantiation>&,
+                                               const std::shared_ptr<const Context>&),
+  const Feature *feature)
   : AbstractModule(feature), do_instantiate(instantiate)
 {
 }
 
-BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(const ModuleInstantiation *,
-                                                                          Arguments, const Children&),
-                             const Feature *feature)
+BuiltinModule::BuiltinModule(
+  std::shared_ptr<AbstractNode> (*instantiate)(const std::shared_ptr<const ModuleInstantiation>&,
+                                               Arguments, const Children&),
+  const Feature *feature)
   : AbstractModule(feature)
 {
-  do_instantiate = [instantiate](const ModuleInstantiation *inst,
+  do_instantiate = [instantiate](const std::shared_ptr<const ModuleInstantiation>& inst,
                                  const std::shared_ptr<const Context>& context) {
     return instantiate(inst, Arguments(inst->arguments, context), Children(inst->scope, context));
   };
 }
 
-BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(const ModuleInstantiation *,
-                                                                          Arguments),
+BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(
+                               const std::shared_ptr<const ModuleInstantiation>&, Arguments),
                              const Feature *feature)
   : AbstractModule(feature)
 {
-  do_instantiate = [instantiate](const ModuleInstantiation *inst,
+  do_instantiate = [instantiate](const std::shared_ptr<const ModuleInstantiation>& inst,
                                  const std::shared_ptr<const Context>& context) {
     Arguments arguments(inst->arguments, context);
     noChildren(inst, arguments);
@@ -68,13 +70,15 @@ BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(const 
 }
 
 std::shared_ptr<AbstractNode> BuiltinModule::instantiate(
-  const std::shared_ptr<const Context>& /*defining_context*/, const ModuleInstantiation *inst,
+  const std::shared_ptr<const Context>& /*defining_context*/,
+  const std::shared_ptr<const ModuleInstantiation>& inst,
   const std::shared_ptr<const Context>& context) const
 {
   return do_instantiate(inst, context);
 }
 
-void BuiltinModule::noChildren(const ModuleInstantiation *inst, Arguments& arguments, std::string auxmsg)
+void BuiltinModule::noChildren(const std::shared_ptr<const ModuleInstantiation>& inst,
+                               Arguments& arguments, std::string auxmsg)
 {
   if (inst->scope->hasChildren()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -25,28 +25,33 @@ public:
   [[nodiscard]] virtual bool is_experimental() const { return feature != nullptr; }
   [[nodiscard]] virtual bool is_enabled() const { return (feature == nullptr) || feature->is_enabled(); }
   virtual std::shared_ptr<AbstractNode> instantiate(
-    const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst,
+    const std::shared_ptr<const Context>& defining_context,
+    const std::shared_ptr<const ModuleInstantiation>& inst,
     const std::shared_ptr<const Context>& context) const = 0;
 };
 
 class BuiltinModule : public AbstractModule
 {
 public:
-  BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(const ModuleInstantiation *,
-                                                             const std::shared_ptr<const Context>&),
+  BuiltinModule(
+    std::shared_ptr<AbstractNode> (*instantiate)(const std::shared_ptr<const ModuleInstantiation>&,
+                                                 const std::shared_ptr<const Context>&),
+    const Feature *feature = nullptr);
+  BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(
+                  const std::shared_ptr<const ModuleInstantiation>&, Arguments, const Children&),
                 const Feature *feature = nullptr);
-  BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(const ModuleInstantiation *, Arguments,
-                                                             const Children&),
-                const Feature *feature = nullptr);
-  BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(const ModuleInstantiation *, Arguments),
+  BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(
+                  const std::shared_ptr<const ModuleInstantiation>&, Arguments),
                 const Feature *feature = nullptr);
   std::shared_ptr<AbstractNode> instantiate(
-    const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst,
+    const std::shared_ptr<const Context>& defining_context,
+    const std::shared_ptr<const ModuleInstantiation>& inst,
     const std::shared_ptr<const Context>& context) const override;
-  static void noChildren(const ModuleInstantiation *, Arguments&, std::string auxmsg = {});
+  static void noChildren(const std::shared_ptr<const ModuleInstantiation>&, Arguments&,
+                         std::string auxmsg = {});
 
 private:
-  std::function<std::shared_ptr<AbstractNode>(const ModuleInstantiation *,
+  std::function<std::shared_ptr<AbstractNode>(const std::shared_ptr<const ModuleInstantiation>&,
                                               const std::shared_ptr<const Context>&)>
     do_instantiate;
 };

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -41,7 +41,8 @@
 
 size_t AbstractNode::idx_counter;
 
-AbstractNode::AbstractNode(const ModuleInstantiation *mi) : modinst(mi), idx(idx_counter++)
+AbstractNode::AbstractNode(std::shared_ptr<const ModuleInstantiation> mi)
+  : modinst(std::move(mi)), idx(idx_counter++)
 {
 }
 
@@ -117,7 +118,7 @@ void AbstractNode::getCodeLocation(int currentLevel, int includeLevel, int *firs
 void AbstractNode::findNodesWithSameMod(const std::shared_ptr<const AbstractNode>& node_mod,
                                         std::vector<std::shared_ptr<const AbstractNode>>& nodes) const
 {
-  if (node_mod->modinst == modinst) {
+  if (node_mod->modinst.get() == modinst.get()) {
     nodes.push_back(shared_from_this());
   }
   for (const auto& step : children) {
@@ -194,7 +195,7 @@ std::shared_ptr<AbstractNode> find_root_tag(const std::shared_ptr<AbstractNode>&
             rootTag = child;
             // shortcut if we're not interested in further root modifiers
             if (!nextLocation) return;
-          } else if (nextLocation && rootTag->modinst != child->modinst) {
+          } else if (nextLocation && rootTag->modinst.get() != child->modinst.get()) {
             // Throw if we have more than one root modifier in the source
             *nextLocation = &child->modinst->location();
             return;

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -17,7 +17,6 @@
 extern int progress_report_count;
 extern void (*progress_report_f)(const std::shared_ptr<const AbstractNode>&, void *, int);
 extern void *progress_report_vp;
-extern std::vector<std::shared_ptr<ModuleInstantiation>> modinsts_list;
 
 void progress_report_prep(const std::shared_ptr<AbstractNode>& root,
                           void (*f)(const std::shared_ptr<const AbstractNode>& node, void *vp, int mark),

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -17,7 +17,7 @@
 extern int progress_report_count;
 extern void (*progress_report_f)(const std::shared_ptr<const AbstractNode>&, void *, int);
 extern void *progress_report_vp;
-extern std::vector<ModuleInstantiation *> modinsts_list;
+extern std::vector<std::shared_ptr<ModuleInstantiation>> modinsts_list;
 
 void progress_report_prep(const std::shared_ptr<AbstractNode>& root,
                           void (*f)(const std::shared_ptr<const AbstractNode>& node, void *vp, int mark),
@@ -55,7 +55,7 @@ class AbstractNode : public BaseVisitable, public std::enable_shared_from_this<A
   static size_t idx_counter;  // Node instantiation index
 public:
   VISITABLE();
-  AbstractNode(const ModuleInstantiation *mi);
+  AbstractNode(std::shared_ptr<const ModuleInstantiation> mi);
   virtual std::string toString() const;
   /*! The 'OpenSCAD name' of this node, defaults to classname, but can be
       overloaded to provide specialization for e.g. CSG nodes, primitive nodes etc.
@@ -73,7 +73,7 @@ public:
 
   // FIXME: Make protected
   std::vector<std::shared_ptr<AbstractNode>> children;
-  const ModuleInstantiation *modinst;
+  std::shared_ptr<const ModuleInstantiation> modinst;
 
   // progress_mark is a running number used for progress indication
   // FIXME: Make all progress handling external, put it in the traverser class?
@@ -112,7 +112,9 @@ class AbstractIntersectionNode : public AbstractNode
 {
 public:
   VISITABLE();
-  AbstractIntersectionNode(const ModuleInstantiation *mi) : AbstractNode(mi) {}
+  AbstractIntersectionNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(std::move(mi))
+  {
+  }
   std::string toString() const override;
   std::string name() const override;
 };
@@ -121,7 +123,7 @@ class AbstractPolyNode : public AbstractNode
 {
 public:
   VISITABLE();
-  AbstractPolyNode(const ModuleInstantiation *mi) : AbstractNode(mi) {}
+  AbstractPolyNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(std::move(mi)) {}
 
   enum class render_mode_e { RENDER_CGAL, RENDER_OPENCSG };
 };
@@ -134,7 +136,7 @@ class ListNode : public AbstractNode
 {
 public:
   VISITABLE();
-  ListNode(const ModuleInstantiation *mi) : AbstractNode(mi) {}
+  ListNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractNode(std::move(mi)) {}
   std::string name() const override;
 };
 
@@ -146,8 +148,8 @@ class GroupNode : public AbstractNode
 {
 public:
   VISITABLE();
-  GroupNode(const ModuleInstantiation *mi, std::string name = "")
-    : AbstractNode(mi), _name(std::move(name))
+  GroupNode(std::shared_ptr<const ModuleInstantiation> mi, std::string name = "")
+    : AbstractNode(std::move(mi)), _name(std::move(name))
   {
   }
   std::string name() const override;
@@ -169,18 +171,15 @@ class RootNode : public GroupNode
 {
 public:
   VISITABLE();
-  RootNode() : GroupNode(&mi), mi("group") {}
+  RootNode() : GroupNode(std::make_shared<ModuleInstantiation>("group")) {}
   std::string name() const override;
-
-private:
-  ModuleInstantiation mi;
 };
 
 class LeafNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  LeafNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  LeafNode(std::shared_ptr<const ModuleInstantiation> mi) : AbstractPolyNode(std::move(mi)) {}
   virtual std::unique_ptr<const class Geometry> createGeometry() const = 0;
 };
 

--- a/src/core/node_clone.cc
+++ b/src/core/node_clone.cc
@@ -59,14 +59,11 @@
 #include "geometry/GeometryUtils.h"
 #include "geometry/linalg.h"
 
-std::vector<std::shared_ptr<ModuleInstantiation>> modinsts_list;
-
 #define NodeCloneFunc(T)                                                                               \
   std::shared_ptr<T> clone_what(const T *node)                                                         \
   {                                                                                                    \
     auto inst = std::make_shared<ModuleInstantiation>(node->modinst->name(), node->modinst->arguments, \
                                                       node->modinst->location());                      \
-    modinsts_list.push_back(inst);                                                                     \
     auto clone = std::make_shared<T>(*node);                                                           \
     clone->modinst = inst;                                                                             \
     return clone;                                                                                      \

--- a/src/core/node_clone.cc
+++ b/src/core/node_clone.cc
@@ -59,17 +59,17 @@
 #include "geometry/GeometryUtils.h"
 #include "geometry/linalg.h"
 
-std::vector<ModuleInstantiation *> modinsts_list;
+std::vector<std::shared_ptr<ModuleInstantiation>> modinsts_list;
 
-#define NodeCloneFunc(T)                                                           \
-  std::shared_ptr<T> clone_what(const T *node)                                     \
-  {                                                                                \
-    ModuleInstantiation *inst = new ModuleInstantiation(                           \
-      node->modinst->name(), node->modinst->arguments, node->modinst->location()); \
-    modinsts_list.push_back(inst);                                                 \
-    auto clone = std::make_shared<T>(*node);                                       \
-    clone->modinst = inst;                                                         \
-    return clone;                                                                  \
+#define NodeCloneFunc(T)                                                                               \
+  std::shared_ptr<T> clone_what(const T *node)                                                         \
+  {                                                                                                    \
+    auto inst = std::make_shared<ModuleInstantiation>(node->modinst->name(), node->modinst->arguments, \
+                                                      node->modinst->location());                      \
+    modinsts_list.push_back(inst);                                                                     \
+    auto clone = std::make_shared<T>(*node);                                                           \
+    clone->modinst = inst;                                                                             \
+    return clone;                                                                                      \
   }
 
 #define NodeCloneUse(T)                              \
@@ -130,7 +130,7 @@ void AbstractNode::dump_counts(int indent, int use_cnt)
   int i = 0;
   for (i = 0; i < indent; i++) printf(" ");
 
-  printf("%s use =%d mi=%p ", this->name().c_str(), use_cnt, this->modinst);
+  printf("%s use =%d mi=%p ", this->name().c_str(), use_cnt, (void *)this->modinst.get());
 
   printf("(%d/%d/%d) ", this->modinst->tag_highlight, this->modinst->tag_background,
          this->modinst->tag_root);

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -84,7 +84,8 @@ static void generate_circle(InsertIterator iter, double r, double z, double angl
  * @return radius value of type Value::Type::NUMBER or Value::Type::UNDEFINED if both
  *         variables are invalid or not set.
  */
-static Value lookup_radius(const Parameters& parameters, const ModuleInstantiation *inst,
+static Value lookup_radius(const Parameters& parameters,
+                           const std::shared_ptr<const ModuleInstantiation>& inst,
                            const std::string& diameter_var, const std::string& radius_var)
 {
   const auto& d = parameters[diameter_var];
@@ -177,7 +178,8 @@ std::shared_ptr<const Geometry> CubeNode::dragPoint(const Vector3d& pt, const Ve
   return std::shared_ptr<const Geometry>(std::move(createGeometry()));
 }
 
-static std::shared_ptr<AbstractNode> builtin_cube(const ModuleInstantiation *inst, Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_cube(const std::shared_ptr<const ModuleInstantiation>& inst,
+                                                  Arguments arguments)
 {
   auto node = std::make_shared<CubeNode>(inst);
 
@@ -288,7 +290,8 @@ std::shared_ptr<const Geometry> SphereNode::dragPoint(const Vector3d& pt, const 
   return std::shared_ptr<const Geometry>(std::move(createGeometry()));
 }
 
-static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *inst, Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_sphere(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"d"});
 
@@ -392,8 +395,8 @@ std::shared_ptr<const Geometry> CylinderNode::dragPoint(const Vector3d& pt, cons
   return std::shared_ptr<const Geometry>(std::move(createGeometry()));
 }
 
-static std::shared_ptr<AbstractNode> builtin_cylinder(const ModuleInstantiation *inst,
-                                                      Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_cylinder(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"h", "r1", "r2", "center", "angle"},
@@ -527,8 +530,8 @@ std::unique_ptr<const Geometry> PolyhedronNode::createGeometry() const
   return p;
 }
 
-static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiation *inst,
-                                                        Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_polyhedron(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   auto node = std::make_shared<PolyhedronNode>(inst);
 
@@ -642,7 +645,8 @@ std::unique_ptr<const Geometry> SquareNode::createGeometry() const
   return std::make_unique<Polygon2d>(o);
 }
 
-static std::shared_ptr<AbstractNode> builtin_square(const ModuleInstantiation *inst, Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_square(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   auto node = std::make_shared<SquareNode>(inst);
 
@@ -706,7 +710,8 @@ std::unique_ptr<const Geometry> CircleNode::createGeometry() const
   return std::make_unique<Polygon2d>(o);
 }
 
-static std::shared_ptr<AbstractNode> builtin_circle(const ModuleInstantiation *inst, Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_circle(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"d", "angle"});
@@ -987,8 +992,8 @@ std::unique_ptr<const Geometry> SplineNode::createGeometry() const
   return p;
 }
 
-static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *inst,
-                                                     Arguments arguments)
+static std::shared_ptr<AbstractNode> builtin_polygon(
+  const std::shared_ptr<const ModuleInstantiation>& inst, Arguments arguments)
 {
   auto node = std::make_shared<PolygonNode>(inst, CurveDiscretizer(3));
 

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -41,7 +41,7 @@
 class CubeNode : public LeafNode
 {
 public:
-  CubeNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  CubeNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override
   {
     std::ostringstream stream;
@@ -76,8 +76,8 @@ std::unique_ptr<const Geometry> sphereCreateFuncGeometry(void *funcptr, double f
 class SphereNode : public LeafNode
 {
 public:
-  SphereNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : LeafNode(mi), discretizer(std::move(discretizer))
+  SphereNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : LeafNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
@@ -97,8 +97,8 @@ public:
 class CylinderNode : public LeafNode
 {
 public:
-  CylinderNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : LeafNode(mi), discretizer(std::move(discretizer))
+  CylinderNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : LeafNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
@@ -117,7 +117,7 @@ public:
 class PolyhedronNode : public LeafNode
 {
 public:
-  PolyhedronNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  PolyhedronNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "polyhedron"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
@@ -132,7 +132,7 @@ public:
 class EdgeNode : public LeafNode
 {
 public:
-  EdgeNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  EdgeNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override
   {
     std::ostringstream stream;
@@ -149,7 +149,7 @@ public:
 class SquareNode : public LeafNode
 {
 public:
-  SquareNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  SquareNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override
   {
     std::ostringstream stream;
@@ -167,8 +167,8 @@ public:
 class CircleNode : public LeafNode
 {
 public:
-  CircleNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : LeafNode(mi), discretizer(std::move(discretizer))
+  CircleNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : LeafNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
@@ -183,8 +183,8 @@ public:
 class PolygonNode : public LeafNode
 {
 public:
-  PolygonNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : LeafNode(mi), discretizer(std::move(discretizer))
+  PolygonNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : LeafNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
@@ -202,8 +202,8 @@ public:
 class PolylineNode : public LeafNode
 {
 public:
-  PolylineNode(const ModuleInstantiation *mi, CurveDiscretizer discretizer)
-    : LeafNode(mi), discretizer(std::move(discretizer))
+  PolylineNode(std::shared_ptr<const ModuleInstantiation> mi, CurveDiscretizer discretizer)
+    : LeafNode(std::move(mi)), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
@@ -217,7 +217,7 @@ public:
 class SplineNode : public LeafNode
 {
 public:
-  SplineNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  SplineNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "spline"; }
   std::vector<Vector2d> draw_arc(int fn, const Vector2d& tang1, double l1, const Vector2d& tang2,
@@ -232,7 +232,7 @@ class SheetNode : public LeafNode
 {
 public:
   VISITABLE();
-  SheetNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  SheetNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "sheet"; }
 #ifdef ENABLE_PYTHON

--- a/src/genlang/genlang.h
+++ b/src/genlang/genlang.h
@@ -10,10 +10,10 @@
 #include "core/UserModule.h"
 #include "core/CsgOpNode.h"
 
-#define DECLARE_INSTANCE()                                                                              \
-  std::string instance_name;                                                                            \
-  AssignmentList inst_asslist;                                                                          \
-  ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE); \
+#define DECLARE_INSTANCE()                                                                            \
+  std::string instance_name;                                                                          \
+  AssignmentList inst_asslist;                                                                        \
+  auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE); \
   modinsts_list.push_back(instance);
 
 extern std::vector<std::string> mapping_name;

--- a/src/genlang/genlang.h
+++ b/src/genlang/genlang.h
@@ -10,11 +10,10 @@
 #include "core/UserModule.h"
 #include "core/CsgOpNode.h"
 
-#define DECLARE_INSTANCE()                                                                            \
-  std::string instance_name;                                                                          \
-  AssignmentList inst_asslist;                                                                        \
-  auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE); \
-  modinsts_list.push_back(instance);
+#define DECLARE_INSTANCE()     \
+  std::string instance_name;   \
+  AssignmentList inst_asslist; \
+  auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE);
 
 extern std::vector<std::string> mapping_name;
 extern std::vector<std::string> mapping_code;

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1543,8 +1543,8 @@ GeometryEvaluator::ResultObject GeometryEvaluator::applyToChildren3D(const Abstr
   case OpenSCADOperator::OFFSET: {
     std::string instance_name;
     AssignmentList inst_asslist;
-    ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE);
-    auto node1 = std::make_shared<CsgOpNode>(instance, OpenSCADOperator::UNION);
+    auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE);
+    auto node1 = std::make_shared<CsgOpNode>(std::move(instance), OpenSCADOperator::UNION);
 
     Geometry::Geometries actualchildren;
     for (const auto& item : children) {

--- a/src/geometry/cgal/cgalutils-applyops-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-minkowski.cc
@@ -25,8 +25,8 @@ std::shared_ptr<const Geometry> applyMinkowski3D(const Geometry::Geometries& chi
   t_tot.start();
   AssignmentList inst_asslist;
   std::string instance_name;
-  ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE);
-  CsgOpNode node(instance, OpenSCADOperator::UNION);
+  auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE);
+  CsgOpNode node(std::move(instance), OpenSCADOperator::UNION);
 
   auto it = children.begin();
   std::shared_ptr<const Geometry> operands[2] = {it->second, std::shared_ptr<const Geometry>()};

--- a/src/io/import_3mf_v1.cc
+++ b/src/io/import_3mf_v1.cc
@@ -431,8 +431,8 @@ std::unique_ptr<PolySet> import_3mf(const std::string& filename, const Location&
     lib3mf_getinterfaceversion(&interfaceVersionMajor, &interfaceVersionMinor, &interfaceVersionMicro);
   std::string instance_name;
   AssignmentList inst_asslist;
-  ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE);
-  auto node = std::make_shared<CsgOpNode>(instance, OpenSCADOperator::UNION);
+  auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE);
+  auto node = std::make_shared<CsgOpNode>(std::move(instance), OpenSCADOperator::UNION);
   if (result != LIB3MF_OK) {
     LOG(message_group::Error, "Error reading 3MF library version");
     return PolySet::createEmpty();

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -337,8 +337,8 @@ std::unique_ptr<PolySet> import_3mf(const std::string& filename, const Location&
   Lib3MF::PWrapper wrapper;
   std::string instance_name;
   AssignmentList inst_asslist;
-  ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE);
-  auto node = std::make_shared<CsgOpNode>(instance, OpenSCADOperator::UNION);
+  auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE);
+  auto node = std::make_shared<CsgOpNode>(std::move(instance), OpenSCADOperator::UNION);
 
   try {
     wrapper = Lib3MF::CWrapper::loadLibrary();

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -262,8 +262,8 @@ std::unique_ptr<PolySet> AmfImporter::read(const std::string& filename)
 
   std::string instance_name;
   AssignmentList inst_asslist;
-  ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE);
-  auto node = std::make_shared<CsgOpNode>(instance, OpenSCADOperator::UNION);
+  auto instance = std::make_shared<ModuleInstantiation>(instance_name, inst_asslist, Location::NONE);
+  auto node = std::make_shared<CsgOpNode>(std::move(instance), OpenSCADOperator::UNION);
 
   if (polySets.empty()) {
     return PolySet::createEmpty();

--- a/src/python/FrepNode.h
+++ b/src/python/FrepNode.h
@@ -69,7 +69,7 @@ protected:
 class FrepNode : public LeafNode
 {
 public:
-  explicit FrepNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  explicit FrepNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
   std::string toString() const override;
   std::string name() const override { return "sdf"; }
   std::unique_ptr<const Geometry> createGeometry() const override;

--- a/src/python/FrepNode.h
+++ b/src/python/FrepNode.h
@@ -69,7 +69,7 @@ protected:
 class FrepNode : public LeafNode
 {
 public:
-  explicit FrepNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(mi) {}
+  explicit FrepNode(std::shared_ptr<const ModuleInstantiation> mi) : LeafNode(std::move(mi)) {}
   std::string toString() const override;
   std::string name() const override { return "sdf"; }
   std::unique_ptr<const Geometry> createGeometry() const override;

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1376,7 +1376,6 @@ std::string evaluatePython(const std::string& code, bool dry_run)
   PyObjectUniquePtr pyExcTraceback(nullptr, &PyObjectDeleter);
   /* special python code to catch errors from stdout and stderr and make them available in OpenSCAD
    * console */
-  modinsts_list.clear();  // shared_ptrs auto-free
   pythonDryRun = dry_run;
   if (!pythonMainModuleInitialized) return "Python not initialized";
   struct EvaluatePythonGil {

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -778,9 +778,9 @@ PyObject *python_callfunction(const std::shared_ptr<const Context>& cxt, const s
  * Actually trying use python to evaluate a OpenSCAD Module
  */
 
-std::shared_ptr<AbstractNode> python_modulefunc(const ModuleInstantiation *op_module,
-                                                const std::shared_ptr<const Context>& cxt,
-                                                std::string& error)  // null & error: error, else: None
+std::shared_ptr<AbstractNode> python_modulefunc(
+  const std::shared_ptr<const ModuleInstantiation>& op_module, const std::shared_ptr<const Context>& cxt,
+  std::string& error)  // null & error: error, else: None
 {
   std::shared_ptr<AbstractNode> result = nullptr;
   std::string errorstr = "";
@@ -1376,10 +1376,7 @@ std::string evaluatePython(const std::string& code, bool dry_run)
   PyObjectUniquePtr pyExcTraceback(nullptr, &PyObjectDeleter);
   /* special python code to catch errors from stdout and stderr and make them available in OpenSCAD
    * console */
-  for (ModuleInstantiation *mi : modinsts_list) {
-    delete mi;  // best time to delete it
-  }
-  modinsts_list.clear();
+  modinsts_list.clear();  // shared_ptrs auto-free
   pythonDryRun = dry_run;
   if (!pythonMainModuleInitialized) return "Python not initialized";
   struct EvaluatePythonGil {

--- a/src/python/pyopenscad.h
+++ b/src/python/pyopenscad.h
@@ -132,7 +132,7 @@ PyTypeObject *PyOpenSCADObjectType(PyObject *objs);
 int python_more_obj(std::vector<std::shared_ptr<AbstractNode>>& children, PyObject *more_obj);
 Outline2d python_getprofile(void *v_cbfunc, int fn, double arg);
 double python_doublefunc(void *v_cbfunc, double arg);
-std::shared_ptr<AbstractNode> python_modulefunc(const ModuleInstantiation *module,
+std::shared_ptr<AbstractNode> python_modulefunc(const std::shared_ptr<const ModuleInstantiation>& module,
                                                 const std::shared_ptr<const Context>& context,
                                                 std::string& error);
 std::vector<int> python_intlistval(PyObject *list);

--- a/src/python/python_public.h
+++ b/src/python/python_public.h
@@ -43,9 +43,9 @@ int ipython(const std::vector<std::string>& args);
 // propagate (0 on clean exit, non-zero on init failure).
 int repl(void);
 
-std::shared_ptr<AbstractNode> python_modulefunc(const ModuleInstantiation *op_module,
-                                                const std::shared_ptr<const Context>& cxt,
-                                                std::string& error);
+std::shared_ptr<AbstractNode> python_modulefunc(
+  const std::shared_ptr<const ModuleInstantiation>& op_module, const std::shared_ptr<const Context>& cxt,
+  std::string& error);
 
 Value python_functionfunc(const FunctionCall *call, const std::shared_ptr<const Context>& cxt,
                           int& error);


### PR DESCRIPTION
## Summary

Converts `ModuleInstantiation` from raw pointer (`const ModuleInstantiation*`) to `std::shared_ptr<const ModuleInstantiation>` across the entire codebase (62 files).

### Problem

`ModuleInstantiation` objects — which represent individual module calls such as `cube(...)` or `color(...)` in a script — were passed around as raw pointers with no clear ownership semantics. This made it possible for a `modinst` to be freed while still referenced elsewhere, leading to potential use-after-free bugs that were previously worked around with ad-hoc patches rather than fixed at the root.

### Solution

Adopt shared ownership via `std::shared_ptr<const ModuleInstantiation>` so that each `modinst` is guaranteed to remain alive for as long as any node or evaluator holds a reference to it, and is freed automatically once all references are released.

### Changes

- **All node constructors** (`AbstractNode` and every concrete subclass: `CgalAdvNode`, `ColorNode`, `CsgOpNode`, `LinearExtrudeNode`, etc.) now accept `std::shared_ptr<const ModuleInstantiation>` instead of a raw pointer.
- **All builtin module functions** (the `builtin_*` callbacks registered with the module system) updated to match the new signature.
- **`CSGTreeEvaluator`** updated to propagate the shared pointer through geometry evaluation.
- **`ModuleInstantiation` itself** updated to enable shared-pointer construction and usage.
- **Build system (`CMakeLists.txt`)**: Several Python-specific node sources (`PullNode.cc`, `WrapNode.cc`, `SheetNode.cc`, `DebugNode.cc`, `RepairNode.cc`, `OversampleNode.cc`, `node_clone.cc`) moved from `CORE_SOURCES` into `PYTHON_SOURCES` so they are only compiled when Python support is enabled.

### Impact

Pure refactor — no observable behaviour change. Eliminates an entire class of lifetime bugs at the source rather than patching individual symptoms.