### PR TITLE
fix(python): detect pythonscad-python argv[0] to enter Python mode

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -844,7 +844,8 @@ int openscad_main(int argc, char **argv)
   // just forward everything to the python main.
   const auto applicationName = fs::path(argv[0]).filename().generic_string();
   if (applicationName == "python" || applicationName == "python3" ||
-      applicationName.rfind("python3.", 0) == 0 || applicationName == "openscad-python") {
+      applicationName.rfind("python3.", 0) == 0 || applicationName == "openscad-python" ||
+      applicationName == PYTHON_EXECUTABLE_NAME) {
     return pythonRunArgs(argc, argv);
   }
 #endif

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -841,8 +841,14 @@ int openscad_main(int argc, char **argv)
 
 #ifdef ENABLE_PYTHON
   // The original name as called, not resolving links and so on. This will
-  // just forward everything to the python main.
-  const auto applicationName = fs::path(argv[0]).filename().generic_string();
+  // just forward everything to the python main. On Windows the Python shim is
+  // a ".exe" copy (e.g. pythonscad-python.exe), so drop that extension before
+  // matching; only ".exe" is stripped, preserving e.g. "python3.14" naming.
+  auto applicationPathName = fs::path(argv[0]).filename();
+  if (boost::iequals(applicationPathName.extension().string(), ".exe")) {
+    applicationPathName.replace_extension();
+  }
+  const auto applicationName = applicationPathName.generic_string();
   if (applicationName == "python" || applicationName == "python3" ||
       applicationName.rfind("python3.", 0) == 0 || applicationName == "openscad-python" ||
       applicationName == PYTHON_EXECUTABLE_NAME) {


### PR DESCRIPTION
## Summary

- The `argv[0]` check in `openscad.cc` that routes the binary into Python interpreter mode only included `"openscad-python"` (the upstream OpenSCAD name), missing `"pythonscad-python"` (`PYTHON_EXECUTABLE_NAME`).
- When `File > Python > Create venv` is used, Python's `venv` module internally spawns a subprocess — `pythonscad-python -m ensurepip --upgrade --default-pip` — to bootstrap pip into the new venv. Because `pythonscad-python` wasn't recognised, the binary fell through to OpenSCAD's CLI parser which doesn't understand `--upgrade`, causing exit code 1 and a failed venv creation.
- Fix: add `|| applicationName == PYTHON_EXECUTABLE_NAME` to the condition so the binary enters Python mode whenever it is invoked under its own executable name.

## Test plan

- [x] Built locally on macOS
- [x] `pythonscad-python --version` now returns `Python 3.14.3` instead of showing OpenSCAD help
- [x] `pythonscad-python -m venv /tmp/test-venv` completes successfully and pip is functional in the new venv

🤖 Generated with [Claude Code](https://claude.ai/claude-code)