### PR TITLE
feat(appdata): replace inherited OpenSCAD releases with PythonSCAD history

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,39 @@ jobs:
           # Use bot account PAT to allow release events to trigger other workflows
           token: ${{ secrets.RELEASE_TOKEN }}
 
+      # When a release PR is open, regenerate the AppStream release list from
+      # the CHANGELOG.md that release-please just wrote and commit it onto the
+      # PR branch. That way the new <release> entry is already part of the
+      # source tree the moment the PR is merged (and tagged/released).
+      #
+      # release-please force-pushes its branch on every update, so this step
+      # re-applies deterministically after each run; the generator is
+      # idempotent and derives everything from CHANGELOG.md.
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          persist-credentials: false
+
+      - name: Sync AppStream release list onto release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/update-appdata-releases.py
+          if git diff --quiet -- pythonscad.appdata.xml.in; then
+            echo "AppStream release list already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pythonscad.appdata.xml.in
+          git commit -m "chore: sync appdata release list"
+          git push "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${RELEASE_PR_BRANCH}"
+
       - name: Checkout code
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v7

--- a/.github/workflows/validate-appdata.yml
+++ b/.github/workflows/validate-appdata.yml
@@ -1,0 +1,48 @@
+name: Validate AppStream Metadata
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - pythonscad.appdata.xml.in
+      - .github/workflows/validate-appdata.yml
+  pull_request:
+    paths:
+      - pythonscad.appdata.xml.in
+      - .github/workflows/validate-appdata.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install appstreamcli
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends appstream
+
+      - name: Render template and validate
+        run: |
+          set -euo pipefail
+          # pythonscad.appdata.xml.in is a CMake configure_file template;
+          # strip the ${...} placeholders to get a valid metainfo document.
+          rendered="$(mktemp --suffix=.metainfo.xml)"
+          sed "s/\${SUFFIX_WITH_DASH}//g; s/\${SNAPSHOT_SUFFIX}//g" \
+            pythonscad.appdata.xml.in > "$rendered"
+          # --no-net: skip URL/screenshot reachability checks (flaky in CI,
+          # they only warn) and validate schema/structure instead.
+          appstreamcli validate --no-net "$rendered"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,20 @@ repos:
           - id: shellcheck
             args: ["--severity=warning"]
             exclude: ^(submodules|tests/data)/
+    - repo: local
+      hooks:
+          # The AppStream <releases> block in pythonscad.appdata.xml.in is
+          # generated from CHANGELOG.md by scripts/update-appdata-releases.py.
+          # Fail if the committed file drifts from what the generator would
+          # produce (e.g. a hand-edit, or a CHANGELOG change without a
+          # regenerate). Uses only the Python stdlib, so `language: system`
+          # needs no extra dependencies.
+          - id: appdata-releases
+            name: appdata releases up to date
+            entry: python3 scripts/update-appdata-releases.py --check
+            language: system
+            files: ^(CHANGELOG\.md|pythonscad\.appdata\.xml\.in)$
+            pass_filenames: false
     - repo: https://github.com/zizmorcore/zizmor-pre-commit
       rev: v1.26.1
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,12 +110,13 @@ repos:
           # generated from CHANGELOG.md by scripts/update-appdata-releases.py.
           # Fail if the committed file drifts from what the generator would
           # produce (e.g. a hand-edit, or a CHANGELOG change without a
-          # regenerate). Uses only the Python stdlib, so `language: system`
-          # needs no extra dependencies.
+          # regenerate). The script is stdlib-only; `language: python` lets
+          # pre-commit provision an interpreter consistently across platforms
+          # (notably Windows, where `python3` is often not on PATH).
           - id: appdata-releases
             name: appdata releases up to date
