### PR TITLE
fix(wasm): compile svg target with -fPIC for web build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,45 @@ fix(python): resolve memory leak in pyopenscad module
 docs: update build instructions for Ubuntu 24.04
 ```
 
+### Issue and PR Conventions
+
+**CRITICAL:** Every new issue and pull request MUST be properly categorized.
+When creating an issue or PR (whether by hand or via `gh`), always set:
+
+- **Labels** — apply at least one descriptive label that matches the change
+  (e.g. `bug`, `enhancement`, `build`, `ci`, `docs`, `refactor`, `perf`,
+  `test`, `dependencies`, `security`, `UI/UX`). Never leave an issue or PR
+  unlabeled.
+- **Assignee** — by default, assign the issue/PR to the person actually
+  working on it (the author). Do not leave work items unassigned.
+- **Issue type** (issues only) — set the correct GitHub issue type. The
+  available types are:
+  - `Bug` — an unexpected problem or behavior.
+  - `Feature` — a request, idea, or new functionality.
+  - `Task` — a specific piece of work that is neither a bug nor a feature.
+
+Set a milestone when the work is targeted at a specific release.
+
+Examples:
+
+```bash
+# Create a labeled, typed, assigned, milestoned issue
+gh issue create \
+  --title "fix(wasm): svg target not compiled with -fPIC" \
+  --label bug --label build \
+  --assignee @me \
+  --milestone "Prominentio v1.1.0" \
+  --body "..."
+# Issue type is org-level; set it via the API or the web UI after creation.
+
+# Create a labeled, assigned PR
+gh pr create --title "..." --label bug --label build --assignee @me --body "..."
+```
+
+GitHub issue *types* are an organization-level field separate from labels and
+are not settable with `gh issue create` flags; set the type through the issue's
+web UI or the GraphQL/REST API after the issue exists.
+
 ### Pre-commit Hooks
 
 The project uses pre-commit hooks that run automatically:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,11 @@ if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
   # https://emscripten.org/docs/tools_reference/emcc.html
   # https://emscripten.org/docs/tools_reference/settings_reference.html
   target_compile_options(OpenSCADLibInternal PUBLIC -fexceptions -fPIC)
+  # The svg target was created before CMAKE_POSITION_INDEPENDENT_CODE is set
+  # above, so (unlike OpenSCADLibInternal) it never inherited -fPIC. Under the
+  # web build's -sMAIN_MODULE=2 (a PIC main module) its non-PIC exception
+  # relocations fail to link, so set the flags on it explicitly here too.
+  target_compile_options(svg PUBLIC -fexceptions -fPIC)
   target_link_options(OpenSCADExe PUBLIC
     -fexceptions
     -sABORT_ON_WASM_EXCEPTIONS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,10 +319,12 @@ if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
   # https://emscripten.org/docs/tools_reference/emcc.html
   # https://emscripten.org/docs/tools_reference/settings_reference.html
   target_compile_options(OpenSCADLibInternal PUBLIC -fexceptions -fPIC)
-  # The svg target was created before CMAKE_POSITION_INDEPENDENT_CODE is set
-  # above, so (unlike OpenSCADLibInternal) it never inherited -fPIC. Under the
-  # web build's -sMAIN_MODULE=2 (a PIC main module) its non-PIC exception
-  # relocations fail to link, so set the flags on it explicitly here too.
+  # Both svg and OpenSCADLibInternal were created before
+  # CMAKE_POSITION_INDEPENDENT_CODE is set above, so neither inherits PIC from
+  # it. OpenSCADLibInternal gets -fPIC from the explicit option on the line
+  # above; svg had no such line, so under the web build's -sMAIN_MODULE=2 (a PIC
+  # main module) its non-PIC exception relocations fail to link. Give svg the
+  # same flags explicitly.
   target_compile_options(svg PUBLIC -fexceptions -fPIC)
   target_link_options(OpenSCADExe PUBLIC
     -fexceptions


### PR DESCRIPTION
## Summary

- The WASM **web** build (`-DWASM_BUILD_TYPE=web`, which links with `-sMAIN_MODULE=2`) failed at the final link step with `relocation R_WASM_TABLE_INDEX_SLEB cannot be used against symbol __cxa_throw; recompile with -fPIC` against `libsvg.a`.
- Root cause: `CMAKE_POSITION_INDEPENDENT_CODE ON` and the explicit `-fPIC` on `OpenSCADLibInternal` were added in #777, but the `svg` target was created earlier (before that line) and so never inherited PIC nor received an explicit flag. #793 then rearranged the link sets so `libsvg`'s exception-carrying object files are now pulled into the `MAIN_MODULE` link, surfacing the latent error.
- Fix: compile the `svg` target with `-fexceptions -fPIC` in the Emscripten block, mirroring `OpenSCADLibInternal`.

This PR also updates `CLAUDE.md` to require that new issues and PRs always carry descriptive labels, are assigned to the person working on them by default, and that issues use the correct GitHub issue type.

Closes #797

## Test plan

- [x] `pre-commit run --files CLAUDE.md CMakeLists.txt` passes
- [x] Web variant builds clean: `./scripts/wasm-base-docker-run.sh cmake --build build-wasm-web -j$(nproc)` → `[100%] Built target OpenSCADExe`, producing `pythonscad.js` / `.wasm` / `.data`, with no `wasm-ld` / `-fPIC` errors
- [ ] CI green

Made with [Cursor](https://cursor.com)