-            entry: python3 scripts/update-appdata-releases.py --check
-            language: system
+            entry: python scripts/update-appdata-releases.py --check
+            language: python
             files: ^(CHANGELOG\.md|pythonscad\.appdata\.xml\.in)$
             pass_filenames: false
     - repo: https://github.com/zizmorcore/zizmor-pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 * **chore:** add pythonscad logo source ([#710](https://github.com/pythonscad/pythonscad/issues/710)) ([bd017d2](https://github.com/pythonscad/pythonscad/commit/bd017d25e3d965856592f042c969c3df6a966ec3))
 * **ci:** add MSIX packaging as reusable composite action ([#638](https://github.com/pythonscad/pythonscad/issues/638)) ([422b28a](https://github.com/pythonscad/pythonscad/commit/422b28a15f9070e547df1696a3b434584f096521))
 * **distributions:** add support for Fedora 44 and Ubuntu 26.04 LTS ([#624](https://github.com/pythonscad/pythonscad/issues/624)) ([5a78c77](https://github.com/pythonscad/pythonscad/commit/5a78c77f73d0f662884c312ddd41f2d670b23a4c))
-* **gui:** display abosolute filepath in the title bar ([#576](https://github.com/pythonscad/pythonscad/issues/576)) ([41c6552](https://github.com/pythonscad/pythonscad/commit/41c6552d2a658a7be824864623a7f4e3a23d1a6a))
+* **gui:** display absolute filepath in the title bar ([#576](https://github.com/pythonscad/pythonscad/issues/576)) ([41c6552](https://github.com/pythonscad/pythonscad/commit/41c6552d2a658a7be824864623a7f4e3a23d1a6a))
 * **gui:** replace Python trust dialog with inline trust bar ([#667](https://github.com/pythonscad/pythonscad/issues/667)) ([1382dd7](https://github.com/pythonscad/pythonscad/commit/1382dd7515c91cc18593e0b5f1ca5281a90ba1e0))
 * **install:** per-user Windows installer with on-demand UAC elevation ([#696](https://github.com/pythonscad/pythonscad/issues/696)) ([20a4f18](https://github.com/pythonscad/pythonscad/commit/20a4f186df15c53e939385522c05bb2faf453291))
 * native vector operations for addition, subtraction, scaling, dot and cross product ([#588](https://github.com/pythonscad/pythonscad/issues/588)) ([267c753](https://github.com/pythonscad/pythonscad/commit/267c7535f6daccbf76a3499c8442738983d7ae71))
-* **polyline:** polylines work work difference and intersection now ([#572](https://github.com/pythonscad/pythonscad/issues/572)) ([6f0ee76](https://github.com/pythonscad/pythonscad/commit/6f0ee76f29ca90151cfecea36b1dcd9306bbc51a))
+* **polyline:** polylines work with difference and intersection now ([#572](https://github.com/pythonscad/pythonscad/issues/572)) ([6f0ee76](https://github.com/pythonscad/pythonscad/commit/6f0ee76f29ca90151cfecea36b1dcd9306bbc51a))
 * **python:** add MultiToolExporter helper to pythonscad module ([#585](https://github.com/pythonscad/pythonscad/issues/585)) ([e15e0cf](https://github.com/pythonscad/pythonscad/commit/e15e0cfd5542572c9fef52720e5b04d602d718db))
 * **python:** expose root ColorNode RGBA as solid property `c` ([#562](https://github.com/pythonscad/pythonscad/issues/562)) ([0da296a](https://github.com/pythonscad/pythonscad/commit/0da296abcae4d4762226de22c95e66d7e15ee2c8))
 * **python:** introduce _openscad / openscad / pythonscad three-module layout ([#579](https://github.com/pythonscad/pythonscad/issues/579)) ([542c89e](https://github.com/pythonscad/pythonscad/commit/542c89eaac1e9bdcac3115e3a9f1370076be1234))
@@ -42,7 +42,7 @@
 * **ci:** use CERTUM_CERTIFICATE_CN secret for MSIX publisher DN ([#704](https://github.com/pythonscad/pythonscad/issues/704)) ([f4c3d15](https://github.com/pythonscad/pythonscad/commit/f4c3d15ac96c323dca56ce93790300582f36ad75))
 * **ci:** use PAT when promoting release so PyPI workflow gets triggered ([#582](https://github.com/pythonscad/pythonscad/issues/582)) ([05c1508](https://github.com/pythonscad/pythonscad/commit/05c1508a67bd29d4746a57a0a6e44e5d838bf291))
 * **csg:** handle missing CONCAT case in CSGTreeEvaluator switch ([#653](https://github.com/pythonscad/pythonscad/issues/653)) ([2814b29](https://github.com/pythonscad/pythonscad/commit/2814b2901527081947b698a909c1a25545de3ba9))
-* **debug:** udpated pythonscad logo on mac ([#655](https://github.com/pythonscad/pythonscad/issues/655)) ([4954ff0](https://github.com/pythonscad/pythonscad/commit/4954ff0b554932fd1c0857410a6d805f46be4660))
+* **debug:** updated pythonscad logo on mac ([#655](https://github.com/pythonscad/pythonscad/issues/655)) ([4954ff0](https://github.com/pythonscad/pythonscad/commit/4954ff0b554932fd1c0857410a6d805f46be4660))
 * **docs:** proof of project ownership for certum.pl to get proper Windows SmartScreen certificates ([#692](https://github.com/pythonscad/pythonscad/issues/692)) ([e9142c0](https://github.com/pythonscad/pythonscad/commit/e9142c0817ec4816628884eaf2f0fb1f90c00a8d))
 * **gui:** defer editorContentChanged signal until activeEditor is set ([#694](https://github.com/pythonscad/pythonscad/issues/694)) ([0331363](https://github.com/pythonscad/pythonscad/commit/03313630b0bf8bcea942b800298fd16e35169373)), closes [#690](https://github.com/pythonscad/pythonscad/issues/690)
 * **gui:** don't mark windows as quitting on session-manager checkpoint ([#581](https://github.com/pythonscad/pythonscad/issues/581)) ([7da0c96](https://github.com/pythonscad/pythonscad/commit/7da0c967265a2433ed3f014dc9329ad8970b8668)), closes [#580](https://github.com/pythonscad/pythonscad/issues/580)
@@ -99,7 +99,7 @@
 * **gui:** log terminal notice on single-instance IPC handoff ([#552](https://github.com/pythonscad/pythonscad/issues/552)) ([b27aca0](https://github.com/pythonscad/pythonscad/commit/b27aca05e0611a8242ba0201392c5fc2b984fd7f))
 * **gui:** session restore, customizer params without F5, dry-run safety ([#415](https://github.com/pythonscad/pythonscad/issues/415)) ([0078525](https://github.com/pythonscad/pythonscad/commit/0078525cc47653afb0f5f220ade97c4f3107a3b0))
 * **oversample:** add dynamic method ([61a25c7](https://github.com/pythonscad/pythonscad/commit/61a25c71feb0f2f08b01c2ac1b70ec5e3d73d7aa))
-* **oversmaple:** more work ([681be5a](https://github.com/pythonscad/pythonscad/commit/681be5a48f060573ecc8ee0ed191d1af8bb8266b))
+* **oversample:** more work ([681be5a](https://github.com/pythonscad/pythonscad/commit/681be5a48f060573ecc8ee0ed191d1af8bb8266b))
 
 
 ### Bug Fixes
@@ -107,7 +107,7 @@
 * **chore:** undo wrong files ([48f8cc7](https://github.com/pythonscad/pythonscad/commit/48f8cc728a435247116bdca7525bb8d458158ee2))
 * **crash:** right Click works better ([7130b80](https://github.com/pythonscad/pythonscad/commit/7130b803bc0d5288145b23ade34d55fdf839409e))
 * **crash:** right Click works better ([e89716b](https://github.com/pythonscad/pythonscad/commit/e89716b78185fac6fcc137dc2d7d24988b1e177b))
-* fix typo / terminlogy in code comments ([74b0cf2](https://github.com/pythonscad/pythonscad/commit/74b0cf2317be5e0fe0582e03f392f59de126e66a))
+* fix typo / terminology in code comments ([74b0cf2](https://github.com/pythonscad/pythonscad/commit/74b0cf2317be5e0fe0582e03f392f59de126e66a))
 * **gui:** align save-as path, filters, and untitled names with editor language ([#541](https://github.com/pythonscad/pythonscad/issues/541)) ([cd2ba3e](https://github.com/pythonscad/pythonscad/commit/cd2ba3e8511de7e74c64b087a9f0d11d179610c9))
 * **gui:** session restore and CLI prompt for missing design files ([#548](https://github.com/pythonscad/pythonscad/issues/548)) ([8477ee3](https://github.com/pythonscad/pythonscad/commit/8477ee3d8825888a8d894d2d96a1046b278e436e))
 * **gui:** skip stale-path session dialog for default Untitled files ([#546](https://github.com/pythonscad/pythonscad/issues/546)) ([b3c27f3](https://github.com/pythonscad/pythonscad/commit/b3c27f3af64cdd6d0783bb5a711b46e31118afc6))
@@ -376,7 +376,7 @@
 
 ### Bug Fixes
 
-* udpated tests ([0efb4a3](https://github.com/pythonscad/pythonscad/commit/0efb4a35102d0cee37a37b6b94e656a710bde685))
+* updated tests ([0efb4a3](https://github.com/pythonscad/pythonscad/commit/0efb4a35102d0cee37a37b6b94e656a710bde685))
 
 ## [0.8.31](https://github.com/pythonscad/pythonscad/compare/v0.8.30...v0.8.31) (2026-01-16)
 

--- a/pythonscad.appdata.xml.in
+++ b/pythonscad.appdata.xml.in
@@ -43,11 +43,11 @@
           <li>chore: add pythonscad logo source</li>
           <li>ci: add MSIX packaging as reusable composite action</li>
           <li>distributions: add support for Fedora 44 and Ubuntu 26.04 LTS</li>
-          <li>gui: display abosolute filepath in the title bar</li>
+          <li>gui: display absolute filepath in the title bar</li>
           <li>gui: replace Python trust dialog with inline trust bar</li>
           <li>install: per-user Windows installer with on-demand UAC elevation</li>
           <li>native vector operations for addition, subtraction, scaling, dot and cross product</li>
-          <li>polyline: polylines work work difference and intersection now</li>
+          <li>polyline: polylines work with difference and intersection now</li>
           <li>python: add MultiToolExporter helper to pythonscad module</li>
           <li>python: expose root ColorNode RGBA as solid property <code>c</code></li>
           <li>python: introduce _openscad / openscad / pythonscad three-module layout</li>
@@ -81,13 +81,13 @@
           <li>gui: log terminal notice on single-instance IPC handoff</li>
           <li>gui: session restore, customizer params without F5, dry-run safety</li>
           <li>oversample: add dynamic method</li>
-          <li>oversmaple: more work</li>
+          <li>oversample: more work</li>
         </ul>
         <p>Bug fixes:</p>
         <ul>
           <li>chore: undo wrong files</li>
           <li>crash: right Click works better</li>
-          <li>fix typo / terminlogy in code comments</li>
+          <li>fix typo / terminology in code comments</li>
           <li>gui: align save-as path, filters, and untitled names with editor language</li>
           <li>gui: session restore and CLI prompt for missing design files</li>
           <li>gui: skip stale-path session dialog for default Untitled files</li>
@@ -261,7 +261,7 @@
         </ul>
         <p>Bug fixes:</p>
         <ul>
-          <li>udpated tests</li>
+          <li>updated tests</li>
         </ul>
       </description>
     </release>

--- a/pythonscad.appdata.xml.in
+++ b/pythonscad.appdata.xml.in
@@ -35,15 +35,288 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release date="2021-01-31" version="2021.01"/>
-    <release date="2019-05-16" version="2019.05"/>
-    <release date="2016-02-22" version="2015.03-3"/>
-    <release date="2015-11-15" version="2015.03-2"/>
-    <release date="2015-04-21" version="2015.03-1"/>
-    <release date="2015-03-10" version="2015.03"/>
-    <release date="2014-03-09" version="2014.03"/>
-    <release date="2013-06-18" version="2013.06"/>
-    <release date="2013-01-17" version="2013.01"/>
-    <release date="2011-12-29" version="2011.12"/>
+    <release version="1.0.0" date="2026-06-02">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v1.0.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>chore: add pythonscad logo source</li>
+          <li>ci: add MSIX packaging as reusable composite action</li>
+          <li>distributions: add support for Fedora 44 and Ubuntu 26.04 LTS</li>
+          <li>gui: display abosolute filepath in the title bar</li>
+          <li>gui: replace Python trust dialog with inline trust bar</li>
+          <li>install: per-user Windows installer with on-demand UAC elevation</li>
+          <li>native vector operations for addition, subtraction, scaling, dot and cross product</li>
+          <li>polyline: polylines work work difference and intersection now</li>
+          <li>python: add MultiToolExporter helper to pythonscad module</li>
+          <li>python: expose root ColorNode RGBA as solid property <code>c</code></li>
+          <li>python: introduce _openscad / openscad / pythonscad three-module layout</li>
+          <li>python: launch real IPython via --ipython, add --repl for legacy prompt</li>
+          <li>and more</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>3mf: scope per-mesh material IDs to append_polyset (lib3mf v1)</li>
+          <li>appstream: align &lt;id&gt; and desktop filename to reverse-DNS convention</li>
+          <li>build: add hidapi and libspnav dependencies across all platforms</li>
+          <li>build: guard sha256_digest call for nettle 4.0 API change</li>
+          <li>chore: accept defines on command line also during animation</li>
+          <li>chore: improved GUI performance</li>
+          <li>chore: make it compilable</li>
+          <li>chore: rebrand remaining OpenSCAD references to PythonSCAD</li>
+          <li>chore: replace more openscad links</li>
+          <li>chore: update Homepage URL</li>
+          <li>ci: bind-mount output dir in arm64 Docker builds for deb and rpm</li>
+          <li>ci: digest-pin all container images in supported-distributions.json</li>
+          <li>and more</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.20.0" date="2026-04-13">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.20.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>gui: enable session management by default</li>
+          <li>gui: log terminal notice on single-instance IPC handoff</li>
+          <li>gui: session restore, customizer params without F5, dry-run safety</li>
+          <li>oversample: add dynamic method</li>
+          <li>oversmaple: more work</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>chore: undo wrong files</li>
+          <li>crash: right Click works better</li>
+          <li>fix typo / terminlogy in code comments</li>
+          <li>gui: align save-as path, filters, and untitled names with editor language</li>
+          <li>gui: session restore and CLI prompt for missing design files</li>
+          <li>gui: skip stale-path session dialog for default Untitled files</li>
+          <li>gui: use QStandardPaths for session/lock file directory on all platforms</li>
+          <li>measure: show correct vertex indexes again</li>
+          <li>remove duplicate definition of <code>GeometryEvaluator::applyHull3D(const Geometry::Geometries&amp;)</code> from src/geometry/GeometryEvaluator.cc</li>
+          <li>sync: undo wrong color</li>
+          <li>update application icon in Windows resource file</li>
+          <li>update nightly icon references in Windows resource file</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.19.0" date="2026-03-31">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.19.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>add polyline primitive</li>
+          <li>add support for importing corel-draw images</li>
+          <li>add: update icons-svg-default.scad source for gc, ps, stp icons (previous effort was manually hacked using Inkscape)</li>
+          <li>gcode: optimize object order</li>
+          <li>gui: add icons for GC, PS, STP</li>
+          <li>gui: add icons for GC, PS, STP (fix typo, edit filename, not extension)</li>
+          <li>gui: add icons for GC, PS, STP updating icons-chokusen and icons-chokusen-dark .qrc files</li>
+          <li>gui: update MainWindow.ui for GC, PS, and STP icons</li>
+          <li>polyline: add 3D support</li>
+          <li>svg,gcode: SVG class and &lt;style&gt; rules; G-code outlines sorted by area</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>2d: improve cleanUnion function</li>
+          <li>add feedAdd property</li>
+          <li>crash and various and issues/bugfixes with polyline/gcode</li>
+          <li>gui: guard against null modinst and path in right-click context menu</li>
+          <li>lazy collider is not used anymore</li>
+          <li>polygon: add discretizer as cache key</li>
+          <li>prevent font family prefix-matching bug in QFontComboBox</li>
+          <li>python: parse Python from editor buffer, not lastCompiledDoc</li>
+          <li>python: trust dialog once; reopen and menu to trust</li>
+          <li>rectified transform</li>
+          <li>removed debug stuff</li>
+          <li>small bug in pylaser which resulted in short plugs</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.18.0" date="2026-03-09">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.18.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>prepare project for PyPI publishing</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>build: add PORTABLE_BINARY=ON to Windows and macOS release builds</li>
+          <li>gui: prevent dialog flickering on Qt5 caused by resize oscillation</li>
+          <li>resolve Qt6 deprecation warnings in GUI code</li>
+          <li>use Fusion style with explicit palettes for reliable cross-platform theming</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.17.0" date="2026-03-06">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.17.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>setrender: allow python code to set vieweing perspective</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>open New Window with Untitled.py tab instead of Untitled.scad</li>
+          <li>resolve cppcheck findings in src/python/</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.16.0" date="2026-02-28">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.16.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>python: add .size, .position, and .bbox properties for 2D objects</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.15.0" date="2026-02-16">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.15.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>release: AppImage signing, release checksums, downloads page improvements</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.14.0" date="2026-02-13">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.14.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>macos: add code signing and notarization for release builds</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>added missing include</li>
+          <li>additional sync to upstream/master</li>
+          <li>compiles</li>
+          <li>pip: add minkowski.cpp to manifold sources for pip build</li>
+          <li>sync all in src/core</li>
+          <li>sync in src/geometry</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.13.0" date="2026-02-10">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.13.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>add hasattr, getattr, setattr</li>
+          <li>added gcode init and exit code</li>
+          <li>enable libfive across all platforms and fix Python module path</li>
+          <li>solids are iteratble</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>cleaned 7 tests</li>
+          <li>filter git describe to match only PythonSCAD version tags</li>
+          <li>fixed plan script</li>
+          <li>Merge commit '030f55de832cd024c64c489a440180d7c3725303' into sync/openscad-2026-02-03</li>
+          <li>minor sync</li>
+          <li>switch clang-tidy to install qt6 dependencies as that's the new default</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.12.0" date="2026-01-28">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.12.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>add GUI theme preference (light/dark/auto) with native look for light mode</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.11.0" date="2026-01-27">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.11.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>macos: improve DMG install experience and fix release build</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.10.0" date="2026-01-21">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.10.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>better lasercutter support</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>use PythonSCAD icon in application overview</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.9.0" date="2026-01-20">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.9.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>ci: add native Windows packaging workflow</li>
+          <li>python: extend add_parameter() with customizer options</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>udpated tests</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.8.0" date="2025-12-30">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.8.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>add macOS build and upload workflow</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.7.0" date="2025-12-28">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.7.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>add Windows binary distribution packaging</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.6.0" date="2025-12-23">
+      <url type="details">https://github.com/pythonscad/pythonscad/releases/tag/v0.6.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>add AUTO option for Qt5Gamepad with Qt6 compatibility check</li>
+          <li>add icons to language selection menu in status bar</li>
+          <li>add language selector to status bar with manual override support</li>
+          <li>add language-specific icons to editor tabs</li>
+          <li>add position property to Python object interface</li>
+          <li>add Python wrapper module with operator overloads and install support</li>
+          <li>add PythonSCAD application icons for stable and nightly builds</li>
+          <li>enable calling OpenSCAD functions from PythonSCAD via osuse()</li>
+          <li>implement three-state CMake options for dependency handling</li>
+          <li>macos: bundle Python framework for portable distribution</li>
+          <li>modernize AppImage build script and add automated workflow</li>
+        </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>68 and #69</li>
+          <li>Adapt GitHub issue template for PythonSCAD</li>
+          <li>add conditional install for lib3mf-dev and libqt5gamepad5-dev</li>
+          <li>Add ellipsis to python venv menu entries as user action is required after clicking them</li>
+          <li>add libfuse2 dependency and explicitly specify desktop file</li>
+          <li>add missing functions to Python stub</li>
+          <li>automatically download linuxdeploy in case it is not found</li>
+          <li>cmake: Correctly handle REQUIRED in FindLib3MF.cmake</li>
+          <li>cmake: define EXECUTABLE_NAME before winconsole subdirectory</li>
+          <li>Corrected gvim startup problems and setting to use gvim in preferences</li>
+          <li>Disable manifold tests when ENABLE_MANIFOLD is OFF</li>
+          <li>do not run tests requiring lib3mf if OpenSCAD was compiled without lib3mf</li>
+          <li>and more</li>
+        </ul>
+      </description>
+    </release>
   </releases>
 </component>

--- a/scripts/update-appdata-releases.py
+++ b/scripts/update-appdata-releases.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Regenerate the AppStream <releases> block in pythonscad.appdata.xml.in.
+
+The release history shown by Linux software centers (GNOME Software, KDE
+Discover, Flathub, ...) is generated from CHANGELOG.md, which is the single
+source of truth maintained by release-please.
+
+Release selection policy (hybrid):
+
+  * Versions <= BACKFILL_MINORS_THROUGH: only minor/major releases
+    (patch component == 0) are listed. This collapses the early
+    rapid-fire patch bursts that carry little user value.
+  * Versions  > BACKFILL_MINORS_THROUGH: every release is listed,
+    patches included.
+
+Usage:
+    update-appdata-releases.py [--check]
+    update-appdata-releases.py --changelog CHANGELOG.md --appdata file.xml.in
+
+With --check the script makes no changes and exits non-zero if the file is
+out of date (for CI / pre-commit).
+"""
+
+import argparse
+import html
+import re
+import sys
+from pathlib import Path
+
+# Releases at or below this version are pruned to minor/major only; newer
+# releases are all listed. See module docstring.
+BACKFILL_MINORS_THROUGH = (1, 0, 0)
+
+# Maximum number of bullet points rendered per section before the list is
+# truncated with a trailing "and more" entry.
+MAX_ITEMS_PER_SECTION = 12
+
+# CHANGELOG sections mapped to the human-facing label used in the release
+# notes. Only these (user-facing) sections are surfaced in the metadata.
+SECTIONS = [
+    ("Features", "Features:"),
+    ("Bug Fixes", "Bug fixes:"),
+]
+
+TAG_URL = "https://github.com/pythonscad/pythonscad/releases/tag/v{version}"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+HEADING_RE = re.compile(r"^## \[?(\d+)\.(\d+)\.(\d+)")
+DATE_RE = re.compile(r"\((\d{4}-\d{2}-\d{2})\)\s*$")
+SECTION_RE = re.compile(r"^### (.+?)\s*$")
+BULLET_RE = re.compile(r"^\* (.+?)\s*$")
+RELEASES_BLOCK_RE = re.compile(r"^[ \t]*<releases>.*?</releases>", re.DOTALL | re.MULTILINE)
+
+
+def parse_changelog(text):
+    """Parse CHANGELOG.md into a list of release dicts (newest first)."""
+    releases = []
+    current = None
+    section = None
+    for line in text.splitlines():
+        heading = HEADING_RE.match(line)
+        if heading:
+            version = tuple(int(g) for g in heading.groups())
+            date_match = DATE_RE.search(line)
+            current = {
+                "version": version,
+                "date": date_match.group(1) if date_match else "",
+                "sections": {},
+            }
+            releases.append(current)
+            section = None
+            continue
+        if current is None:
+            continue
+        section_match = SECTION_RE.match(line)
+        if section_match:
+            section = section_match.group(1)
+            continue
+        bullet_match = BULLET_RE.match(line)
+        if bullet_match and section is not None:
+            current["sections"].setdefault(section, []).append(bullet_match.group(1))
+    return releases
+
+
+def selected(version):
+    """Apply the hybrid release-selection policy."""
+    if version > BACKFILL_MINORS_THROUGH:
+        return True
+    return version[2] == 0
+
+
+def _xml_escape(text):
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def clean_bullet(text):
+    """Turn a markdown changelog bullet into AppStream-safe inline text."""
+    # Drop trailing PR/commit reference groups, e.g. " ([#710](url))".
+    text = re.sub(r"\s*\(\[[^\]]+\]\([^)]+\)\)", "", text)
+    # Drop "closes #nnn" style trailers.
+    text = re.sub(r",?\s*closes\s*\[[^\]]+\]\([^)]+\)", "", text, flags=re.IGNORECASE)
+    # Flatten any remaining markdown links to their text.
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    # Bold markers carry no meaning once flattened (used for scopes).
+    text = text.replace("**", "")
+    # CHANGELOG already HTML-escapes some characters; normalise to raw first.
+    text = html.unescape(text)
+
+    # Re-escape for XML, turning inline `code` spans into <code> elements.
+    parts = []
+    for index, segment in enumerate(text.split("`")):
+        if index % 2 == 1:
+            parts.append(f"<code>{_xml_escape(segment)}</code>")
+        else:
+            parts.append(_xml_escape(segment))
+    result = "".join(parts)
+
+    # Prevent CMake configure_file() from treating ${...} as a substitution.
+    result = result.replace("${", "&#36;{")
+    return re.sub(r"\s+", " ", result).strip()
+
+
+def render_release(release):
+    version_str = ".".join(str(n) for n in release["version"])
+    lines = [f'    <release version="{version_str}" date="{release["date"]}">']
+    lines.append(f'      <url type="details">{TAG_URL.format(version=version_str)}</url>')
+
+    blocks = []
+    for key, label in SECTIONS:
+        bullets = release["sections"].get(key)
+        if not bullets:
+            continue
+        seen = set()
+        unique = []
+        for bullet in bullets:
+            cleaned = clean_bullet(bullet)
+            if cleaned and cleaned not in seen:
+                seen.add(cleaned)
+                unique.append(cleaned)
+        if not unique:
+            continue
+        truncated = len(unique) > MAX_ITEMS_PER_SECTION
+        shown = unique[:MAX_ITEMS_PER_SECTION]
+        item_lines = [f"          <li>{item}</li>" for item in shown]
+        if truncated:
+            item_lines.append("          <li>and more</li>")
+        blocks.append((label, item_lines))
+
+    if blocks:
+        lines.append("      <description>")
+        for label, item_lines in blocks:
+            lines.append(f"        <p>{label}</p>")
+            lines.append("        <ul>")
+            lines.extend(item_lines)
+            lines.append("        </ul>")
+        lines.append("      </description>")
+
+    lines.append("    </release>")
+    return "\n".join(lines)
+
+
+def render_releases_block(releases):
+    chosen = [r for r in releases if selected(r["version"])]
+    chosen.sort(key=lambda r: r["version"], reverse=True)
+    body = "\n".join(render_release(r) for r in chosen)
+    return f"  <releases>\n{body}\n  </releases>"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--changelog", type=Path, default=REPO_ROOT / "CHANGELOG.md")
+    parser.add_argument("--appdata", type=Path,
+                        default=REPO_ROOT / "pythonscad.appdata.xml.in")
+    parser.add_argument("--check", action="store_true",
+                        help="exit non-zero if the file would change; make no edits")
+    args = parser.parse_args()
+
+    changelog = args.changelog.read_text(encoding="utf-8")
+    appdata = args.appdata.read_text(encoding="utf-8")
+
+    releases = parse_changelog(changelog)
+    if not releases:
+        print("Error: no releases parsed from changelog", file=sys.stderr)
+        return 1
+
+    new_block = render_releases_block(releases)
+    if not RELEASES_BLOCK_RE.search(appdata):
+        print(f"Error: no <releases> block found in {args.appdata}", file=sys.stderr)
+        return 1
+    updated = RELEASES_BLOCK_RE.sub(lambda _: new_block, appdata, count=1)
+
+    if updated == appdata:
+        return 0
+
+    if args.check:
+        print(f"{args.appdata} is out of date; run scripts/update-appdata-releases.py",
+              file=sys.stderr)
+        return 1
+
+    args.appdata.write_text(updated, encoding="utf-8")
+    print(f"Updated {args.appdata}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update-appdata-releases.py
+++ b/scripts/update-appdata-releases.py
@@ -53,6 +53,15 @@ SECTION_RE = re.compile(r"^### (.+?)\s*$")
 BULLET_RE = re.compile(r"^\* (.+?)\s*$")
 RELEASES_BLOCK_RE = re.compile(r"^[ \t]*<releases>.*?</releases>", re.DOTALL | re.MULTILINE)
 
+# A trailing "([text](url))" PR/commit reference group, anchored to the end.
+TRAILING_REF_RE = re.compile(r"\s*\(\[[^\]]+\]\([^)]+\)\)\s*$")
+# A trailing "closes/fixes [text](url)" issue reference, optionally wrapped in
+# parentheses (e.g. "(closes [#648](url))") and anchored to the end.
+TRAILING_CLOSES_RE = re.compile(
+    r",?\s*\(?(?:closes|fixes)\s+\[[^\]]+\]\([^)]+\)\)?\s*$", re.IGNORECASE)
+# An in-text markdown link "[text](url)" -> "text".
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+
 
 def parse_changelog(text):
     """Parse CHANGELOG.md into a list of release dicts (newest first)."""
@@ -97,12 +106,18 @@ def _xml_escape(text):
 
 def clean_bullet(text):
     """Turn a markdown changelog bullet into AppStream-safe inline text."""
-    # Drop trailing PR/commit reference groups, e.g. " ([#710](url))".
-    text = re.sub(r"\s*\(\[[^\]]+\]\([^)]+\)\)", "", text)
-    # Drop "closes #nnn" style trailers.
-    text = re.sub(r",?\s*closes\s*\[[^\]]+\]\([^)]+\)", "", text, flags=re.IGNORECASE)
-    # Flatten any remaining markdown links to their text.
-    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    # Strip trailing reference noise (PR/commit links and "closes #nnn"
+    # trailers). Anchored to the end and applied in a loop so several stacked
+    # trailers are removed (e.g. " ([#664](url)) ([8722c7b](url))" or
+    # "..., closes [#591](url)") without touching links in the middle of a
+    # bullet, which are legitimate content.
+    previous = None
+    while previous != text:
+        previous = text
+        text = TRAILING_REF_RE.sub("", text)
+        text = TRAILING_CLOSES_RE.sub("", text)
+    # Flatten any remaining (in-text) markdown links to their visible text.
+    text = MARKDOWN_LINK_RE.sub(r"\1", text)
     # Bold markers carry no meaning once flattened (used for scopes).
     text = text.replace("**", "")
     # CHANGELOG already HTML-escapes some characters; normalise to raw first.


### PR DESCRIPTION
## Summary

- Replace the 10 inherited OpenSCAD entries in `pythonscad.appdata.xml.in` with PythonSCAD's own minor/major releases (`0.6.0 … 1.0.0`), each with a short changelog, so Linux software centers (GNOME Software, KDE Discover, Flathub) show an accurate, current version history instead of OpenSCAD's `2011.12 … 2021.01`.
- Add `scripts/update-appdata-releases.py`, which generates the `<releases>` block from `CHANGELOG.md` (the release-please source of truth). Hybrid selection policy: minors-only through `1.0.0`, every release thereafter. Idempotent, with a `--check` mode.
- Extend `.github/workflows/release-please.yml`: when a release PR is open, regenerate the list and commit it onto the release PR branch, so the new `<release>` entry is already in the tree the moment the PR merges (and is tagged/released). Re-applies idempotently after release-please force-pushes.
- Guardrails: a `pre-commit` drift hook (`--check`, runs in CI via the existing `--all-files` pass) and a dedicated `validate-appdata.yml` workflow that renders the template and runs `appstreamcli validate --no-net`.

`openscad.appdata.xml.in` is intentionally left untouched (unused, kept to ease upstream syncing).

## How it stays current

```
commit on master → release-please opens/updates release PR (VERSION.txt + CHANGELOG.md)
                 → same workflow regenerates <releases>, commits onto the PR branch
merge PR         → release-please tags + releases; the released tree already contains the entry
```

## Test plan

- [x] `appstreamcli validate --no-net` passes on the rendered metainfo (only pre-existing `developer-name` deprecation infos remain)
- [x] `xmllint --noout` confirms well-formed XML
- [x] Generator is idempotent (`--check` clean after generation)
- [x] `actionlint` + `zizmor --min-severity=high` clean on both workflows
- [x] Full `pre-commit` hook set passes on changed files
- [x] Confirm CI green on the PR

Made with [Cursor](https://cursor.com)