### PR TITLE
fix(gui): launch gvim reliably as external editor

### DIFF
--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.24\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2015-03-06 10:27+0100\n"
 "Last-Translator: Miro Hrončok <miro@hroncok.cz>\n"
 "Language-Team: Czech <miro@hroncok.cz>\n"
@@ -96,7 +96,7 @@ msgstr "Ukládat obrázky"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Předvolby"
 
@@ -254,7 +254,7 @@ msgid "TextLabel"
 msgstr "za textem"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Aktualizace"
 
@@ -359,23 +359,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -417,7 +417,7 @@ msgstr "Barevné téma:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "vždy stejný"
@@ -495,8 +495,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgid "Clear console"
 msgstr "Konzole"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 #, fuzzy
 msgid "Save As..."
 msgstr "Uložit &jako..."
@@ -799,7 +799,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr ""
 
@@ -1180,7 +1180,7 @@ msgid "Font path"
 msgstr "Písmo"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Styl"
 
@@ -2034,7 +2034,7 @@ msgid "E&xport"
 msgstr "&Exportovat"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2153,7 +2153,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2195,7 +2195,7 @@ msgid "Form"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr ""
 
@@ -2254,754 +2254,763 @@ msgstr ""
 msgid "More actions"
 msgstr "&Dokumentace"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D zobrazení"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 #, fuzzy
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Editor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Funkce"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Povolit/Zakázat experimentální funkce"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 #, fuzzy
 msgid "Axes"
 msgstr "Zobrazit osy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Barevné téma:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Zobrazovat varování a chyby v 3D okně"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 #, fuzzy
 msgid "Alt"
 msgstr "Vše"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 #, fuzzy
 msgid "Step Size"
 msgstr "Velikost"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Zalamování řádek"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "vypnout"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "zalamovat na úrovni znaků"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "zalamovat na úrovni slov"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Odsazení zalomených řádek"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Pozice symbolu zalomení"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "jako počátek"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "odsazený"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "odsadí"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Začátek"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "za textem"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "konec řádky"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "levý okraj"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Konec"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Vzhled"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Zvýrazňovat aktuální řádek"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Zvýrazňovat párové závorky"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Písmo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Barva zvýrazňování syntaxe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd a kolečko myši mění velikost písma"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(vyžaduje restart aplikace)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Odsazování"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Automatické odsazování"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Odsazovat pomocí"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "mezer"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "tabulátorů"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Velikost odsazení"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Šířka tabulátoru"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Funkce klávesy tabulátor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "vloží znak tabulátoru"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Zobrazovat mazery"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "nikdy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "vždy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "pouze za odsazením"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Velikost"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Automaticky vyhledávat aktualizace"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Včetně nestabilních verzí"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Zkontrolovat nyní"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Poslední kontrola:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 msgid "Default Print Service"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 #, fuzzy
 msgid "Check"
 msgstr "Zkontrolovat nyní"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 #, fuzzy
 msgid "Action"
 msgstr "Aplikace"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 #, fuzzy
 msgid "Show"
 msgstr "Zobrazit osy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Aplikace"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Soubor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Zobrazovat varování o vlastnostech"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Vypnout renderování při"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "prvcích"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Vynutit zobrazení Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "Vy&renderovat"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 #, fuzzy
 msgid "Backend"
 msgstr "Zezadu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Velikost CGAL cache"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Velikost PolySet cache"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "Z&prava"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
-msgid "Auto (follow system)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
-#, fuzzy
-msgid "Enable docking helper widgets in different places"
-msgstr "Povolit zaparkování editoru a konzole na různá místa"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
-#, fuzzy
-msgid "Enable undocking of helper widgets to separate windows"
-msgstr "Povolit plovoucí editor a konzoli"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
-msgid "Show Welcome Screen"
-msgstr "Zobrazovat uvítací obrazovku"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
-msgid "Enable user interface localization (requires restart of PythonSCAD)"
-msgstr "Povolit lokalizaci rozhraní PythonSCADu (vyžaduje restart aplikace)"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
-msgid "Bring window to front after automatic reload"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
-msgid "Play sound notification on render complete"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
-msgid "Play sound when render completion time is at least"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
-msgid "sec"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
-msgid "When launching another instance with files:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
-msgid "Enable session management (save/restore tabs on quit, requires restart)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
-msgid "Autosave session in background for crash recovery"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
-msgid "Autosave interval:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
-msgid "Console"
-msgstr "Konzole"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
-msgid "Clear console before Preview/Render"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
-msgid "Maximum lines for Console to keep:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
-msgid "(0 for unlimited)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
-#, fuzzy
-msgid "Customizer"
-msgstr "Skrýt &terminál"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
-msgid "OpenSCAD Language Features"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
-#, fuzzy
-msgid "Warnings"
-msgstr "OpenGL varování"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
-msgid "Stop on the first warning"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
-msgid "Check the parameter range for builtin modules"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
-msgid "Warn when there is a parameter mismatch in user module calls"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
-msgid "Trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
-msgid "Trace depth:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
-msgid "(max. number or trace messages)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
-msgid "Show parameters of usermodule calls in trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
-msgid "Render Summary"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
-msgid "Camera"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
-msgid "Bounding Box"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
-msgid "Measurements: Area"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
-msgid "Measurements: Volume"
+msgid "Auto (follow system)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
-msgid "Export Features"
-msgstr "Funkce"
+msgid "Enable docking helper widgets in different places"
+msgstr "Povolit zaparkování editoru a konzole na různá místa"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
-msgid "Toolbar Export 3D"
-msgstr ""
+#, fuzzy
+msgid "Enable undocking of helper widgets to separate windows"
+msgstr "Povolit plovoucí editor a konzoli"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
-msgid "Toolbar Export 2D"
-msgstr ""
+msgid "Show Welcome Screen"
+msgstr "Zobrazovat uvítací obrazovku"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
-msgid "Debugging"
-msgstr ""
+msgid "Enable user interface localization (requires restart of PythonSCAD)"
+msgstr "Povolit lokalizaci rozhraní PythonSCADu (vyžaduje restart aplikace)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
-msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
+msgid "Bring window to front after automatic reload"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
-msgid "Network Import List"
+msgid "Play sound notification on render complete"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
-msgid "Globally trust Python designs"
+msgid "Play sound when render completion time is at least"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
-msgid "Really (very dangerous)"
+msgid "sec"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
-msgid "Dialog visibility"
+#: src/gui/Preferences.cc:419
+msgid "When launching another instance with files:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
-msgid "Always show PDF export dialog"
+#: src/gui/Preferences.cc:421
+msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
-msgid "Always show 3MF export dialog"
+#: src/gui/Preferences.cc:423
+msgid "Autosave session in background for crash recovery"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
-msgid "Always show SVF export dialog"
+#: src/gui/Preferences.cc:424
+msgid "Autosave interval:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
-msgid "Always show GCODE export dialog"
-msgstr ""
+msgid "Console"
+msgstr "Konzole"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
-msgid "Always show Print Service dialog"
+msgid "Clear console before Preview/Render"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+msgid "Maximum lines for Console to keep:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+msgid "(0 for unlimited)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#, fuzzy
+msgid "Customizer"
+msgstr "Skrýt &terminál"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+msgid "OpenSCAD Language Features"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#, fuzzy
+msgid "Warnings"
+msgstr "OpenGL varování"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+msgid "Stop on the first warning"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+msgid "Check the parameter range for builtin modules"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+msgid "Warn when there is a parameter mismatch in user module calls"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+msgid "Trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+msgid "Trace depth:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
+msgid "(max. number or trace messages)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
+msgid "Show parameters of usermodule calls in trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
+msgid "Render Summary"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
+msgid "Camera"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
+msgid "Bounding Box"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
+msgid "Measurements: Area"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
+msgid "Measurements: Volume"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
+#, fuzzy
+msgid "Export Features"
+msgstr "Funkce"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
+msgid "Toolbar Export 3D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
+msgid "Toolbar Export 2D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
+msgid "Debugging"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
+msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
+msgid "Network Import List"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
+msgid "Globally trust Python designs"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
+msgid "Really (very dangerous)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
+msgid "Dialog visibility"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
+msgid "Always show PDF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
+msgid "Always show 3MF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
+msgid "Always show SVF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
+msgid "Always show GCODE export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
+msgid "Always show Print Service dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Předvolby"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 msgid "Profiles"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 msgid "Active Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Soubor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 msgid "API Parameters"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 msgid "Add Parameter"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 msgid "Remove Parameter"
 msgstr ""
 
@@ -3163,55 +3172,18 @@ msgstr ""
 "Pohled: posun = [ %.2f %.2f %.2f ], rotace = [ %.2f %.2f %.2f ], vzdálenost "
 "= %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3541,76 +3513,64 @@ msgstr ""
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 msgid "Parameter Key"
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 msgid "Parameter Value"
 msgstr ""
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr ""
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr ""
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 #, fuzzy
 msgid "Error"
 msgstr "Skrýt nástrojové lišty"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Soubor"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "&Soubor"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "Duplicate Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3713,55 +3673,55 @@ msgstr ""
 "%1 již existuje.\n"
 "Chcete jej nahradit?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Soubor"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 #, fuzzy
 msgid "Close Tab"
 msgstr "Zavřít"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Chcete uložit změny?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Příště nezobrazovat"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3770,15 +3730,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3788,7 +3748,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3797,40 +3757,40 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 #, fuzzy
 msgid "Failed to open file for writing"
 msgstr "Nepodařilo se otevřít soubor %s: %s"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr ""
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Uložit soubor"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Uložit &jako..."
@@ -3906,7 +3866,7 @@ msgstr ""
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "O aplikaci PythonSCAD"
@@ -3933,19 +3893,19 @@ msgstr "Začátek"
 msgid "Show File"
 msgstr "Zobrazit pravítko"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3953,19 +3913,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4177,9 +4137,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "Editor QScintilla"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(vyžaduje restart aplikace)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "Povolit současné otevření více dokumentů"

--- a/locale/de.po
+++ b/locale/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2014.01.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2021-12-04 20:17+0100\n"
 "Last-Translator: Torsten Paul <Torsten.Paul@gmx.de>\n"
 "Language-Team: German\n"
@@ -107,7 +107,7 @@ msgstr "Bilder ausgeben"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -266,7 +266,7 @@ msgid "TextLabel"
 msgstr "TextLabel"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Aktualisieren"
 
@@ -379,23 +379,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Löschen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -437,7 +437,7 @@ msgstr "Farbschema:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Fest"
@@ -515,8 +515,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -563,7 +563,7 @@ msgid "Clear console"
 msgstr "Konsole löschen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "Speichern &Unter..."
 
@@ -817,7 +817,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -1201,7 +1201,7 @@ msgid "Font path"
 msgstr "Font"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Stil"
 
@@ -2037,7 +2037,7 @@ msgid "E&xport"
 msgstr "&Exportieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2153,7 +2153,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgid "Form"
 msgstr "Form"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Parameter"
 
@@ -2260,752 +2260,761 @@ msgstr "-"
 msgid "More actions"
 msgstr "Rotation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D Ansicht"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Editor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Funktionen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Experimentelle Erweiterungen ein-/ausschalten"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Achsen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Treiberkonfiguration und Achsenzuordnung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Knöpfe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "3D-Druck"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "3D-Druckdienstleister"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Farbschema:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Fehler und Warnungen in der 3D Ansicht anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "Vergrößern an Maus zentrieren"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr "Number Scroll"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr "Alt"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "Left Mouse Button"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "Either"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr "Schrittgröße"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "Number Scroll Via Mouse Wheel"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr "Modifier For Wheel Scroll "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "Automatisch vervollständigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr "Zeichengrenze"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "Automatisches Vervollständigen einschalten"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Zeilenumbruch"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Nie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "An jedem Zeichen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "An Wörtern"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Einrückung nach Zeilenumbruch"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Zeilenumbruch anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Wie vorherige Zeile"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Eingerückt"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Einrücken"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Anfang"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Text"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Rand"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Seitenrand"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Ende"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Anzeige"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Aktuelle Zeile hervorheben"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Zusammengehörige Klammern hervorheben"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Font"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Syntaxhervorhebung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd+Mausrad zum Vergrößern des Textes benutzen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(Neustart erforderlich)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Einrückung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Automatisch einrücken"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Backspace verringert Einzug"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Einrücken mit"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Leerzeichen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Tabs"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Einrückungstiefe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Tabulatorschrittweite"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Funktion der Tab-Taste"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Tab einfügen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Formatierungsymbole anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Nie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Immer"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Nur nach Einrückung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Größe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Automatisch nach Aktualisierungen suchen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Entwickler-Versionen einschließen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Jetzt suchen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Zuletzt gesucht: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "3D-Druckdienstleister"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "API Key"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Laden"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Prüfen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Slicing Profil"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Slicing Engine"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Datei Format"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Aktion"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 "Hinweis: Der API Key wird unverschlüsselt in den Einstellungen gespeichert."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Application"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Datei"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Kompatibilitätswarnung anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Rendern abbrechen ab "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "Elementen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Goldfeather Algorithmus erzwingen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "&Rendern"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 #, fuzzy
 msgid "Backend"
 msgstr "Hinten"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "CGAL Cache Größe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "PolySet Cache Größe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Benutzerinterface"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "&Rechts"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Verschieben des Editor und Konsolen-Fensters erlauben"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr "Separate Editor und Konsolen-Fenster erlauben"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Startbildschirm anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr "Lokalisierung der GUI einschalten (benötigt Neustart von PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "Fenster nach vorne bringen nach automatischem Neuladen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "Ton abspielen wenn rendern abgeschlossen ist"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr "Ton abspielen wenn das Rendern abgeschlossen ist"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "sec"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Konsole"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr "Maximale Anzahl von Zeilen in der Konsole:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr "(0 = unbegrenzt)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "Customizer"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "OpenSCAD Spracheigenschaften"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 #, fuzzy
 msgid "Warnings"
 msgstr "OpenGL Warnung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "Bei erster Warnung abbrechen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "Parameter Bereiche für System-Module prüfen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr "Warnen bei nicht übereinstimmenden Parametern"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr "Zusammenfassung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr "Kamera"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr "Begrenzungsrahmen "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr "Messungen: Fläche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 #, fuzzy
 msgid "Measurements: Volume"
 msgstr "Messungen: Fläche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr "Export Features"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "Fehlersuche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr "Protokoll für HIDAPI einschalten (benötigt Neustart von PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Einstellungen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Slicing Profil"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Slicing Profil"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Neue Datei"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Parameter"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Parameter"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Parameter"
@@ -3171,55 +3180,18 @@ msgstr ""
 "Ansicht: Verschiebung = [ %.2f %.2f %.2f ], Rotation = [ %.2f %.2f %.2f ], "
 "Abstand = %.2f, Sichtfeld = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3556,79 +3528,67 @@ msgstr "Bitte einen Namen für diese Voreinstellung eingeben"
 msgid "New set "
 msgstr "Neue Parameter Liste"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Parameter"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Parameter"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<Standard>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Erfolg: Server Version = %2, API Version = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Fehler"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Neue Datei"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "Dateiname kopieren"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Slicing Profil"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "A profile with that name already exists."
 msgstr "Set %1 existiert bereits"
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3732,54 +3692,54 @@ msgstr ""
 "%1 existiert bereits.\n"
 "Möchten Sie die Datei ersetzen?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "Dateiname kopieren"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "Pfad kopieren"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Datei öffen"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr "Reiter schließen"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Möchten Sie die Änderungen speichern?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Dialog nicht wieder anzeigen"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3788,15 +3748,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3806,7 +3766,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3815,39 +3775,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Datei konnte nicht zum schreiben geöffnet werden"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Fehler beim speichern des Designs"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Speichern Unter..."
@@ -3926,7 +3886,7 @@ msgstr "Datei\"%1$s\" konnte nicht zum Export geöffnet werden"
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\" Schreibfehler. (Speicher voll?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "Über PythonSCAD"
@@ -3953,19 +3913,19 @@ msgstr "Anfang"
 msgid "Show File"
 msgstr "Axen&einteilung anzeigen"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3973,7 +3933,7 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
@@ -3981,7 +3941,7 @@ msgstr ""
 "PythonSCAD läuft bereits, reagiert jedoch nicht. Der alte PythonSCAD-Prozess "
 "muss beendet werden, um ein neues Fenster zu öffnen."
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
@@ -3989,7 +3949,7 @@ msgstr ""
 "Wiederholen Sie den Versuch, wenn die laufende Instanz wieder reagieren "
 "könnte, oder beenden Sie sie, um eine neue zu starten."
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr "PythonSCAD schließen"
 
@@ -4328,9 +4288,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "QScintilla Editor"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(Neustart erforderlich)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "Öffnen von mehreren Dokumenten erlauben"

--- a/locale/es.po
+++ b/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2025-04-10 09:14-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: Español\n"
@@ -104,7 +104,7 @@ msgstr "Grabar imágenes"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -255,7 +255,7 @@ msgid "TextLabel"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Actualizar"
 
@@ -360,23 +360,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -417,7 +417,7 @@ msgstr "Paleta de colores:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Ajustar"
@@ -495,8 +495,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -543,7 +543,7 @@ msgid "Clear console"
 msgstr "Limpiar consola"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "Guardar Como..."
 
@@ -796,7 +796,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgid "Font path"
 msgstr "Lista de &Fuentes"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Estilo"
 
@@ -1997,7 +1997,7 @@ msgid "E&xport"
 msgstr "E&xportar"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2113,7 +2113,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgid "Form"
 msgstr "Formulario"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Parámetro"
 
@@ -2210,749 +2210,758 @@ msgstr ""
 msgid "More actions"
 msgstr "Anotaciones"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "Vista 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Editar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Características"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Activar/Desactivar características experimentales"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Ejes"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Paleta de colores:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Mostrar errores y advertencias en la vista 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Ajuste de línea"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Nada"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Ajustar a los límites de caracteres"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Ajustar a los límites de las palabras"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Ajuste de línea en el sangrado"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Visualización del ajuste de línea"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Mismo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Sangrado"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Indentar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Inicio"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Texto"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Borde"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Margen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Final"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Mostrar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Marcar línea actual"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Mostrar números de línea"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Habilitar alineamiento forzado"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Fuente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Colorear sintaxis"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd + la rueda del mouse para hacer zoom al texto"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(necesita reiniciar)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Indentación"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Sangría automática"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Indentar usando"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Espacio"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Pestañas"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Ancho de indentado"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Ancho de la pestaña"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Atajo de pestaña"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Insertar pestaña"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Mostrar espacios en blanco"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Nunca"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Siempre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Sólo después de la indentación"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Tamaño"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Comprobar automáticamente actualizaciones"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Incluir las versiones en desarrollo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Comprobar ahora"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Última verificación: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 msgid "Default Print Service"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Comprobar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Acción"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Mostrar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Aplicación"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Archivo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Mostrar advertencias de capacidad"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Desactivar el render en "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "elementos"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Forzar Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "R&enderizar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 #, fuzzy
 msgid "Backend"
 msgstr "Atrás"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Tamaño de caché de CGAL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Tamaño de caché de PolySet"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "&Derecha"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Habilitar soporte de editor y consola en diferentes lugares"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr ""
 "Habilitar el desacoplamiento de editor y consola para separar las ventanas"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Mostrar pantalla de bienvenida"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
 "Habilitar adaptación local de la interfaz de usuario (necesita reiniciar "
 "PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Consola"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 msgid "Warnings"
 msgstr "Advertencias"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 msgid "Measurements: Volume"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Preferencias"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 msgid "Profiles"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 msgid "Active Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Nuevo Archivo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Parámetro"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Parámetro"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Parámetro"
@@ -3112,55 +3121,18 @@ msgstr ""
 "Ventana: traslado = [ %.2f %.2f %.2f ], rotación = [ %.2f %.2f %.2f ], "
 "distancia = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3477,77 +3449,65 @@ msgstr ""
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Parámetro"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Parámetro"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr ""
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr ""
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr ""
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Nuevo Archivo"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "Paleta de colores:"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "Duplicate Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3650,54 +3610,54 @@ msgstr ""
 "%1 ya existe.\n"
 "Desea reemplazarlo?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "Abrir Archiv&o"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "¿Desea guardar los cambios?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "No mostrar de nuevo"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3706,15 +3666,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3724,7 +3684,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3733,39 +3693,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr ""
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Guardar como..."
@@ -3840,7 +3800,7 @@ msgstr ""
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "Acerca de PythonSCAD"
@@ -3867,19 +3827,19 @@ msgstr "Inicio"
 msgid "Show File"
 msgstr "Mostrar Uso de la Escala"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3887,19 +3847,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4086,9 +4046,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "Editor QScintilla"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(necesita reiniciar)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "Permitir abrir varios documentos"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.07\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2019-09-17 \n"
 "Last-Translator: Pierre ROUZEAU <github.com/PRouzeau>\n"
 "Language-Team: French\n"
@@ -107,7 +107,7 @@ msgstr "Exporter images"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Préférences"
 
@@ -260,7 +260,7 @@ msgid "TextLabel"
 msgstr "Texte"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Mettre à jour"
 
@@ -373,23 +373,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Effacer"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr "Palette de couleurs:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Fixé"
@@ -509,8 +509,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -557,7 +557,7 @@ msgid "Clear console"
 msgstr "Effacer la console"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 #, fuzzy
 msgid "Save As..."
 msgstr "Enregistrer &sous..."
@@ -814,7 +814,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -1195,7 +1195,7 @@ msgid "Font path"
 msgstr "Police"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Style"
 
@@ -2055,7 +2055,7 @@ msgid "E&xport"
 msgstr "E&xporter"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2173,7 +2173,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2225,7 +2225,7 @@ msgid "Form"
 msgstr "Formulaire"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Paramètre"
 
@@ -2283,761 +2283,770 @@ msgstr "-"
 msgid "More actions"
 msgstr "Rotation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "&Vue 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Avancé"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Éditeur"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Fonctionnalités"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Activer/Désactiver les fonctionnalités expérimentales"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Axes"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Configuration des pilotes et de l'association des axes"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Boutons"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "Impression 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "Services d'impression 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Palette de couleurs:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Afficher les Avertissements et les Erreurs dans la fenêtre de rendu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "Zoom centré sur le pointeur"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 #, fuzzy
 msgid "Alt"
 msgstr "Tout"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 #, fuzzy
 msgid "Step Size"
 msgstr "Taille"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Retour à la ligne automatique"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Aucun"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Coupure au caractère"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Coupure au mot"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Indentation des retours à la ligne"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Visualisation des retours à la ligne"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Identique"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Indenté"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Indenter"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Début"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Texte"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Bordure"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Marge"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Fin"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Afficher"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Surligner la ligne courante"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Afficher les numéros de ligne"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Activer la correspondance d'accolades"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Police"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Utiliser la coloration syntaxique"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-Roulette-Souris agrandit le texte"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(nécessite un redémarrage)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Indentation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Indentation automatique"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "La touche \"effacement\" retire l'indentation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Indenter en utilisant"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Espaces"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Tabulations"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Largeur d'Indentation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Largeur des tabulations"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Fonction de la touche Tab"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Insérer une Tabulation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Afficher les espaces blancs"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Jamais"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Toujours"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Seulement après indentation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Taille"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Vérifier les mises à jour automatiquement"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Inclure les versions de développement"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Vérifier Maintenant"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Dernière vérification: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "Services d'impression 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "Clé API"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Charge"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Vérifie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Profil de tranchage"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Trancheur"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Format de fichier"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Action"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Montre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 "Note: La clé API n'est pas chiffrée dans l'enregistrement des préférences"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Application"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Fichier"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Afficher les avertissements de fonctionnalité"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Désactiver le rendu à "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "éléments"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Forcer Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "Calculer le r&endu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 #, fuzzy
 msgid "Backend"
 msgstr "Arrière"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Taille du Cache de CGAL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "Mo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Taille du Cache PolySet"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Interface utilisateur"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "Vue de droite"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Activer l'ancrage de l'Éditeur et de la Console à différents endroits"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr ""
 "Activer désancrage de l'Éditeur et de la Console dans des fenêtres séparés"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Affiche l'écran d'accueil"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
 "Activer la localisation de l'interface utilisateur (Nécessite un redémarrage "
 "de PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "Afficher la fenêtre en premier plan après un rechargement automatique"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "Jouer un son de notification lorsque le rendu est terminé"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 #, fuzzy
 msgid "Play sound when render completion time is at least"
 msgstr "Jouer un son de notification lorsque le rendu est terminé"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Console"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "Panneau de personnalisation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "Fonctionnalités du langage OpenSCAD"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 #, fuzzy
 msgid "Warnings"
 msgstr "Avertissements OpenGL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "Arrêter après la première alerte"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 #, fuzzy
 msgid "Check the parameter range for builtin modules"
 msgstr "Vérifier la plage de paramètre(s) pour les modules incorporés"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr ""
 "Alerter lorsqu'il y des paramètres incompatibles dans les appels de modules "
 "utilisateurs"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 msgid "Measurements: Volume"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 #, fuzzy
 msgid "Export Features"
 msgstr "Fonctionnalités"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Préférences"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Profil de tranchage"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Profil de tranchage"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Fichier"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Paramètre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Paramètre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Paramètre"
@@ -3202,55 +3211,18 @@ msgstr ""
 "Fenêtre de rendu: translation = [ %.2f %.2f %.2f ], rotation = [ %.2f %.2f "
 "%.2f ], distance = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3590,80 +3562,68 @@ msgstr "Entrer le nom du jeu de paramètres"
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Paramètre"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Paramètre"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 #, fuzzy
 msgid "<Default>"
 msgstr "valeurs de conception par défaut"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Succès: Version serveur = %2, Version API = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Erreur"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Fichier"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "&Fichier"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Profil de tranchage"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "A profile with that name already exists."
 msgstr "Le jeu de paramètres \"%1\" existe déjà"
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3767,55 +3727,55 @@ msgstr ""
 "%1 existe déjà.\n"
 "Voulez-vous le remplacer?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Fichier"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 #, fuzzy
 msgid "Close Tab"
 msgstr "Fermer"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Voulez-vous enregistrer vos changements?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Ne plus afficher"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3824,15 +3784,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3842,7 +3802,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3851,39 +3811,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Échec d'ouverture de fichier en écriture"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Erreur lors de l'enregistrement de la conception"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Enregistrer le Fichier"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Enregistrer &sous..."
@@ -3961,7 +3921,7 @@ msgstr "Ne peut pas ouvrir le fichier \"%1$s\" pour exportation"
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "ERREUR: \"%1$s\" erreur d'écriture. (Disque plein?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "À propos de PythonSCAD"
@@ -3988,19 +3948,19 @@ msgstr "Début"
 msgid "Show File"
 msgstr "Afficher les graduations"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -4008,19 +3968,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4359,9 +4319,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "Éditeur QScintilla"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(nécessite un redémarrage)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "Autoriser l'ouverture de plusieurs documents"

--- a/locale/hy.po
+++ b/locale/hy.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2020.02.01\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2020-04-20 17:00+0400\n"
 "Last-Translator: Sargis Malkonyan <melkonyansarg@gmail.com>\n"
 "Language-Team: Agarak Armath Engineering Laboratories\n"
@@ -102,7 +102,7 @@ msgstr "Թափոն նկարները"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Կարգավորումներ"
 
@@ -256,7 +256,7 @@ msgid "TextLabel"
 msgstr "Տեքստ"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Թարմացնել"
 
@@ -369,23 +369,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Մաքրել"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -427,7 +427,7 @@ msgstr "Գունային համակարգ։"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Ֆիքսված"
@@ -505,8 +505,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -552,7 +552,7 @@ msgid "Clear console"
 msgstr "Մաքրել հրամանների վահանակը"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 #, fuzzy
 msgid "Save As..."
 msgstr "Պահել &որպես..."
@@ -809,7 +809,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Չեղարկել"
 
@@ -1190,7 +1190,7 @@ msgid "Font path"
 msgstr "Տառատեսակ"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Ոճ"
 
@@ -2046,7 +2046,7 @@ msgid "E&xport"
 msgstr "&Արտահանել"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2164,7 +2164,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgid "Form"
 msgstr "Ձև"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Պարամետր"
 
@@ -2274,755 +2274,764 @@ msgstr "-"
 msgid "More actions"
 msgstr "Պտտում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D տեսք"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Առաջատար"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Խմբագիր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Հնարավորություններ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Միացնել/Անջատել փորձնական հնարավորությունները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Առանցքներ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Ներմուծել driver֊ի կարգաբերումը և առանցքների տեղորոշումը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Կոճակներ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "Եռաչափ տպագրություն"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "Եռաչափ տպագրության ծառայություններ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Գունային համակարգ։"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Ցուցադրել զգուշացումները և սխալները 3D տեսքով"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "մկնիկի կենտրոնային խոշորացում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 #, fuzzy
 msgid "Alt"
 msgstr "Ամբողջը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 #, fuzzy
 msgid "Step Size"
 msgstr "Չափս"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Գծի փաթաթում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Ոչ մեկը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Փաթեավորել կերպարի սահմանները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Պահել բառի սահմաններում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Կտրել գծի սահմանում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Գծի փաթեթավորման վիզուալիզացիա"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Նույնությամբ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Ատամնավոր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Կտրվածք"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Մեկնարկ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Տեքստ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Սահման"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Եզրեր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Վերջ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Ցուցադրել"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Ընդգծել այս գիծը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Ցուցադրել գծի համարները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Միացնել փակագծի համընկնումը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Տառատեսակ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Գունային այլագրի առանձնացում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-Mouse-wheel zooms text"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(Անհրաժեշտ է վերագործարկել)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Կտրվածքների պատրաստում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Ավտոմատ կտրվածք"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Backspace unindents"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Օգտագործել կտրվածքը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Տարածքներ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Ներդիրներ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Կտրվածքի հաստություն"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Ներդիրի հաստություն"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Ներդիրի ստեղնի գործառույթ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Տեղադրել ներդիր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Ցուցադրել դատարկ տարածքները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Երբեք"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Մշտապես"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Միայն կտրատումից հետո"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Չափս"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Ինքնուրույն ստուգել թարմացումները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Ներառել ծրագրավորման դրվագները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Ստուգել հիմա"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Վերջին ստուգումը:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "Եռաչափ տպագրության ծառայություններ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "API Key"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Բեռնել"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Ստուգել"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Շերտավորել պրոֆիլը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Շերտավորել գործիքը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Նիշքի ձևաչափը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Գործողություն"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Ցույց տալ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "Նշում:  API֊ի կոճակը գաղտնագրով պահված է հավելվածի կարգաբերումներում."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Ծրագիր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Նիշք"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Ցուցադրել հնարավոր զգուշացումները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Անջատել տարածումը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "տարրեր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Ստիպել Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "Հրապարակել"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "CGAL֊ի «քեշ»- ի չափը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "ՄԲ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "PolySet֊ի «քեշ»- ի չափը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Միջերես"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "&Աջ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
-msgid "Auto (follow system)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
-#, fuzzy
-msgid "Enable docking helper widgets in different places"
-msgstr "Միացնել խմբագրիչի եւ կառավարման վահանակի պահումը տարբեր տեղերում"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
-#, fuzzy
-msgid "Enable undocking of helper widgets to separate windows"
-msgstr "Անջատել խմբագրիչի եւ կառավարման վահանակի պահումը տարբեր պատուհաններում"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
-msgid "Show Welcome Screen"
-msgstr "Ցույց տալ ԲԱՐԻ ԳԱԼՈՒՍՏ֊ը"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
-msgid "Enable user interface localization (requires restart of PythonSCAD)"
-msgstr ""
-"Միացնել միջերեսի տեղայնացումը (պահանջում է PythonSCAD֊ի վերագործարկում)"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
-msgid "Bring window to front after automatic reload"
-msgstr "Բերել պատուհանը առջևի մաս  ավտոմատ բեռնումից հետո"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
-msgid "Play sound notification on render complete"
-msgstr "Ձայնով ծանուցել նիշքի վերարտադրումից հետո"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
-#, fuzzy
-msgid "Play sound when render completion time is at least"
-msgstr "Ձայնով ծանուցել նիշքի վերարտադրումից հետո"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
-msgid "sec"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
-msgid "When launching another instance with files:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
-msgid "Enable session management (save/restore tabs on quit, requires restart)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
-msgid "Autosave session in background for crash recovery"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
-msgid "Autosave interval:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
-msgid "Console"
-msgstr "Վահանակ"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
-msgid "Clear console before Preview/Render"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
-msgid "Maximum lines for Console to keep:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
-msgid "(0 for unlimited)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
-msgid "Customizer"
-msgstr "Անհատական հարմարեցում"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
-msgid "OpenSCAD Language Features"
-msgstr "OpenSCAD լեզվային հատկություններ"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
-#, fuzzy
-msgid "Warnings"
-msgstr "OpenGL զգուշացում"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
-msgid "Stop on the first warning"
-msgstr "Կանգնեցնել առաջին զգուշացումից"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
-#, fuzzy
-msgid "Check the parameter range for builtin modules"
-msgstr "ստուգել պարամետրերի միջակայքը ներքին մոդուլների համար"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
-msgid "Warn when there is a parameter mismatch in user module calls"
-msgstr "Շգուշացնել, երբ օգտատերը կանչել է սխալ պարամետրեր "
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
-msgid "Trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
-msgid "Trace depth:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
-msgid "(max. number or trace messages)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
-msgid "Show parameters of usermodule calls in trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
-msgid "Render Summary"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
-msgid "Camera"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
-msgid "Bounding Box"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
-msgid "Measurements: Area"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
-msgid "Measurements: Volume"
+msgid "Auto (follow system)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
-msgid "Export Features"
-msgstr "Հնարավորություններ"
+msgid "Enable docking helper widgets in different places"
+msgstr "Միացնել խմբագրիչի եւ կառավարման վահանակի պահումը տարբեր տեղերում"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
-msgid "Toolbar Export 3D"
-msgstr ""
+#, fuzzy
+msgid "Enable undocking of helper widgets to separate windows"
+msgstr "Անջատել խմբագրիչի եւ կառավարման վահանակի պահումը տարբեր պատուհաններում"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
-msgid "Toolbar Export 2D"
-msgstr ""
+msgid "Show Welcome Screen"
+msgstr "Ցույց տալ ԲԱՐԻ ԳԱԼՈՒՍՏ֊ը"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
-msgid "Debugging"
+msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
+"Միացնել միջերեսի տեղայնացումը (պահանջում է PythonSCAD֊ի վերագործարկում)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
-msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
-msgstr ""
+msgid "Bring window to front after automatic reload"
+msgstr "Բերել պատուհանը առջևի մաս  ավտոմատ բեռնումից հետո"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
-msgid "Network Import List"
-msgstr ""
+msgid "Play sound notification on render complete"
+msgstr "Ձայնով ծանուցել նիշքի վերարտադրումից հետո"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
-msgid "Globally trust Python designs"
-msgstr ""
+#, fuzzy
+msgid "Play sound when render completion time is at least"
+msgstr "Ձայնով ծանուցել նիշքի վերարտադրումից հետո"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
-msgid "Really (very dangerous)"
+msgid "sec"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
-msgid "Dialog visibility"
+#: src/gui/Preferences.cc:419
+msgid "When launching another instance with files:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
-msgid "Always show PDF export dialog"
+#: src/gui/Preferences.cc:421
+msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
-msgid "Always show 3MF export dialog"
+#: src/gui/Preferences.cc:423
+msgid "Autosave session in background for crash recovery"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
-msgid "Always show SVF export dialog"
+#: src/gui/Preferences.cc:424
+msgid "Autosave interval:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
-msgid "Always show GCODE export dialog"
-msgstr ""
+msgid "Console"
+msgstr "Վահանակ"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
-msgid "Always show Print Service dialog"
+msgid "Clear console before Preview/Render"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+msgid "Maximum lines for Console to keep:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+msgid "(0 for unlimited)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+msgid "Customizer"
+msgstr "Անհատական հարմարեցում"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+msgid "OpenSCAD Language Features"
+msgstr "OpenSCAD լեզվային հատկություններ"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#, fuzzy
+msgid "Warnings"
+msgstr "OpenGL զգուշացում"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+msgid "Stop on the first warning"
+msgstr "Կանգնեցնել առաջին զգուշացումից"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#, fuzzy
+msgid "Check the parameter range for builtin modules"
+msgstr "ստուգել պարամետրերի միջակայքը ներքին մոդուլների համար"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+msgid "Warn when there is a parameter mismatch in user module calls"
+msgstr "Շգուշացնել, երբ օգտատերը կանչել է սխալ պարամետրեր "
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+msgid "Trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+msgid "Trace depth:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
+msgid "(max. number or trace messages)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
+msgid "Show parameters of usermodule calls in trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
+msgid "Render Summary"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
+msgid "Camera"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
+msgid "Bounding Box"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
+msgid "Measurements: Area"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
+msgid "Measurements: Volume"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
+#, fuzzy
+msgid "Export Features"
+msgstr "Հնարավորություններ"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
+msgid "Toolbar Export 3D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
+msgid "Toolbar Export 2D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
+msgid "Debugging"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
+msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
+msgid "Network Import List"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
+msgid "Globally trust Python designs"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
+msgid "Really (very dangerous)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
+msgid "Dialog visibility"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
+msgid "Always show PDF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
+msgid "Always show 3MF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
+msgid "Always show SVF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
+msgid "Always show GCODE export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
+msgid "Always show Print Service dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Կարգավորումներ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Շերտավորել պրոֆիլը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Շերտավորել պրոֆիլը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Նիշք"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Պարամետր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Պարամետր"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Պարամետր"
@@ -3187,55 +3196,18 @@ msgstr ""
 "Տեսաշերտ՝ թարգմանել = [ %.2f %.2f %.2f ], պտտել = [ %.2f %.2f %.2f ], "
 "հեռավորություն = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3573,79 +3545,67 @@ msgstr "Մուտքագրեք պարամետրերի հավաքածուի անո�
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Պարամետր"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Պարամետր"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<Default>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Հաջողված ՝ Server-ի տարբերակը = %2, API-ի տարբերակը = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Սխալմունք"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Նիշք"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "&Նիշք"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Շերտավորել պրոֆիլը"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "A profile with that name already exists."
 msgstr "Անուն %1-ը արդեն գոյություն ունի"
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3749,55 +3709,55 @@ msgstr ""
 "%1 արդեն գոյություն ունի.\n"
 "Ցանկանո՞ւմ եք փոխարինել այն։"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Նիշք"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 #, fuzzy
 msgid "Close Tab"
 msgstr "Փակել"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Ցանկանում եք պահպանել կատարած փոփոխությունները?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Այլևս չցուցադրել"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3806,15 +3766,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3824,7 +3784,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3833,39 +3793,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Չհաջողվեց բացել նիշքը խմբագրելու համար"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Էսքիզը չհաջողվեց պահպանել"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Պահպանել նիշքը"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Պահպանել որպես՝"
@@ -3941,7 +3901,7 @@ msgstr "Նիշքը բացել հնարավոր չէ\"%1$s\" տարածման հ�
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "ՍԽԱԼՄՈՒՆՔ: \"%1$s\" չստացվեց պահել/գրել (Սկավառակը լցված է?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "PythonSCAD-ի մասին"
@@ -3968,19 +3928,19 @@ msgstr "Մեկնարկ"
 msgid "Show File"
 msgstr "Ցուցադրել մասշատբի նշումները"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3988,19 +3948,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4327,9 +4287,6 @@ msgstr ""
 
 #~ msgid "&Open..."
 #~ msgstr "&Բացել..."
-
-#~ msgid "(requires restart)"
-#~ msgstr "(Անհրաժեշտ է վերագործարկել)"
 
 #~ msgid "/"
 #~ msgstr "/"

--- a/locale/it.po
+++ b/locale/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2024.01.06\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2025-08-02 19:25+0200\n"
 "Last-Translator: \n"
 "Language-Team: Italian\n"
@@ -107,7 +107,7 @@ msgstr "Genera sequenza d'immagini"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Preferenze"
 
@@ -260,7 +260,7 @@ msgid "TextLabel"
 msgstr "TextLabel"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Aggiornamento"
 
@@ -365,23 +365,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Pulisci"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr "Schema Colori:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Fisso"
@@ -500,8 +500,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -547,7 +547,7 @@ msgid "Clear console"
 msgstr "Pulisci console"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "Salva come..."
 
@@ -802,7 +802,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -1202,7 +1202,7 @@ msgid "Font path"
 msgstr "Nome Carattere"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Stile"
 
@@ -2036,7 +2036,7 @@ msgid "E&xport"
 msgstr "&Esporta come..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2151,7 +2151,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid "Form"
 msgstr "Form"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Parametro"
 
@@ -2258,753 +2258,761 @@ msgstr ""
 msgid "More actions"
 msgstr "Annotazioni"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "Vista 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Avanzate"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Editor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Funzionalità"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Abilita/Disabilita funzionalità sperimentali"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Assi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Impostare la configurazione del driver e la Mappature degli Assi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Tasti"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "Stampa 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "Servizio di Stampa 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Schema Colori:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Mostra Notifiche e Errori nella Vista 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "Ingrandimento centrato sul cursore"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr "Scorrimento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "Pulsante Sinistro Mouse"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "Entrambi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr "Ampiezza"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "N° di linee dello Scorrimento con Rotella"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr "Modificatore per Scorrimento con Rotella "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "Auto-Completamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr "Soglia Caratteri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "Abilita Auto-Completamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Accapo linea"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Nessuno"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Al carattere"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "A fine parola"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Indentazione Accapo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Visualizzazione Accapo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Stesso"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Indentato"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Indenta"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Inizio"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Testo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Bordo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Margine"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Fine"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Mostra"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Evidenzia Linea corrente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Mostra N° Linea"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Abilita Corrispondenza Parentesi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Carattere"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Colori Evidenziazione Sintassi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Varia la dimensione del Testo con Ctrl+Rotella Mouse"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+msgid "Use gvim as editor (requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Indentazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Automatica"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Backspace diminuisce Indentazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Indenta usando"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Spazi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Schede"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Ampiezza Indentazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Ampiezza TAB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Funzione tasto TAB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Inserisci TAB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Mostra spazi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Mai"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Sempre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Solo dopo Indentazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Dimensione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Verifica automatica degli Aggiornamenti"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Includi Versioni di Sviluppo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Verifica ora"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Ultima Verifica: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "Servizio di Stampa 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "Indirizzo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "Chiave API"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Carica"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Verifica"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Profilo Slicing"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Motore Slicing"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Formato File"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Azione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Mostra"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 "Nota: La chiave API è memorizzata in chiaro insieme alle impostazione "
 "dell'applicazione."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Applicazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&File"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Mostra Notifiche di compatibilità"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Disattiva Resa 3D a "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "elementi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Forza uso di di Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "&Resa 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Dimensione Cache CGAL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Dimensione Cache PolySet"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Interfaccia Utente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "Vista da &destra"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Abilita aggancio finestre Editor e Console in posti differenti"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr "Abilita sgancio Finestre Editor e Console per separare le Finestre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Mostra schermata di benvenuto"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
 "Carica Localizzazione Interfaccia Utente (richiede riavvio di PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "Porta la finestra in primo piano dopo il ricaricamento automatico"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "Emetti suono di notifica al completamento della Resa 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr "Durata del suono di notifica al completamento della Resa 3D di almeno"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "sec"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Console"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr "Azzera la Console prima dell'Anteprima/Resa Grafica"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr "N. massimo di linee della console mantenuto:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr "(0 per illimitato)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "Configuratore"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "Funzionalità linguaggio di OpenSCAD"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 msgid "Warnings"
 msgstr "Notifiche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "Termina l'esecuzione alla prima Notifica"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "Verifica la consistenza dei parametri per i moduli interni"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr "Avvisa una chiamata a moduli d'utente ha parametri incongruenti"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr "Tracciamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr "Profondità:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 #, fuzzy
 msgid "(max. number or trace messages)"
 msgstr "(numero massimo di messaggi di tracciamento)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr "Mostra i parametri delle chiamate dei moduli d'utente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr "Riepilogo Resa Grafica 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr "Riquadro di delimitazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr "Misure: area"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 #, fuzzy
 msgid "Measurements: Volume"
 msgstr "Misure: area"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr "Funzionalità Esportazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr "Barra Strumenti Esportazione 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr "Barra Strumenti Esportazione 2D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "Verifica errori"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr "Abilita tracciamento eventi HIDAPI (richiede riavvio di PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Preferenze"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Profilo Slicing"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Profilo Slicing"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Nuovo File"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Parametro"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Parametro"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Parametro"
@@ -3165,55 +3173,18 @@ msgid ""
 "distance = %.2f, fov = %.2f"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3549,79 +3520,67 @@ msgstr "Imposta il nome del un nuovo insieme di parametri"
 msgid "New set "
 msgstr "Nuovo insieme "
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Parametro"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Parametro"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<Predefinito>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr ""
 "Operazione terminata correttamente: Versione Server= %2, Versione API = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Errore"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Nuovo File"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "Copia nome file"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Profilo Slicing"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3724,54 +3683,54 @@ msgstr ""
 "%1 esiste già.\n"
 "Si desidera sovrascriverlo?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "Copia nome file"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "Copia intero percorso"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "Apri &cartella"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr "Chiudi Scheda"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Si desidera salvare le modifiche?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Non mostrare più"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3780,15 +3739,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3798,7 +3757,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3807,39 +3766,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Fallita apertura del file in scrittura"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Errore di salvataggio Progetto"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Salva File"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Salva una Copia"
@@ -3917,7 +3876,7 @@ msgstr ""
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "A proposito di PythonSCAD"
@@ -3944,19 +3903,19 @@ msgstr "Inizio"
 msgid "Show File"
 msgstr "Mostra utilizzo scala"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3964,19 +3923,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2022.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2023-02-14 16:47+0100\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <(nothing)>\n"
@@ -106,7 +106,7 @@ msgstr "კადრების შენახვა"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "პარამეტრები"
 
@@ -259,7 +259,7 @@ msgid "TextLabel"
 msgstr "ტექსტური ჭდე"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "განახლება"
 
@@ -364,23 +364,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "გასუფთავება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr "ფერების სქემა:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "ფიქსირებული"
@@ -500,8 +500,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -547,7 +547,7 @@ msgid "Clear console"
 msgstr "კონსოლის გასუფთავება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "შენახვა, როგორც..."
 
@@ -801,7 +801,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "გაუქმება"
 
@@ -1183,7 +1183,7 @@ msgid "Font path"
 msgstr "ფონტი"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "სტილი"
 
@@ -2018,7 +2018,7 @@ msgid "E&xport"
 msgstr "&გატანა"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2133,7 +2133,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2185,7 +2185,7 @@ msgid "Form"
 msgstr "ფორმა"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "პარამეტრი"
 
@@ -2240,754 +2240,762 @@ msgstr "-"
 msgid "More actions"
 msgstr "შემობრუნება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D ხედი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "დაწინაურებული"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "რედაქტორი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "თვისებები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "ექსპერიმენტალური თვისებების ჩართვა/გამორთვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "ღერძები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "შეყვანის დრაივერის მორგება და ღერძების მიბმა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "ღილაკები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "3D ბეჭდვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "3D ბეჭდვის სერვისები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "ფერების სქემა:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "3 ხედში გაფრთხილებებისა და შეცდომების ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "თაგუნას მდებარეობით გადიდება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr "ციფრების გადახვევა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr "Alt"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "თაგუნას მარცხენა ღილაკი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "ან"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr "ბიჯის ზომა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "რიცხვების თაგუნას ბორბლით გადახვევა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr "თაგუნას ბორბლით მოდიფიკატორი "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "ავტო შევსება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr "სიმბოლოების ზღვარი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "ავტომატური დასრულების ჩართვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "ხაზების გადატანა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "None"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "სიმბოლოს საზღვრიდან გადატანა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "სიტყვის ბოლოდან გადატანა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "სწორება გადატანისას"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "ხაზის გადატანის ვიზუალიზაცია"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "იგივე"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "შეწევით"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "შეწევა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "გაშვება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "ტექსტი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "საზღვარი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "ზღვარი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "დასასრული"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "დროის ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "მიმდინარე ხაზის გამოკვეთა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "ხაზების ნომრების ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "ბრჭყალის წყვილების გამოკვეთა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "ფონტი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "ფერადი სინტაქსის გამოკვეთა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-თაგუნას-ბორბალი ტექსტს გაადიდებს"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+msgid "Use gvim as editor (requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "სწორება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "ავტომატური სწორება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Backspace აუქმებს სწორებას"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "სწორება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "სივრცეები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "დაფები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "სწორების სიგანე"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "ტაბულაციის სიგანე"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "ტაბულაციის ღილაკის ფუნქცია"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "ტაბულაციის სიმბოლოს ჩასმა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "გამოტოვების ინდიკატორების ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "არასდროს"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "ყოველთვის"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "მხოლოდ სწორების შემდეგ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "SIZE"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "განახლების ავტომატური შემოწმება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "სატესტო ვერსიების ჩათვლით"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "ახლა შემოწმება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "ბოლო შემოწმება: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "3D ბეჭდვის სერვისები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "API-ის გასაღები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "ჩატვირთვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "შემოწმება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "სლაისერის პროფილი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "სლაისერის ძრავა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "ფაილის ფორმატი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "პარამეტრები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "შენიშვნა: API-ის გასაღები აპლიკაციის პარამეტრებში დაუშიფრავად ინახება."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "აპლიკაცია"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&ფაილი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "შესაძლებლობების გაფრთხილებების ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "რენდერის გაჩერება "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "ელემენტები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "ნაძალადევი Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "&რენდერი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "CGAL-ის კეშის ზომა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "მბ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "PolySet-ის კეშის ზომა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "სამომხმარებლო ინტერფეისი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "მ&არჯვენა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "კონსოლისა და რედაქტორის სხვადასხვა ადგილებზე მიმაგრების ჩართვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr "კონსოლისა და რედაქტორის ცალ-ცალკე ფანჯრებში გატანის ჩართვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "საწყისი ეკრანის ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
 "მომხმარებლის ინტერფეისის ლოკალიზაციის ჩართვა (აუცილებელია PythonSCAD-ის "
 "გადატვირთვა)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "ავტომატური თავიდან ჩატვირთვის შემდეგ ფანჯრის წინ გამოტანა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "რენდერის დასრულებისას ხმის დაკვრა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr "ხმის დაკვრა, როცა რენდერის დასრულებამდე დარჩენილია არა ნაკლებ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "წმ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "კონსოლი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr "კონსოლის ხაზების მაქსიმალური რიცხვი:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr "(0 შეუზღუდავისთვის)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "მომრგები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "OpenSCAD-ის ენის შესაძლებლობები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 #, fuzzy
 msgid "Warnings"
 msgstr "OpenGL-ის გაფრთხილება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "პრველ გაფრთხილებაზე შეჩერება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "შეამოწმეთ ჩაშენებული მოდულების პარამეტრების დიაპაზონი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr ""
 "მომხმარებლის მოდულის გამოძახებებში პარამეტრების არ-დამთხვევის შეტყობინება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr "რენდერის შეჯამება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr "კამერა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr "შემზღუდავი ოთხკუთხედი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr "გაბარიტები: ფართობი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 #, fuzzy
 msgid "Measurements: Volume"
 msgstr "გაბარიტები: ფართობი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr "გატანის მორგება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr "3D გატანის პანელი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr "2D გატანის პანელი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "გამართვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr ""
 "HIDAPI მოვლენების ტრეისინგის ჩართვა (PythonSCAD-ის გადატვირთვა აუცილებელია)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "პარამეტრები"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "სლაისერის პროფილი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "სლაისერის პროფილი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&ახალი ფაილი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "პარამეტრი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "პარამეტრი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "პარამეტრი"
@@ -3153,55 +3161,18 @@ msgstr ""
 "ვიუპორტი: translate = [ %.2f %.2f %.2f ], rotate = [ %.2f %.2f %.2f ], "
 "distance = %.2f, fov = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3537,78 +3508,66 @@ msgstr "შეიყვანეთ პარამეტრების სე�
 msgid "New set "
 msgstr "ახალი სეტი "
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "პარამეტრი"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "პარამეტრი"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<ნაგულისხმები>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "წარმატება: სერვერის ვერსია = %2, API-ის ვერსია = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "შეცდომა"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&ახალი ფაილი"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "ფაილის სახელის კოპირება"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "სლაისერის პროფილი"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3712,54 +3671,54 @@ msgstr ""
 "%1 უკვე არსებობს\n"
 "გნებავთ გადააწეროთ?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "ფაილის სახელის კოპირება"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "სრული ბილიკის კოპირება"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "საქაღალდის გახსნა"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr "ჩანართის დახურვა"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "გნებავთ შეინახოთ თქვენი ცვლილებები?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "მეორედ არ მაჩვენო"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3768,15 +3727,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3786,7 +3745,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3795,39 +3754,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "ფაილის ჩასაწერად გახსნის შეცდომა"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "დიზაინის შენახვის შეცდომა"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "ფაილის შენახვა"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "ყველას შენახვა"
@@ -3904,7 +3863,7 @@ msgstr "გასატანად \"%1$s\"-ის გახსნა შეუ
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\"-ის ჩაწერის შეცდოა. (დისკი გადაივსო?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "PythonSCAD-ის შესახებ"
@@ -3931,19 +3890,19 @@ msgstr "გაშვება"
 msgid "Show File"
 msgstr "მასშტაბის ჭდეების ჩვენება"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3951,19 +3910,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2021-06-19 19:07+0100\n"
 "Last-Translator: Jarosław Teterycz <openscad@jtk.com.pl>\n"
 "Language-Team: \n"
@@ -106,7 +106,7 @@ msgstr "Eksportuj klatki"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Preferencje"
 
@@ -262,7 +262,7 @@ msgid "TextLabel"
 msgstr "Tekst"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Aktualizuj"
 
@@ -375,23 +375,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Wyczyść"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -433,7 +433,7 @@ msgstr "Schemat kolorów:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Na sztywno"
@@ -511,8 +511,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -558,7 +558,7 @@ msgid "Clear console"
 msgstr "Wyczyść konsolę"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 #, fuzzy
 msgid "Save As..."
 msgstr "Zapisz &jako…"
@@ -815,7 +815,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -1197,7 +1197,7 @@ msgid "Font path"
 msgstr "Czcionka"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Styl"
 
@@ -2054,7 +2054,7 @@ msgid "E&xport"
 msgstr "&Eksportuj"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2172,7 +2172,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2224,7 +2224,7 @@ msgid "Form"
 msgstr "Formularz"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Parametr"
 
@@ -2284,757 +2284,766 @@ msgstr "-"
 msgid "More actions"
 msgstr "Ob&rót"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "Widok 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Zaawansowane"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Edytor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Właściwości"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Włącz/wyłącz funkcje eksperymentalne"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 #, fuzzy
 msgid "Axes"
 msgstr "Osie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Konfiguracja sterownika wejściowego i mapowanie osi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Przyciski"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "Druk 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "Usługi druku 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Schemat kolorów:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Pokazuj ostrzeżenia i błędy w widoku 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "Przybliżenie względem wskaźnika myszki"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr "Cyfrowe przewijanie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 #, fuzzy
 msgid "Alt"
 msgstr "All"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "Lewy przycisk myszki"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "Dowolny"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 #, fuzzy
 msgid "Step Size"
 msgstr "Wielkość kroku"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "Liczbowe przewijanie kółkiem myszki"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr "Współczynnik dla kółka myszki"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "Autouzupełnianie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr "Zakres znaków"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "Włącz autouzupełnianie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Zawijanie wierszy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Brak"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Zawijaj za znakiem"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Zawijaj za słowem"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Wcięcie zawiniętych wierszy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Wizualizacja zawiniętych wierszy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Takie samo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Wcięte"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Wcięcie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Początek"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Tekst"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Krawędź"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Margines"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Koniec"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Wygląd"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Zaznacz aktywny wiersz"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Numeruj wiersze"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Włącz dopasowywanie nawiasów"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Czcionka"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Koloruj składnię"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-kółko myszy - przybliża tekst"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(wymaga ponownego uruchomienia)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Wcięcia"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Automatyczne wcięcia"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Backspace usuwa wcięcie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Do wcięć używaj"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Spacji"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "TABy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Szerokość wcięć"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Szerokość TABów"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Funkcja klawisza TAB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Wstaw TAB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Pokazuj znaki niedrukowalne"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Nigdy"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Zawsze"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Tylko po wcięciu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Rozmiar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Automatycznie sprawdzaj aktualizacje"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Uwzględniaj wersje rozwojowe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Sprawdź teraz"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Ostatnio sprawdzono: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "Usługi druku 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "Klucz API"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Załaduj"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Sprawdź"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Profil slicera"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Silnik slicera"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Format pliku"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Akcja"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 #, fuzzy
 msgid "Show"
 msgstr "Pokaż"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "Uwaga: Klucz API przechowywany jest w jawnej postaci."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Aplikacja"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Plik"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Pokazuj ostrzeżenia o zdolnościach"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Wyłącz renderowanie przy "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "elementach"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Wymuś Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "&Renderuj"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Rozmiar cache CGAL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Rozmiar pamięci podręcznej PolySetów"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Interfejs użytkownika"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "Z &prawej"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Włącz dokowanie edytora i konsoli w różnych miejscach"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr "Włącz przenoszenie edytora i konsoli do osobnych okien"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Pokaż ekran powitalny"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr "Włącz tłumaczenie interfejsu użytkownika (wymaga restartu PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "Przenieś okno na górę po automatycznym przeładowaniu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "Odtwarzaj dźwięk po ukończeniu renderowania"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 #, fuzzy
 msgid "Play sound when render completion time is at least"
 msgstr "Odtwarzaj dźwięk, gdy czas renderowanie jest dłuższy niż"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "s"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Konsola"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr "Maksymalna ilość zachowywanych wierszy konsoli"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr "(0 = bez ograniczeń)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "Panel dostosowania"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "Funkcje języka OpenSCAD"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 #, fuzzy
 msgid "Warnings"
 msgstr "Ostrzeżenie OpenGL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "Zatrzymaj przy pierwszym ostrzeżeniu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "Sprawdzaj zakres parametrów dla modułów wbudowanych"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr ""
 "Ostrzeż, gdy występuje niezgodność parametrów przy wywołaniu modułu "
 "użytkownika"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 msgid "Measurements: Volume"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 #, fuzzy
 msgid "Export Features"
 msgstr "Funkcje eksporu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "Debugowanie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr "Włącz śledzenie wydarzeń HIDAPI (wymaga restartu PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Preferencje"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Profil slicera"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Profil slicera"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Nowy plik"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Parametr"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Parametr"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Parametr"
@@ -3200,55 +3209,18 @@ msgstr ""
 "Podgląd: translacja = [ %.2f %.2f %.2f ], obrót = [ %.2f %.2f %.2f ], odstęp "
 "= %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3584,78 +3556,66 @@ msgstr "Podaj nazwę zestawu parametrów"
 msgid "New set "
 msgstr "Nowy zestaw "
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Parametr"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Parametr"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<Domyślny>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Sukces: wersja serwera = %2, weraja API = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Błąd"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Nowy plik"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "Skopiuj nazwę pliku"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Profil slicera"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3758,55 +3718,55 @@ msgstr ""
 "%1 już istnieje.\n"
 "Czy chcesz nadpisać?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "Skopiuj nazwę pliku"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "Skopiuj pełną ścieżkę"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Otwórz plik"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 #, fuzzy
 msgid "Close Tab"
 msgstr "Zamknij zakładkę"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Czy chcesz zapisać zmiany?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Nie pokazuj ponownie"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3815,15 +3775,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3833,7 +3793,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3842,39 +3802,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Nie udało się otworzyć pliku do zapisu"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Błąd przy zapisie projektu"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Zapisz plik"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Zapisz &jako"
@@ -3952,7 +3912,7 @@ msgstr "Nie można otworzyć pliku \"%1$s\" do eksportu"
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "Błąd: \"%1$s\" – błąd zapisu. (Pełny dysk?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "O programie PythonSCAD"
@@ -3979,19 +3939,19 @@ msgstr "Początek"
 msgid "Show File"
 msgstr "Pokaż podziałkę"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3999,19 +3959,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4339,9 +4299,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "Edytor QScintilla"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(wymaga ponownego uruchomienia)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "Pozwalaj na otwieranie wielu dokumentów"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2025-04-10 09:02-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: \n"
@@ -107,7 +107,7 @@ msgstr "Gravar imagens"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Preferências"
 
@@ -262,7 +262,7 @@ msgid "TextLabel"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Atualizar"
 
@@ -367,23 +367,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Limpar"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr "Esquema de colores:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Fixo"
@@ -503,8 +503,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -550,7 +550,7 @@ msgid "Clear console"
 msgstr "Limpar console"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "Salvar Como..."
 
@@ -806,7 +806,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1206,7 +1206,7 @@ msgid "Font path"
 msgstr "Nome da fonte"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Estilo"
 
@@ -2044,7 +2044,7 @@ msgid "E&xport"
 msgstr "E&xportar"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2160,7 +2160,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2202,7 +2202,7 @@ msgid "Form"
 msgstr "Formulário"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Parâmetros"
 
@@ -2258,762 +2258,770 @@ msgstr ""
 msgid "More actions"
 msgstr "Anotações"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "Vista 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Avançado"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Editor"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Recursos"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Ativar/desativar recursos experimentais"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Eixos"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Configuração do driver de entrada e mapeamento de Eixo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Botões"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "Impressão 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "Serviços de Impressão 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Esquema de colores:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Mostrar erros e avisos na vista 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "ampliação centrada no mouse"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "Botão Esquerdo do Mouse"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "Qualquer"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr "Tamanho do Passo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 #, fuzzy
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "Number Scroll Via Roda do Mouse"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 #, fuzzy
 msgid "Modifier For Wheel Scroll "
 msgstr "Modificador para Roda do Mouse "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "Autocompletar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr "Limiar de Caractere"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 #, fuzzy
 msgid "Enable Autocompletion"
 msgstr "Habilitar Autocomplete"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Quebra de linha"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Nenhum"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Quebrar nos limites de caracter"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Quebrar nos limites de palavra"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Indentação de quebra de linha"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Visualização de quebra de linha"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Mesmo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Indentado"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Indentar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Início"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Texto"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Borda"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Margen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Final"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Mostrar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Realçar linha atual"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Mostrar números de linha"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Habilitar correspondência de chaves"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Fonte"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Realce colorido de sintaxe"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd+Roda-do-mouse amplia texto"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+msgid "Use gvim as editor (requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Indentação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Indentação Automática"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 #, fuzzy
 msgid "Backspace unindents"
 msgstr "Backspace desindenta"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Indentar usando"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Espaços"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Abas"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Largura da indentação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Largura da tabulação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Função da tecla Tab"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Inserir Aba"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Mostrar espaços em branco"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Nunca"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Sempre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Apenas depois da indentação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Tamanho"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Verificar atualizações automaticamente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Incluir as versões em desenvolvimento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Verificar Agora"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Última verificação: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "Serviços de Impressão 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "Chave de API"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Carregar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Verificar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Perfile de Fatiamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Motor de Fatiamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Formato de Arquivo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Ação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Mostrar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 "Nota: a chave da API é armazenada sem criptografia nas configurações do "
 "aplicativo."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Aplicação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Arquivo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Mostrar avisos de capacidade"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Desativar renderização em "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "elementos"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Forçar Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "R&enderizar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Tamanho do Cache de CGAL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Tamanho do Cache de PolySet"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Interface de Usuário"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "Di&reita"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Habilitar encaixe de Editor e Console em diferentes lugares"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr "Habilitar o desencaixe de Editor e Console para janelas separadas"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Mostrar Janela de Boas-Vindas"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
 "Habilitar localização da interface de usuário (requer reinicialização do "
 "PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "Trazer janela para a frente após recarga automática"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "Tocar notificação sonora quando completar a renderização"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr "Tocar som quando o tempo para completar a renderização for pelo menos"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "s"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Console"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr "Limpar console antes da Pré-visualização/Renderização"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr "Máximo de linhas mantidas pelo Console:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr "(0 para ilimitado)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "Customizador"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "Recursos da Linguagem OpenSCAD"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 msgid "Warnings"
 msgstr "Avisos"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "Parar no primeiro aviso"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "Verificar a faixa de parâmetros para módulos internos"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr ""
 "Avisar quando houver incompatibilidade de parâmetros nas chamadas do módulo "
 "do usuário"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr "Rastreamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr "Profundidade do rastreamento:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 #, fuzzy
 msgid "(max. number or trace messages)"
 msgstr "(número máx. de mensages de rastreamento)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr "Mostrar parâmetros de chamadas do módulo de usuário no rastreamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr "Sumário de Renderização"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr "Câmera"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr "Caixa Delimitadora"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr "Medidas: Área"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 #, fuzzy
 msgid "Measurements: Volume"
 msgstr "Medidas: Área"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr "Recursos de Eportação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr "Exportação da Barra de Ferramentas 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr "Exportação da Barra de Ferramentas 2D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "Depuração"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr ""
 "Habilitar rastreamento de eventos HIDAPI (requer reinicialização do "
 "PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Preferências"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Perfile de Fatiamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Perfile de Fatiamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Novo Arquivo"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Parâmetros"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Parâmetros"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Parâmetros"
@@ -3176,55 +3184,18 @@ msgid ""
 "distance = %.2f, fov = %.2f"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3558,78 +3529,66 @@ msgstr "Entrar nome do conjunto de parâmetros"
 msgid "New set "
 msgstr "Novo conjunto "
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Parâmetros"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Parâmetros"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<Padrão>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Successo: Versão do Servidor = %2, Versão da API = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Erro"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Novo Arquivo"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "Copiar nome de arquivo"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Perfile de Fatiamento"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3732,54 +3691,54 @@ msgstr ""
 "%1 já existe.\n"
 "Deseja substituí-lo?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "Copiar nome de arquivo"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "Copiar todo caminho"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "Abrir pasta"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr "Fechar Aba"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Deseja salvar as alterações?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Não mostrar novamente"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3788,15 +3747,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3806,7 +3765,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3815,39 +3774,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Falha abrindo arquivo para escrita"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Erro salvando design"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Salvar arquivo"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Salvar um Cópia"
@@ -3924,7 +3883,7 @@ msgstr ""
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "Sobre o PythonSCAD"
@@ -3951,19 +3910,19 @@ msgstr "Início"
 msgid "Show File"
 msgstr "Mostar Uso de Escala"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3971,19 +3930,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 

--- a/locale/pythonscad.pot
+++ b/locale/pythonscad.pot
@@ -1,4 +1,4 @@
-# #-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.06.21)  #-#-#-#-#
+# #-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.06.28)  #-#-#-#-#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the OpenSCAD package.
@@ -7,10 +7,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"#-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.06.21)  #-#-#-#-#\n"
-"Project-Id-Version: OpenSCAD 2026.06.21\n"
+"#-#-#-#-#  pythonscad-tmp.pot (OpenSCAD 2026.06.28)  #-#-#-#-#\n"
+"Project-Id-Version: OpenSCAD 2026.06.28\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "#-#-#-#-#  appdata-strings.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -106,7 +106,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr ""
 
@@ -257,7 +257,7 @@ msgid "TextLabel"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr ""
 
@@ -362,23 +362,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -415,7 +415,7 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr ""
@@ -490,8 +490,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -536,7 +536,7 @@ msgid "Clear console"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr ""
 
@@ -785,7 +785,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgid "Font path"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgid "E&xport"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2067,7 +2067,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2109,7 +2109,7 @@ msgid "Form"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr ""
 
@@ -2163,735 +2163,743 @@ msgstr ""
 msgid "More actions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+msgid "Use gvim as editor (requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 msgid "Default Print Service"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 msgid "Local Application"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 msgid "File"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 msgid "3D Rendering"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 msgid "Light"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 msgid "Enable docking helper widgets in different places"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 msgid "Warnings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 msgid "Measurements: Volume"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 msgid "AI Preferences"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 msgid "Profiles"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 msgid "Active Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 msgid "New Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 msgid "API Parameters"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 msgid "Add Parameter"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 msgid "Remove Parameter"
 msgstr ""
 
@@ -3042,55 +3050,18 @@ msgid ""
 "distance = %.2f, fov = %.2f"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3400,73 +3371,61 @@ msgstr ""
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 msgid "Parameter Key"
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 msgid "Parameter Value"
 msgstr ""
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr ""
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr ""
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr ""
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 msgid "New AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 msgid "Profile name:"
 msgstr ""
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "Duplicate Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3549,51 +3508,51 @@ msgid ""
 "Do you want to create it?"
 msgstr ""
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 msgid "Open Folder"
 msgstr ""
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 msgid "Do you want to save the changes you made to %1?"
 msgstr ""
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 msgid "Don't save"
 msgstr ""
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3602,15 +3561,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3620,7 +3579,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3629,39 +3588,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr ""
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr ""
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 msgid "Save A Copy"
 msgstr ""
 
@@ -3729,7 +3688,7 @@ msgstr ""
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 msgid "PythonSCAD"
 msgstr ""
 
@@ -3753,19 +3712,19 @@ msgstr ""
 msgid "Show File"
 msgstr ""
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3773,19 +3732,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2022-09-30 00:36+0300\n"
 "Last-Translator: Konstantin Podsvirov <konstantin@podsvirov.pro>\n"
 "Language-Team: \n"
@@ -110,7 +110,7 @@ msgstr "Сохранять кадры"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Параметры"
 
@@ -261,7 +261,7 @@ msgid "TextLabel"
 msgstr "Текст"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Обновления"
 
@@ -366,23 +366,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Очистить"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgstr "Цветовая схема:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Фиксированный"
@@ -502,8 +502,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -549,7 +549,7 @@ msgid "Clear console"
 msgstr "Очистить консоль"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "Сохранить как..."
 
@@ -803,7 +803,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -1185,7 +1185,7 @@ msgid "Font path"
 msgstr "Шрифт"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Стиль"
 
@@ -2020,7 +2020,7 @@ msgid "E&xport"
 msgstr "&Экспортировать"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2136,7 +2136,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2188,7 +2188,7 @@ msgid "Form"
 msgstr "Форма"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Параметр"
 
@@ -2243,750 +2243,759 @@ msgstr "-"
 msgid "More actions"
 msgstr "Вращение"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "Просмотр 3D"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Редактор"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Функции"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Включить/Выключить экспериментальные возможности"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Оси"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Конфигурация драйвера устройства ввода и соответствия осей"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Кнопки"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "3D Печать"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "Сервисы 3D Печати"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Цветовая схема:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Показывать ошибки и предупреждения в 3D виде"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "масштабировать относительно мыши"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr "Прокрутка цифр"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr "Alt"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "Левая кнопка мыши"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "Оба"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr "Размер шага"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "Прокрутка чисел с помощью колеса мыши"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr "Модификатор для прокрутки колеса мыши"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "Автодополнение"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr "Порог символов"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "Включить автодополнение"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Перенос строк"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Нет"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Перенос с границы символа"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Перенос с границы слова"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Отступы в переносах"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Вид переносов строк"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Такой же"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "С отступами"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Добавить отступ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Начало"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Текст"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Граница"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Поле"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Конец"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Вид"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Выделять текущую строку"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Показывать номера строк"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Подсвечивать парные скобки"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Шрифт"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Подсветка синтаксиса"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-Колёсико-мыши увеличивает текст"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(требуется перезапуск)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Отступы"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Автоматические отступы"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Backspace убирает отступы"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Делать отступы"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Пробелами"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Табуляцией"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Ширина отступа"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Ширина табуляции"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Функция клавиши Tab"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Вставить табуляцию"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Показывать пробелы"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Никогда"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Всегда"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Только после отступа"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Размер"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Автоматически проверять обновления"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Включая рабочие сборки"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Проверить сейчас"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Последняя проверка: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "Сервисы 3D Печати"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "Ключ API"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Загрузить"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Проверить"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Профиль слайсера"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Движок слайсера"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Формат"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Действие"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Показать"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "Примечание: ключ API сохранён без шифрования в настройках приложения."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Приложение"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Файл"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Показывать предупреждение о возможностях"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Отключать отрисовку на "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "элементах"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Принудительно использовать Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "&Рендеринг"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Размер кэша CGAL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MБ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Размер кэша PolySet"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Интерфейс"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "С&права"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Включить прилипание редактора и консоли в разных местах"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr "Включить перетаскивание редактора и консоли в разные окна"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Показывать экран приветствия"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr "Включить локализацию интерфейса (необходимо перезапустить PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "Вывести окно на передний план после автоматической перезагрузки"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "Проигрывать звук при завершении рендеринга"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr "Проигрывать звук при времени завершения рендеринга не менее"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "сек"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Консоль"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr "Максимальное количество строк консоли:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr "(0 без ограничений)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "Настройщик"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "Возможности языка OpenSCAD"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 msgid "Warnings"
 msgstr "Предупреждения"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "Остановиться на первом предупреждении"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "Проверять диапазон параметров для встроенных модулей"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr "Предупреждать при несовпадении параметров в вызовах модуля"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr "Сводка по рендерингу"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr "Камена"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr "Ограничивающий параллелепипед"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr "Измерения: область"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 #, fuzzy
 msgid "Measurements: Volume"
 msgstr "Измерения: область"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr "Особенности экспорта"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "Отладка"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr ""
 "Включить отслеживание событий HIDAPI (необходимо перезапустить PythonSCAD)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Параметры"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Профиль слайсера"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Профиль слайсера"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Новый файл"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Параметр"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Параметр"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Параметр"
@@ -3151,55 +3160,18 @@ msgstr ""
 "Область просмотра: translate = [ %.2f %.2f %.2f ], rotate = [ %.2f %.2f "
 "%.2f ], distance = %.2f, fov = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3529,79 +3501,67 @@ msgstr "Введите название нового набора парамет
 msgid "New set "
 msgstr "Новый набор "
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Параметр"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Параметр"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<Default>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Выполнено. Версия сервера = %2, версия API = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Ошибка"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Новый файл"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "Скопировать имя файла"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Профиль слайсера"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "A profile with that name already exists."
 msgstr "Название «%1» уже существует"
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3705,54 +3665,54 @@ msgstr ""
 "%1 уже существует.\n"
 "Перезаписать?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "Скопировать имя файла"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "Скопировать полный путь"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Сохранить изменения?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Больше не показывать"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3761,15 +3721,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3779,7 +3739,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3788,39 +3748,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Не удалось открыть файл для записи"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Ошибка при сохранении проекта"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Сохранить файл"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Сохранить как"
@@ -3897,7 +3857,7 @@ msgstr "Не удалось открыть файл \"%1$s\" для экспор
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "Ошибка записи: \"%1$s\". (Диск переполнен?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "О программе PythonSCAD"
@@ -3924,19 +3884,19 @@ msgstr "Начало"
 msgid "Show File"
 msgstr "Показывать метки масштаба"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3944,19 +3904,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4293,9 +4253,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "Редактор QScintilla"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(требуется перезапуск)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "Разрешить открытие нескольких документов"

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2021.12.04\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2021-12-04 17:55+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: Turkish\n"
@@ -105,7 +105,7 @@ msgstr "Döküm Resimleri"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Tercihler"
 
@@ -258,7 +258,7 @@ msgid "TextLabel"
 msgstr "MetinEtiketi"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Güncelle"
 
@@ -371,23 +371,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "Temizle"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr "Renk şeması:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Onarıldı"
@@ -507,8 +507,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -554,7 +554,7 @@ msgid "Clear console"
 msgstr "Konsolü temizle"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "Farklı Kaydet..."
 
@@ -808,7 +808,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "Vazgeç"
 
@@ -1190,7 +1190,7 @@ msgid "Font path"
 msgstr "Yazı Tipi"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Stil"
 
@@ -2027,7 +2027,7 @@ msgid "E&xport"
 msgstr "D&ışa aktar"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2142,7 +2142,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2194,7 +2194,7 @@ msgid "Form"
 msgstr "Şekil"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Parametre"
 
@@ -2249,754 +2249,762 @@ msgstr "-"
 msgid "More actions"
 msgstr "Döndürme"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D Görünüm"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Gelişmiş"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Düzenleyici"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Özellikler"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Deneysel özellikleri Etkinleştir/Devre Dışı Bırak"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "Eksen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "Giriş sürücüsü yapılandırması ve Eksen eşlemesi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "Düğmeler"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "3B Yazdır"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "3B Baskı Hizmetleri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Renk şeması:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Uyarıları ve Hataları 3B Görünümde Göster"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "fare merkezli yakınlaştırma"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr "Sayı Kaydırma"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr "Alt"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "Sol fare tuşu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "Herhangi biri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr "Adım Boyutu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "Fare Tekerleği Üzerinden Sayı Kaydırma"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr "Tekerlerk Kaydırma İçin Değiştirici "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "Kendiliğinden Tamamlama"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr "Karakter Eşiği"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "Otomatik Tamamlamayı Etkinleştir"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Satır kaydırma"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Hiç"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Karakter sınırlarına sarın"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Kelime sınırlarına sarın"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Satır sarma girintisi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Satır sarma görselleştirme"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Benzer"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Girintili"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Girintili"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Başlangıç"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Metin"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Sınır"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Kenar Boşluğu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Son"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Ekran"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Seçili satırı vurgula"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Satır Sayılarını Göster"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Ayraç eşleştirmeyi etkinleştir"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Yazı Tipi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Renk sözdizimi vurgulama"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-Fare tekerleği metni yakınlaştırır"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+msgid "Use gvim as editor (requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Girinti"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Otomatik Girinti"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Girintileri geri al"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Kullanarak girinti"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Boşluklar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Sekmeler"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Girinti genişliği"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Sekme genişliği"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Sekme tuşu işlevi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Sekme Ekle"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Boşluğu göster"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Asla"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Daima"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Sadece girintiden sonra"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Boyut"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Güncellemeleri otomatik olarak kontrol et"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Geliştirme anlık görüntülerini dahil et"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Şimdi kontrol et"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Son kontrol: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "3B Baskı Hizmetleri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "Sekiz Baskı"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "API Anahtarı"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "Yükle"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "Kontrol Et"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "Dilimleme Profili"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "Dilimleme Motoru"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "Dosya Biçimi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "Eylem"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "Göster"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "Not: API anahtarı, uygulama ayarlarında şifrelenmemiş olarak saklanır."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Uygulama"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Dosya"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Yetenek uyarısını göster"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Şurada oluşturmayı kapat "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "öğeler"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Altın tüyü zorla"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "&İşle"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "CGAL Önbellek boyutu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Çoklu Ayar Önbellek boyutu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "Kullanıcı Arabirimi"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "&Sağ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "Düzenleyici ve Konsolun farklı yerlere yerleştirilmesini etkinleştirin"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr ""
 "Pencereleri ayırmak için Düzenleyici ve Konsolun ayrılmasını etkinleştirin"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "Karşılama Ekranını Göster"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr ""
 "Kullanıcı arabirimi yerelleştirmesini etkinleştir (PythonSCAD'in yeniden "
 "başlatılmasını gerektirir)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "Otomatik yeniden yüklemeden sonra pencereyi öne getirin"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "Oluşturma tamamlandığında sesli bildirimi çal"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr "Oluşturma tamamlanma süresi en az olduğunda ses çal"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "san"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "Konsol"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr "Konsolun tutması gereken maksimum satır:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr "(sınırsız için 0)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "Özelleştirici"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "OpenSCAD Dil Özellikleri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 #, fuzzy
 msgid "Warnings"
 msgstr "OpenGL Uyarısı"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "İlk uyarıda dur"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "Yerleşik modüller için parametre aralığını kontrol edin"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr "Kullanıcı modülü çağrılarında parametre uyuşmazlığı olduğunda uyar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 msgid "Measurements: Volume"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr "Dışa Aktarma Özellikleri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "Hata Ayıklama"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr ""
 "HIDAPI olaylarının izlenmesini etkinleştir (PythonSCAD'in yeniden "
 "başlatılmasını gerektirir)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Tercihler"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "Dilimleme Profili"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "Dilimleme Profili"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Yeni dosya"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Parametre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Parametre"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Parametre"
@@ -3162,55 +3170,18 @@ msgstr ""
 "Görünüm alanı: çeviri = [ %.2f %.2f %.2f ], döndür = [ %.2f %.2f %.2f ], "
 "mesafe = %.2f, fov = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3547,78 +3518,66 @@ msgstr "Parametre setinin adını girin"
 msgid "New set "
 msgstr "Yeni set "
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Parametre"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Parametre"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<Default>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Başarılı: Sunucu Sürümü = %2, API Sürümü = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "Hata"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Yeni dosya"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "Dosya adını kopyala"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "Dilimleme Profili"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3722,54 +3681,54 @@ msgstr ""
 "%1 zaten var.\n"
 "Değiştirmek istiyor musun?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "Dosya adını kopyala"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "Tam yolu kopyala"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Dosya Aç"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Değişiklikleri kaydetmek istiyor musunuz?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Bir daha gösterme"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3778,15 +3737,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3796,7 +3755,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3805,39 +3764,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Dosya yazmak için açılamadı"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Tasarım kaydedilirken hata oluştu"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Dosyayı Kaydet"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Hepsini Kaydet"
@@ -3914,7 +3873,7 @@ msgstr "\"%1$s\" dosyası dışa aktarma için açılamıyor"
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\" yazma hatası. (Disk dolu?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "PythonSCAD Hakkında"
@@ -3941,19 +3900,19 @@ msgstr "Başlangıç"
 msgid "Show File"
 msgstr "Ölçek İşaretlerini Göster"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3961,19 +3920,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2018.08.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2018-11-11 13:00+0200\n"
 "Last-Translator: Kyrylo Romanenko <romanenko-kv@hotmail.com>\n"
 "Language-Team: Ukrainian\n"
@@ -105,7 +105,7 @@ msgstr "Зберігати картинки"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "Налаштування"
 
@@ -263,7 +263,7 @@ msgid "TextLabel"
 msgstr "Текст"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "Оновлення"
 
@@ -368,23 +368,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -426,7 +426,7 @@ msgstr "Схема кольорів:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "Фіксований"
@@ -504,8 +504,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -552,7 +552,7 @@ msgid "Clear console"
 msgstr "Консоль"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 #, fuzzy
 msgid "Save As..."
 msgstr "Зберегти &як..."
@@ -809,7 +809,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgid "Font path"
 msgstr "Шрифт"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "Стиль"
 
@@ -2051,7 +2051,7 @@ msgid "E&xport"
 msgstr "&Експорт"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2169,7 +2169,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2211,7 +2211,7 @@ msgid "Form"
 msgstr "Форма"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "Параметр"
 
@@ -2268,754 +2268,763 @@ msgstr "-"
 msgid "More actions"
 msgstr "&Документація"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D вид"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Поглиблене"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "Редактор"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "Можливості"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "Увімкнути/Вимкнути експериментальні можливості"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 #, fuzzy
 msgid "Axes"
 msgstr "Показуваті вісі"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "Схема кольорів:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Показувати попередження та помилки у 3D виді"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 #, fuzzy
 msgid "Alt"
 msgstr "Все"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 #, fuzzy
 msgid "Step Size"
 msgstr "Розмір"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "Згортання рядків"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Нема"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Згортати на межах знаків"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Згортати на межах слів"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "Відступ згортання рядків"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "Візуалізація згортання рядків"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Такий самий"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "З відступом"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Відступ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "Початок"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Текст"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Межа"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Поле"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "Кінець"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "Показ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "Підсвічувати поточний рядок"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "Показувати номери рядків"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "Увімкнути парні дужки"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "Шрифт"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "Кольорова підсвітка синтаксису"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-колесо масштабує текст"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(потребує перезапуску)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "Відступи"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "Автовідступи"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "Backspace відміняє відступ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "Робити відступи"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Пробілами"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Табуляцією"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "Ширина відступу"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Ширина табуляції"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Клавіша Tab виконує"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Ставить табуляцію"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "Показувати пробіл"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Ніколи"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Завжди"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "Тільки після відступу"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "Розмір"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "Автоматично перевіряти оновлення"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "Включити розробницькі збірки"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "Перевірити зараз"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "Останнього разу перевірено:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 msgid "Default Print Service"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 #, fuzzy
 msgid "Check"
 msgstr "Перевірити зараз"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 #, fuzzy
 msgid "Action"
 msgstr "Програма"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 #, fuzzy
 msgid "Show"
 msgstr "Показуваті вісі"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "Програма"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "&Файл"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "Показувати попередження про здатності"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "Вимкнути рендеринг на "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "елементів"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "Примусово вмикати Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "По&будувати"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "Розмір кешу CGAL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "МБ"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "Розмір кешу PolySet"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "С&права"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
-msgid "Auto (follow system)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
-#, fuzzy
-msgid "Enable docking helper widgets in different places"
-msgstr "Дозволити стикування Редактору та Консолі в різних місцях"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
-#, fuzzy
-msgid "Enable undocking of helper widgets to separate windows"
-msgstr "Дозволити відстикування Редактору та Консолі до різних вікон"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
-msgid "Show Welcome Screen"
-msgstr "Показувати вікно привітання"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
-msgid "Enable user interface localization (requires restart of PythonSCAD)"
-msgstr "Увімкнути локалізацію інтерфейсу (потребує перезапуску)"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
-msgid "Bring window to front after automatic reload"
-msgstr "Піднести вікно на передній план після автоматичного перевантаження"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
-msgid "Play sound notification on render complete"
-msgstr "Програвати звукове оповіщення по завершенні рендерингу"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
-#, fuzzy
-msgid "Play sound when render completion time is at least"
-msgstr "Програвати звукове оповіщення по завершенні рендерингу"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
-msgid "sec"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
-msgid "When launching another instance with files:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
-msgid "Enable session management (save/restore tabs on quit, requires restart)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
-msgid "Autosave session in background for crash recovery"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
-msgid "Autosave interval:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
-msgid "Console"
-msgstr "Консоль"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
-msgid "Clear console before Preview/Render"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
-msgid "Maximum lines for Console to keep:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
-msgid "(0 for unlimited)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
-msgid "Customizer"
-msgstr "Кастомайзер"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
-msgid "OpenSCAD Language Features"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
-#, fuzzy
-msgid "Warnings"
-msgstr "Попередження OpenGL"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
-msgid "Stop on the first warning"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
-msgid "Check the parameter range for builtin modules"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
-msgid "Warn when there is a parameter mismatch in user module calls"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
-msgid "Trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
-msgid "Trace depth:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
-msgid "(max. number or trace messages)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
-msgid "Show parameters of usermodule calls in trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
-msgid "Render Summary"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
-msgid "Camera"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
-msgid "Bounding Box"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
-msgid "Measurements: Area"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
-msgid "Measurements: Volume"
+msgid "Auto (follow system)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
-msgid "Export Features"
-msgstr "Можливості"
+msgid "Enable docking helper widgets in different places"
+msgstr "Дозволити стикування Редактору та Консолі в різних місцях"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
-msgid "Toolbar Export 3D"
-msgstr ""
+#, fuzzy
+msgid "Enable undocking of helper widgets to separate windows"
+msgstr "Дозволити відстикування Редактору та Консолі до різних вікон"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
-msgid "Toolbar Export 2D"
-msgstr ""
+msgid "Show Welcome Screen"
+msgstr "Показувати вікно привітання"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
-msgid "Debugging"
-msgstr ""
+msgid "Enable user interface localization (requires restart of PythonSCAD)"
+msgstr "Увімкнути локалізацію інтерфейсу (потребує перезапуску)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
-msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
-msgstr ""
+msgid "Bring window to front after automatic reload"
+msgstr "Піднести вікно на передній план після автоматичного перевантаження"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
-msgid "Network Import List"
-msgstr ""
+msgid "Play sound notification on render complete"
+msgstr "Програвати звукове оповіщення по завершенні рендерингу"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
-msgid "Globally trust Python designs"
-msgstr ""
+#, fuzzy
+msgid "Play sound when render completion time is at least"
+msgstr "Програвати звукове оповіщення по завершенні рендерингу"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
-msgid "Really (very dangerous)"
+msgid "sec"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
-msgid "Dialog visibility"
+#: src/gui/Preferences.cc:419
+msgid "When launching another instance with files:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
-msgid "Always show PDF export dialog"
+#: src/gui/Preferences.cc:421
+msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
-msgid "Always show 3MF export dialog"
+#: src/gui/Preferences.cc:423
+msgid "Autosave session in background for crash recovery"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
-msgid "Always show SVF export dialog"
+#: src/gui/Preferences.cc:424
+msgid "Autosave interval:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
-msgid "Always show GCODE export dialog"
-msgstr ""
+msgid "Console"
+msgstr "Консоль"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
-msgid "Always show Print Service dialog"
+msgid "Clear console before Preview/Render"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+msgid "Maximum lines for Console to keep:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+msgid "(0 for unlimited)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+msgid "Customizer"
+msgstr "Кастомайзер"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+msgid "OpenSCAD Language Features"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#, fuzzy
+msgid "Warnings"
+msgstr "Попередження OpenGL"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+msgid "Stop on the first warning"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+msgid "Check the parameter range for builtin modules"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+msgid "Warn when there is a parameter mismatch in user module calls"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+msgid "Trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+msgid "Trace depth:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
+msgid "(max. number or trace messages)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
+msgid "Show parameters of usermodule calls in trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
+msgid "Render Summary"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
+msgid "Camera"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
+msgid "Bounding Box"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
+msgid "Measurements: Area"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
+msgid "Measurements: Volume"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
+#, fuzzy
+msgid "Export Features"
+msgstr "Можливості"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
+msgid "Toolbar Export 3D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
+msgid "Toolbar Export 2D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
+msgid "Debugging"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
+msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
+msgid "Network Import List"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
+msgid "Globally trust Python designs"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
+msgid "Really (very dangerous)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
+msgid "Dialog visibility"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
+msgid "Always show PDF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
+msgid "Always show 3MF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
+msgid "Always show SVF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
+msgid "Always show GCODE export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
+msgid "Always show Print Service dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "Налаштування"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 msgid "Profiles"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 msgid "Active Profile"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "&Файл"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "Параметр"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "Параметр"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "Параметр"
@@ -3179,55 +3188,18 @@ msgstr ""
 "Вид: переміщення = [ %.2f %.2f %.2f ], оберт = [ %.2f %.2f %.2f ], відстань "
 "= %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3557,78 +3529,66 @@ msgstr "Введіть назву набору параметрів"
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "Параметр"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "Параметр"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr ""
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr ""
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 #, fuzzy
 msgid "Error"
 msgstr "Сховати панелі інструментів"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "&Файл"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "&Файл"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "Duplicate Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 msgid "A profile with that name already exists."
 msgstr ""
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3732,55 +3692,55 @@ msgstr ""
 "%1 вже існує.\n"
 "Перезаписати?"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr ""
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr ""
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "&Файл"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 #, fuzzy
 msgid "Close Tab"
 msgstr "Закрити"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "Зберегти ваші зміни?"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "Не показувати знову"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3789,15 +3749,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3807,7 +3767,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3816,39 +3776,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "Неможливо відкрити файл для запису"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "Помилка при збереженні дизайну"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "Збереги файл"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "Зберегти &як..."
@@ -3924,7 +3884,7 @@ msgstr "Не можу відкрити файл \"%1$s\" для експорту
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "ПОМИЛКА: \"%1$s\" помилка запису. (Диск переповнено?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "Про PythonSCAD"
@@ -3951,19 +3911,19 @@ msgstr "Початок"
 msgid "Show File"
 msgstr "Показувати масштабні маркери"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3971,19 +3931,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4285,9 +4245,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "QScintilla редактор"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(потребує перезапуску)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "Дозволити відкривати багато документів"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2021-02-26 14:17+0800\n"
 "Last-Translator: 玉堂白鹤 <yjwork@qq.com>\n"
 "Language-Team: \n"
@@ -106,7 +106,7 @@ msgstr "生成图片"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "首选项"
 
@@ -260,7 +260,7 @@ msgid "TextLabel"
 msgstr "文本标签"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "更新"
 
@@ -373,23 +373,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "清除"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr "配色方案:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "固定"
@@ -509,8 +509,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -556,7 +556,7 @@ msgid "Clear console"
 msgstr "清除控制台"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 msgid "Save As..."
 msgstr "另存为..."
 
@@ -810,7 +810,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "取消"
 
@@ -1192,7 +1192,7 @@ msgid "Font path"
 msgstr "字体"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "风格"
 
@@ -2030,7 +2030,7 @@ msgid "E&xport"
 msgstr "导出(&X)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2146,7 +2146,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2198,7 +2198,7 @@ msgid "Form"
 msgstr "表格"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "参数"
 
@@ -2255,750 +2255,759 @@ msgstr "-"
 msgid "More actions"
 msgstr "旋转"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D 视图"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "高级"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "编辑器"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "特性"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "启用/禁用实验功能"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "坐标轴"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "输入驱动配置与轴映射"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "按钮"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "3D 打印"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "3D 打印服务"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "配色方案:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "在 3D 视图中显示告警和错误"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "鼠标中心缩放"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 msgid "Alt"
 msgstr "Alt"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "鼠标左键"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr "任一"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Step Size"
 msgstr "步长"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "自动完成"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "启用自动完成"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "自动换行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "无"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "以字母为分界"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "以词为分界"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "缩进"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "提示符位置"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "保持原缩进"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "增加1缩进"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "缩进"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "行首"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "紧跟文字"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "贴边"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "位于行号栏"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "行尾"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "显示"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "高亮当前行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "显示行号"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "启用括号匹配"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "字体"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "语法高亮"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd +鼠标滚轮缩放文本"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(需重启程序)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "缩进"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "自动缩进"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "缩进使用"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "空格"
 
 # 同时应用在两个位置。一个表示标签页，一个表示 TAB 键。
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "Tab 标签"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "缩进宽度"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Tab 宽度"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Tab 键功能"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "插入制表符"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "显示空白字符"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "从不"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "总是"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "仅在缩进后"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "尺寸"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "自动检查更新"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "包含开发快照"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "立即检查"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "上次检查: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "3D 打印服务"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint 打印服务"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "API 密钥"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "加载"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "检查"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "切片配置"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "切片引擎"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "文件格式"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "动作"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "显示"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "注意：API 密钥未加密地存储在应用程序设置中。"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "应用程序"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "文件(&F)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "显示性能警告"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "关闭渲染于 "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "元素"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "强制使用 Goldfeather 算法"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "绘制(&E)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "CGAL 缓存大小"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "PolySet 缓存大小"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "用户界面"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "右侧面(&R)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
 msgid "Auto (follow system)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
 msgid "Enable docking helper widgets in different places"
 msgstr "解锁编辑器和控制台窗口位置"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
 #, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
 msgstr "允许编辑器和控制台成为浮窗"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
 msgid "Show Welcome Screen"
 msgstr "显示欢迎界面"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
 msgid "Enable user interface localization (requires restart of PythonSCAD)"
 msgstr "启用用户界面本地化 (重启 PythonSCAD 后生效)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
 msgid "Bring window to front after automatic reload"
 msgstr "自动重新加载后将窗口移到前面"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
 msgid "Play sound notification on render complete"
 msgstr "渲染完成时播放声音通知"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
 msgid "Play sound when render completion time is at least"
 msgstr "播放声音，当渲染完成时间至少需要"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
 msgid "sec"
 msgstr "秒时"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: src/gui/Preferences.cc:419
 msgid "When launching another instance with files:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: src/gui/Preferences.cc:421
 msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: src/gui/Preferences.cc:423
 msgid "Autosave session in background for crash recovery"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: src/gui/Preferences.cc:424
 msgid "Autosave interval:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
 msgid "Console"
 msgstr "控制台"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
 msgid "Clear console before Preview/Render"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
 msgid "Maximum lines for Console to keep:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
 msgid "(0 for unlimited)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
 msgid "Customizer"
 msgstr "定制"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
 msgid "OpenSCAD Language Features"
 msgstr "OpenSCAD 语言功能"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
 #, fuzzy
 msgid "Warnings"
 msgstr "OpenGL 警告"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
 msgid "Stop on the first warning"
 msgstr "在第一个警告时停止"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
 msgid "Check the parameter range for builtin modules"
 msgstr "检查内置模块的参数范围"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr "当用户模块调用中的参数不匹配时发出警告"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
 msgid "Trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
 msgid "Trace depth:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
 msgid "(max. number or trace messages)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
 msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
 msgid "Render Summary"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
 msgid "Camera"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
 msgid "Bounding Box"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
 msgid "Measurements: Area"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
 msgid "Measurements: Volume"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
 msgid "Export Features"
 msgstr "导出功能"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
 msgid "Toolbar Export 3D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
 msgid "Toolbar Export 2D"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
 msgid "Debugging"
 msgstr "调试"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
 msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
 msgstr "启用 HIDAPI 事件跟踪 (重启 PythonSCAD 后生效)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
 msgid "Network Import List"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
 msgid "Globally trust Python designs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
 msgid "Really (very dangerous)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
 msgid "Dialog visibility"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
 msgid "Always show PDF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
 msgid "Always show 3MF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
 msgid "Always show SVF export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
 msgid "Always show GCODE export dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
 msgid "Always show Print Service dialog"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "首选项"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "切片配置"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "切片配置"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "新建文件(&N)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "参数"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "参数"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "参数"
@@ -3164,55 +3173,18 @@ msgstr ""
 "三维视图状态: 平移 = [ %.2f %.2f %.2f ], 旋转 = [ %.2f %.2f %.2f ], 距离 = "
 "%.2f, 视角 = %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3539,79 +3511,67 @@ msgstr "输入参数设置的名称"
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "参数"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "参数"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<默认>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "成功: 服务器版本 = %2, API 版本 = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "错误"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "新建文件(&N)"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "复制文件名"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "切片配置"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "A profile with that name already exists."
 msgstr "设置名称 %1 已经存在。"
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3713,54 +3673,54 @@ msgstr ""
 "%1 已经存在。\n"
 "您要替换它么？"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "复制文件名"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "复制完整路径"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "打开文件(&O)"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 msgid "Close Tab"
 msgstr "关闭标签"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "要保存更改吗？"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "不再显示"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3769,15 +3729,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3787,7 +3747,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3796,39 +3756,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "无法打开文件进行写入"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "保存设计时出错"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "保存文件"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "另存为"
@@ -3905,7 +3865,7 @@ msgstr "无法打开文件 \"%1$s\" 进行导出"
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\" 写入错误。(磁盘已满?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "关于 PythonSCAD"
@@ -3932,19 +3892,19 @@ msgstr "行首"
 msgid "Show File"
 msgstr "显示坐标轴刻度"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3952,19 +3912,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4246,9 +4206,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "QScintilla 编辑器"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(需重启程序)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "允许打开多个文档"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2020.02.17\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 14:57+0200\n"
+"POT-Creation-Date: 2026-06-28 04:45+0200\n"
 "PO-Revision-Date: 2020-05-28 14:42+0200\n"
 "Last-Translator: Michael Tsao <cwtsao@sce.pccu.edu.tw>\n"
 "Language-Team: Distance Learning Center at the Chinese Culture University "
@@ -106,7 +106,7 @@ msgstr "轉存圖片"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
 msgid "Preferences"
 msgstr "偏好設定"
 
@@ -259,7 +259,7 @@ msgid "TextLabel"
 msgstr "文字標籤"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
 msgid "Update"
 msgstr "更新"
 
@@ -372,23 +372,23 @@ msgid "AI Chat"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:135
-#: src/gui/ai/ChatWidget.cc:75
+#: src/gui/ai/ChatWidget.cc:99
 msgid "AI Assistant"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:137
-#: src/gui/ai/ChatWidget.cc:77
+#: src/gui/ai/ChatWidget.cc:101
 msgid "Clear chat history"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:139
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
-#: src/gui/ai/ChatWidget.cc:76
+#: src/gui/ai/ChatWidget.cc:100
 msgid "Clear"
 msgstr "清除"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:140
-#: src/gui/ai/ChatWidget.cc:78
+#: src/gui/ai/ChatWidget.cc:102
 msgid "Send"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr "色彩方案:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 #: src/core/Settings.cc:161 src/core/Settings.cc:517
 msgid "Fixed"
 msgstr "固定"
@@ -508,8 +508,8 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
 msgid "..."
 msgstr ""
 
@@ -555,7 +555,7 @@ msgid "Clear console"
 msgstr "清除控制台"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
-#: src/gui/TabManager.cc:1839
+#: src/gui/TabManager.cc:1843
 #, fuzzy
 msgid "Save As..."
 msgstr "另存為(&A)"
@@ -812,7 +812,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
 #: src/gui/UnsavedChangesDialog.cc:60 src/openscad_gui.cc:196
-#: src/openscad_gui.cc:857
+#: src/openscad_gui.cc:860
 msgid "Cancel"
 msgstr "取消"
 
@@ -1194,7 +1194,7 @@ msgid "Font path"
 msgstr "字型"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Style"
 msgstr "樣式"
 
@@ -2048,7 +2048,7 @@ msgid "E&xport"
 msgstr "匯出(&E)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
 #: src/gui/Editor.cc:206 src/gui/Editor.cc:211 examples
 msgid "Python"
 msgstr ""
@@ -2166,7 +2166,7 @@ msgid "OctoPrint API Key Request"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
-#: src/openscad_gui.cc:855
+#: src/openscad_gui.cc:858
 msgid "Retry"
 msgstr ""
 
@@ -2218,7 +2218,7 @@ msgid "Form"
 msgstr "表格"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2685
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
 msgid "Parameter"
 msgstr "參數"
 
@@ -2276,754 +2276,763 @@ msgstr "-"
 msgid "More actions"
 msgstr "旋轉"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "3D View"
 msgstr "3D檢視"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "進階"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Editor"
 msgstr "編輯器"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2691
 msgid "Features"
 msgstr "特徵"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Enable/Disable experimental features"
 msgstr "啟用/禁用實驗功能"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
 msgid "Axes"
 msgstr "座標軸"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
 msgid "Input driver configuration and Axis mapping"
 msgstr "輸入裝置設定與座標軸映射"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
 msgid "Buttons"
 msgstr "按鈕"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
 msgid "Mouse"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2564
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
 msgid "Python Settings"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "3D列印"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
 msgid "3D Printing Services"
 msgstr "3D列印服務"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
 msgid "Dialogs"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
 msgid "AI"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "AI and LLM configurations"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "Directory of the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Extension of the output file without leading dot"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
 msgid "Full path to the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
 msgid "Directory of the main source file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "Full path to the output file"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2580
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
 msgid "Color scheme:"
 msgstr "色彩方案:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "Show Warnings and Errors in 3D View"
 msgstr "在3D檢視中顯示警告與錯誤"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "mouse centric zoom"
 msgstr "以滑鼠為中心縮放"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "Number Scroll"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
 #: src/core/Settings.cc:198
 #, fuzzy
 msgid "Alt"
 msgstr "全部取代"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
 #: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
 #: src/core/Settings.cc:200
 msgid "Either"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 #, fuzzy
 msgid "Step Size"
 msgstr "大小"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Number Scroll Via Mouse Wheel"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Modifier For Wheel Scroll "
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "Autocomplete"
 msgstr "自動補全"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2592
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid " Include defined modules"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2593
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Character Threshold"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2594
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid " Include defined functions"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2595
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "Enable Autocompletion"
 msgstr "啟用自動補全"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
 msgid " Include defined variables"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
 msgid "Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 #: src/core/Settings.cc:538
 msgid "Parsed File Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2599
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 #: src/core/Settings.cc:539
 msgid "Regex Input Text Mode"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2601
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
 msgid "Line wrap"
 msgstr "自動換行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2602
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 #: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
 #: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "沒有"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 #: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "以字母換行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 #: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "以單字換行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "Line wrap indentation"
 msgstr "縮排換行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Line wrap visualization"
 msgstr "視覺化換行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 #: src/core/Settings.cc:161
 msgid "Same"
 msgstr "相同"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 #: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "縮排"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
 #: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "縮排"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
 msgid "Start"
 msgstr "開始"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
 #: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "文字"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 #: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "邊框"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
 #: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "邊緣間隔"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "End"
 msgstr "結束"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid "Display"
 msgstr "顯示"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
 msgid "Highlight current line"
 msgstr "高亮游標所在行"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
 msgid "Display Line Numbers"
 msgstr "顯示行號"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
 msgid "Enable brace matching"
 msgstr "啟用括弧配對"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
 msgid "Font"
 msgstr "字型"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "Color syntax highlighting"
 msgstr "彩色語法標記"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd滑鼠滾輪文字縮放"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
-msgid "Use gvim as editor"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
+#, fuzzy
+msgid "Use gvim as editor (requires restart)"
+msgstr "(必須重新啟動)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "Indentation"
 msgstr "縮排"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Auto Indent"
 msgstr "自動縮排"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
 msgid "Backspace unindents"
 msgstr "退格鍵取消縮排"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
 msgid "Indent using"
 msgstr "縮排使用"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
 #: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "空白"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
 #: src/core/Settings.cc:187
 msgid "Tabs"
 msgstr "分頁"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
 msgid "Indentation width"
 msgstr "縮排寬度"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
 msgid "Tab width"
 msgstr "Tab寬度"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
 msgid "Tab key function"
 msgstr "Tab鍵功能"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2679
 #: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "插入Tab"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2681
 msgid "Show whitespace"
 msgstr "顯示空白字元"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2682
 #: src/core/Settings.cc:178
 msgid "Never"
 msgstr "從不"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
 #: src/core/Settings.cc:179
 msgid "Always"
 msgstr "永遠"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2684
 msgid "Only after indentation"
 msgstr "僅在縮排後"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2686
 msgid "Size"
 msgstr "大小"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
 msgid "Automatically check for updates"
 msgstr "自動檢查更新"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2688
 msgid "Include development snapshots"
 msgstr "包含開發版本"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2689
 msgid "Check Now"
 msgstr "立刻檢查"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
 msgid "Last checked: "
 msgstr "最後檢查： "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
 msgid "General"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
 #, fuzzy
 msgid "Default Print Service"
 msgstr "3D列印服務"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
 msgid "Enable remote print services"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
-#: src/gui/Preferences.cc:630
+#: src/gui/Preferences.cc:617
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
 msgid "URL"
 msgstr "網址"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2798
 msgid "API Key"
 msgstr "API金鑰"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
 msgid "Load"
 msgstr "讀取"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
 msgid "Check"
 msgstr "檢查"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
 msgid "Slicing Profile"
 msgstr "切片參數"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
 msgid "Slicing Engine"
 msgstr "切片引擎"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2677
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
 msgid "File Format"
 msgstr "檔案格式"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
 msgid "Action"
 msgstr "動作"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2673
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
 msgid "Request"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2674
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
 msgid "Show"
 msgstr "顯示"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2675
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2708
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "備註: 此API金鑰以非加密儲存於軟體設定中."
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2676
-#: src/gui/Preferences.cc:631
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2709
+#: src/gui/Preferences.cc:618
 #, fuzzy
 msgid "Local Application"
 msgstr "套用"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2678
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
 #, fuzzy
 msgid "File"
 msgstr "檔案(&F)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2683
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
 msgid "Executable"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2687
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2690
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
 msgid "Temp Dir"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2692
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
 msgid "3D Preview (OpenCSG)"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2693
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2726
 msgid "Show capability warning"
 msgstr "顯示性能警告"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2694
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
 msgid "Turn off rendering at "
 msgstr "關閉渲染於 "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2695
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2728
 msgid "elements"
 msgstr "元素"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2696
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
 msgid "Force Goldfeather"
 msgstr "強制Goldfeather"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2697
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
 #, fuzzy
 msgid "3D Rendering"
 msgstr "渲染(&E)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2698
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
 msgid "Backend"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2699
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
 msgid "CGAL Cache size"
 msgstr "CGAL快取大小"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2700
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2702
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2701
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
 msgid "PolySet Cache size"
 msgstr "PolySet快取大小"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2703
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
 msgid "User Interface"
 msgstr "使用者介面"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2704
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
 msgid "GUI theme"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2705
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
 #, fuzzy
 msgid "Light"
 msgstr "右(&R)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2706
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
 msgid "Dark"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2707
-msgid "Auto (follow system)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2710
-#, fuzzy
-msgid "Enable docking helper widgets in different places"
-msgstr "在不同位置啟用嵌合的編輯器與控制台"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2711
-#, fuzzy
-msgid "Enable undocking of helper widgets to separate windows"
-msgstr "在個別視窗啟用分離的編輯器與控制台"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2712
-msgid "Show Welcome Screen"
-msgstr "顯示歡迎視窗"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2713
-msgid "Enable user interface localization (requires restart of PythonSCAD)"
-msgstr "啟用本地化使用者介面(需要重新啟動PythonSCAD)"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2714
-msgid "Bring window to front after automatic reload"
-msgstr "自動重整後將視窗浮到前景"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2715
-msgid "Play sound notification on render complete"
-msgstr "渲染完成後播放音效通知"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2716
-#, fuzzy
-msgid "Play sound when render completion time is at least"
-msgstr "渲染完成後播放音效通知，當渲染時間大於"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2717
-msgid "sec"
-msgstr "秒"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2718
-#: src/gui/Preferences.cc:433
-msgid "When launching another instance with files:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2719
-#: src/gui/Preferences.cc:435
-msgid "Enable session management (save/restore tabs on quit, requires restart)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2720
-#: src/gui/Preferences.cc:437
-msgid "Autosave session in background for crash recovery"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2721
-#: src/gui/Preferences.cc:438
-msgid "Autosave interval:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2722
-msgid "Console"
-msgstr "控制台"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2723
-msgid "Clear console before Preview/Render"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2724
-msgid "Maximum lines for Console to keep:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2725
-msgid "(0 for unlimited)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2727
-msgid "Customizer"
-msgstr "自訂"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2729
-msgid "OpenSCAD Language Features"
-msgstr "OpenSCAD語言特色"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2730
-#, fuzzy
-msgid "Warnings"
-msgstr "OpenGL警告"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2731
-msgid "Stop on the first warning"
-msgstr "在第一個警告時停止"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2732
-#, fuzzy
-msgid "Check the parameter range for builtin modules"
-msgstr "檢查內建模組的參數範圍"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2733
-msgid "Warn when there is a parameter mismatch in user module calls"
-msgstr "當呼叫使用者模組中有參數錯誤時發出警告"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2734
-msgid "Trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2735
-msgid "Trace depth:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2736
-msgid "(max. number or trace messages)"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2737
-msgid "Show parameters of usermodule calls in trace"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2738
-msgid "Render Summary"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2739
-msgid "Camera"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2740
-msgid "Bounding Box"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2741
-msgid "Measurements: Area"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2742
-msgid "Measurements: Volume"
+msgid "Auto (follow system)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2743
 #, fuzzy
-msgid "Export Features"
-msgstr "特徵"
+msgid "Enable docking helper widgets in different places"
+msgstr "在不同位置啟用嵌合的編輯器與控制台"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2744
-msgid "Toolbar Export 3D"
-msgstr ""
+#, fuzzy
+msgid "Enable undocking of helper widgets to separate windows"
+msgstr "在個別視窗啟用分離的編輯器與控制台"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2745
-msgid "Toolbar Export 2D"
-msgstr ""
+msgid "Show Welcome Screen"
+msgstr "顯示歡迎視窗"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2746
-msgid "Debugging"
-msgstr "除錯"
+msgid "Enable user interface localization (requires restart of PythonSCAD)"
+msgstr "啟用本地化使用者介面(需要重新啟動PythonSCAD)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2747
-msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
-msgstr ""
+msgid "Bring window to front after automatic reload"
+msgstr "自動重整後將視窗浮到前景"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2748
-msgid "Network Import List"
-msgstr ""
+msgid "Play sound notification on render complete"
+msgstr "渲染完成後播放音效通知"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2749
-msgid "Globally trust Python designs"
-msgstr ""
+#, fuzzy
+msgid "Play sound when render completion time is at least"
+msgstr "渲染完成後播放音效通知，當渲染時間大於"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2750
-msgid "Really (very dangerous)"
-msgstr ""
+msgid "sec"
+msgstr "秒"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2751
-msgid "Dialog visibility"
+#: src/gui/Preferences.cc:419
+msgid "When launching another instance with files:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2752
-msgid "Always show PDF export dialog"
+#: src/gui/Preferences.cc:421
+msgid "Enable session management (save/restore tabs on quit, requires restart)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2753
-msgid "Always show 3MF export dialog"
+#: src/gui/Preferences.cc:423
+msgid "Autosave session in background for crash recovery"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2754
-msgid "Always show SVF export dialog"
+#: src/gui/Preferences.cc:424
+msgid "Autosave interval:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2755
-msgid "Always show GCODE export dialog"
-msgstr ""
+msgid "Console"
+msgstr "控制台"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2756
-msgid "Always show Print Service dialog"
+msgid "Clear console before Preview/Render"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2757
+msgid "Maximum lines for Console to keep:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+msgid "(0 for unlimited)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+msgid "Customizer"
+msgstr "自訂"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+msgid "OpenSCAD Language Features"
+msgstr "OpenSCAD語言特色"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#, fuzzy
+msgid "Warnings"
+msgstr "OpenGL警告"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+msgid "Stop on the first warning"
+msgstr "在第一個警告時停止"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2765
+#, fuzzy
+msgid "Check the parameter range for builtin modules"
+msgstr "檢查內建模組的參數範圍"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+msgid "Warn when there is a parameter mismatch in user module calls"
+msgstr "當呼叫使用者模組中有參數錯誤時發出警告"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+msgid "Trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+msgid "Trace depth:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2769
+msgid "(max. number or trace messages)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2770
+msgid "Show parameters of usermodule calls in trace"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2771
+msgid "Render Summary"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2772
+msgid "Camera"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2773
+msgid "Bounding Box"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2774
+msgid "Measurements: Area"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2775
+msgid "Measurements: Volume"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2776
+#, fuzzy
+msgid "Export Features"
+msgstr "特徵"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2777
+msgid "Toolbar Export 3D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2778
+msgid "Toolbar Export 2D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2779
+msgid "Debugging"
+msgstr "除錯"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2780
+msgid "Enable tracing of HIDAPI events (requires restart of PythonSCAD)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2781
+msgid "Network Import List"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2782
+msgid "Globally trust Python designs"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2783
+msgid "Really (very dangerous)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2784
+msgid "Dialog visibility"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2785
+msgid "Always show PDF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2786
+msgid "Always show 3MF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2787
+msgid "Always show SVF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2788
+msgid "Always show GCODE export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2789
+msgid "Always show Print Service dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2790
 #, fuzzy
 msgid "AI Preferences"
 msgstr "偏好設定"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2758
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2791
 msgid ""
-"Note: AI integration is currently under active development. Storing "
-"preferences is supported, but API connection is not yet active."
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2759
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2792
 #, fuzzy
 msgid "Profiles"
 msgstr "切片參數"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2760
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2793
 #, fuzzy
 msgid "Active Profile"
 msgstr "切片參數"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2761
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2794
 #, fuzzy
 msgid "New Profile"
 msgstr "檔案(&F)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2762
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2795
 msgid "Delete"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2763
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2796
 msgid "API Configuration"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2764
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2797
 msgid "API Endpoint"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2766
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2799
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2800
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2801
 #, fuzzy
 msgid "API Parameters"
 msgstr "參數"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2767
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2802
 #, fuzzy
 msgid "Add Parameter"
 msgstr "參數"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2768
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2803
 #, fuzzy
 msgid "Remove Parameter"
 msgstr "參數"
@@ -3189,55 +3198,18 @@ msgstr ""
 "視角: translate = [ %.2f %.2f %.2f ], rotate = [ %.2f %.2f %.2f ], distance "
 "= %.2f"
 
-#: src/gui/ai/ChatWidget.cc:86 src/gui/ai/ChatWidget.cc:169
-msgid ""
-"Hello! I am your OpenSCAD AI assistant. Note: AI connection is under "
-"development and is not yet active. I currently only simulate responses.\n"
-"\n"
-"Ask me to write some code, e.g. \"draw a sphere\" or \"create a box with a "
-"hole\"."
+#: src/gui/ai/ChatWidget.cc:62 src/gui/ai/ChatWidget.cc:143
+msgid "Thinking..."
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:107
-msgid "AI is thinking..."
+#: src/gui/ai/ChatWidget.cc:71
+msgid "Thinking"
 msgstr ""
 
-#: src/gui/ai/ChatWidget.cc:126
+#: src/gui/ai/ChatWidget.cc:114 src/gui/ai/ChatWidget.cc:210
 msgid ""
-"Here is how you can create a sphere in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Sphere with radius 10 and smooth details\n"
-"sphere(r = 10, $fn = 100);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:130
-msgid ""
-"Here is how you can create a cube in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cube centered at the origin\n"
-"cube(size = [10, 20, 15], center = true);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:134
-msgid ""
-"Here is how you can create a cylinder in OpenSCAD:\n"
-"\n"
-"```openscad\n"
-"// Cylinder with height 20 and radius 5\n"
-"cylinder(h = 20, r = 5, center = true, $fn = 50);\n"
-"```"
-msgstr ""
-
-#: src/gui/ai/ChatWidget.cc:137
-msgid ""
-"I received your prompt: \"%1\".\n"
-"\n"
-"I can help you build 3D models using OpenSCAD! Try asking me to create a "
-"shape like a 'sphere' or a 'cube'."
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
 
 #: src/gui/Animate.cc:207
@@ -3566,79 +3538,67 @@ msgstr "輸入參數設定的名稱"
 msgid "New set "
 msgstr ""
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Key"
 msgstr "參數"
 
-#: src/gui/Preferences.cc:295
+#: src/gui/Preferences.cc:296
 #, fuzzy
 msgid "Parameter Value"
 msgstr "參數"
 
 #: src/gui/Preferences.cc:312 src/gui/Preferences.cc:317
-msgid "OpenAI GPT-4"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:325
-msgid "Anthropic Claude"
-msgstr ""
-
-#: src/gui/Preferences.cc:312 src/gui/Preferences.cc:334
 msgid "Ollama Local"
 msgstr ""
 
-#: src/gui/Preferences.cc:312
-msgid "Custom / Local LLM"
-msgstr ""
-
-#: src/gui/Preferences.cc:439
+#: src/gui/Preferences.cc:425
 msgid " seconds"
 msgstr ""
 
-#: src/gui/Preferences.cc:466 src/gui/Preferences.cc:471
-#: src/gui/Preferences.cc:1446 src/gui/Preferences.cc:1485
+#: src/gui/Preferences.cc:452 src/gui/Preferences.cc:457
+#: src/gui/Preferences.cc:1433 src/gui/Preferences.cc:1472
 msgid "<Default>"
 msgstr "<預設>"
 
-#: src/gui/Preferences.cc:629
+#: src/gui/Preferences.cc:616
 msgid "NONE"
 msgstr ""
 
-#: src/gui/Preferences.cc:1429
+#: src/gui/Preferences.cc:1416
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "成功: 伺服器版本 = %2, API版本 = %1"
 
-#: src/gui/Preferences.cc:1431 src/gui/Preferences.cc:1456
-#: src/gui/Preferences.cc:1495
+#: src/gui/Preferences.cc:1418 src/gui/Preferences.cc:1443
+#: src/gui/Preferences.cc:1482
 msgid "Error"
 msgstr "錯誤"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "New AI Profile"
 msgstr "檔案(&F)"
 
-#: src/gui/Preferences.cc:1571
+#: src/gui/Preferences.cc:1559
 #, fuzzy
 msgid "Profile name:"
 msgstr "複製檔案名稱"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "Duplicate Profile"
 msgstr "切片參數"
 
-#: src/gui/Preferences.cc:1576
+#: src/gui/Preferences.cc:1564
 #, fuzzy
 msgid "A profile with that name already exists."
 msgstr "設定名稱 %1 已存在"
 
-#: src/gui/Preferences.cc:1611
+#: src/gui/Preferences.cc:1599
 msgid "Delete AI Profile"
 msgstr ""
 
-#: src/gui/Preferences.cc:1612
+#: src/gui/Preferences.cc:1600
 msgid "Delete profile \"%1\"?"
 msgstr ""
 
@@ -3736,55 +3696,55 @@ msgstr ""
 "%1 已存在。\n"
 "是否要覆寫？"
 
-#: src/gui/TabManager.cc:796
+#: src/gui/TabManager.cc:800
 msgid "Copy file name"
 msgstr "複製檔案名稱"
 
-#: src/gui/TabManager.cc:802
+#: src/gui/TabManager.cc:806
 msgid "Copy full path"
 msgstr "複製完整路徑"
 
-#: src/gui/TabManager.cc:808
+#: src/gui/TabManager.cc:812
 #, fuzzy
 msgid "Open Folder"
 msgstr "檔案(&F)"
 
-#: src/gui/TabManager.cc:813
+#: src/gui/TabManager.cc:817
 #, fuzzy
 msgid "Close Tab"
 msgstr "關閉分頁"
 
-#: src/gui/TabManager.cc:818
+#: src/gui/TabManager.cc:822
 msgid "Close All But This Tab"
 msgstr ""
 
-#: src/gui/TabManager.cc:1114
+#: src/gui/TabManager.cc:1118
 #, fuzzy
 msgid "Do you want to save the changes you made to %1?"
 msgstr "是否要儲存你的變更？"
 
-#: src/gui/TabManager.cc:1115
+#: src/gui/TabManager.cc:1119
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/gui/TabManager.cc:1120
+#: src/gui/TabManager.cc:1124
 #, fuzzy
 msgid "Don't save"
 msgstr "不再顯示"
 
-#: src/gui/TabManager.cc:1582 src/gui/TabManager.cc:1611
-#: src/gui/TabManager.cc:1618 src/gui/TabManager.cc:1646
-#: src/gui/TabManager.cc:1834
+#: src/gui/TabManager.cc:1586 src/gui/TabManager.cc:1615
+#: src/gui/TabManager.cc:1622 src/gui/TabManager.cc:1650
+#: src/gui/TabManager.cc:1838
 msgid "Session Restore"
 msgstr ""
 
-#: src/gui/TabManager.cc:1583
+#: src/gui/TabManager.cc:1587
 msgid ""
 "The session file was created by a newer version of PythonSCAD (session "
 "version %1, but this build only supports up to version %2)."
 msgstr ""
 
-#: src/gui/TabManager.cc:1588
+#: src/gui/TabManager.cc:1592
 msgid ""
 "Exit to keep the session file for use with a newer PythonSCAD, or discard it "
 "to start fresh here.\n"
@@ -3793,15 +3753,15 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/gui/TabManager.cc:1591
+#: src/gui/TabManager.cc:1595
 msgid "Exit"
 msgstr ""
 
-#: src/gui/TabManager.cc:1592
+#: src/gui/TabManager.cc:1596
 msgid "Discard session"
 msgstr ""
 
-#: src/gui/TabManager.cc:1612
+#: src/gui/TabManager.cc:1616
 msgid ""
 "Could not open the session file for reading:\n"
 "%1\n"
@@ -3811,7 +3771,7 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1619
+#: src/gui/TabManager.cc:1623
 msgid ""
 "The session file is corrupt or unreadable:\n"
 "%1\n"
@@ -3820,39 +3780,39 @@ msgid ""
 "Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1647
+#: src/gui/TabManager.cc:1651
 msgid ""
 "The session file uses an old format (version %1) that cannot be migrated to "
 "the current format (version %2). Starting with a fresh session."
 msgstr ""
 
-#: src/gui/TabManager.cc:1835
+#: src/gui/TabManager.cc:1839
 msgid "%1 file(s) could not be found on disk."
 msgstr ""
 
-#: src/gui/TabManager.cc:1837
+#: src/gui/TabManager.cc:1841
 msgid ""
 "The session contents were restored, but the file paths are stale.\n"
 "Use Save As to pick a new location."
 msgstr ""
 
-#: src/gui/TabManager.cc:1840
+#: src/gui/TabManager.cc:1844
 msgid "Dismiss"
 msgstr ""
 
-#: src/gui/TabManager.cc:1953 src/gui/TabManager.cc:2105
+#: src/gui/TabManager.cc:1957 src/gui/TabManager.cc:2109
 msgid "Failed to open file for writing"
 msgstr "寫入時開啟檔案錯誤"
 
-#: src/gui/TabManager.cc:1993 src/gui/TabManager.cc:2119
+#: src/gui/TabManager.cc:1997 src/gui/TabManager.cc:2123
 msgid "Error saving design"
 msgstr "儲存設計錯誤"
 
-#: src/gui/TabManager.cc:2005
+#: src/gui/TabManager.cc:2009
 msgid "Save File"
 msgstr "儲存檔案"
 
-#: src/gui/TabManager.cc:2082
+#: src/gui/TabManager.cc:2086
 #, fuzzy
 msgid "Save A Copy"
 msgstr "全部儲存"
@@ -3931,7 +3891,7 @@ msgstr "無法開啟檔案 \"%1$s\" 用以匯出"
 msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "錯誤: \"%1$s\" 寫入錯誤. (磁碟滿載?)"
 
-#: src/openscad_gui.cc:193 src/openscad_gui.cc:819 src/openscad_gui.cc:849
+#: src/openscad_gui.cc:193 src/openscad_gui.cc:822 src/openscad_gui.cc:852
 #, fuzzy
 msgid "PythonSCAD"
 msgstr "關於 PythonSCAD"
@@ -3958,19 +3918,19 @@ msgstr "開始"
 msgid "Show File"
 msgstr "顯示刻度標記"
 
-#: src/openscad_gui.cc:719
+#: src/openscad_gui.cc:722
 msgid ""
 "PythonSCAD is already running. The existing window was brought to the front; "
 "this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:723
+#: src/openscad_gui.cc:726
 msgid ""
 "PythonSCAD is already running. An open request for the requested design "
 "file(s) was sent to that instance; this process exits."
 msgstr ""
 
-#: src/openscad_gui.cc:820
+#: src/openscad_gui.cc:823
 msgid ""
 "Could not create the application configuration directory required for "
 "session data and single-instance locking:\n"
@@ -3978,19 +3938,19 @@ msgid ""
 "%1"
 msgstr ""
 
-#: src/openscad_gui.cc:851
+#: src/openscad_gui.cc:854
 msgid ""
 "PythonSCAD is already running but is not responding. The old PythonSCAD "
 "process must be closed to open a new window."
 msgstr ""
 
-#: src/openscad_gui.cc:854
+#: src/openscad_gui.cc:857
 msgid ""
 "Try again if the running instance may have recovered, or close it to start a "
 "new one."
 msgstr ""
 
-#: src/openscad_gui.cc:856
+#: src/openscad_gui.cc:859
 msgid "Close PythonSCAD"
 msgstr ""
 
@@ -4313,9 +4273,6 @@ msgstr ""
 
 #~ msgid "QScintilla Editor"
 #~ msgstr "QScintilla編輯器"
-
-#~ msgid "(requires restart)"
-#~ msgstr "(必須重新啟動)"
 
 #~ msgid "Allow opening multiple documents"
 #~ msgstr "允許開啟多個檔案"

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -777,7 +777,7 @@
               <item row="3" column="1">
                <widget class="QCheckBox" name="checkBoxUseGvim">
                 <property name="text">
-                 <string>Use gvim as editor</string>
+                 <string>Use gvim as editor (requires restart)</string>
                 </property>
                 <property name="checked">
                  <bool>false</bool>

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -201,6 +201,22 @@ void warnDesignPathIsDirectory(QWidget *dialogParent, const QString& absPath)
                          .arg(QDir::toNativeSeparators(absPath)));
 }
 
+void launchGvimForFile(const QString& filepath)
+{
+  if (filepath.isEmpty()) return;
+
+  QString escapedFilename = filepath;
+  escapedFilename.replace("'", "'\\''");
+
+  const QString editorcmd = "GDK_BACKEND=x11 gvim --servername PYTHONSCAD --remote-tab-silent '" +
+                            escapedFilename +
+                            "' 2>/dev/null || "
+                            "GDK_BACKEND=x11 gvim --servername PYTHONSCAD '" +
+                            escapedFilename + "' &";
+  const int gvimRc = system(editorcmd.toUtf8().constData());
+  (void)gvimRc;
+}
+
 void initEmptyUntitledTab(EditorInterface *editor)
 {
 #ifdef ENABLE_PYTHON
@@ -393,23 +409,7 @@ void TabManager::tabSwitched(int x)
   parent->setWindowTitle(tabWidget->tabText(x).replace("&&", "&"));
 
   if (use_gvim) {
-    auto *tabEditor = (EditorInterface *)tabWidget->widget(x);
-    std::string filename = tabEditor->filepath.toUtf8().constData();
-    if (!filename.empty()) {
-      QString escapedFilename = QString::fromStdString(filename).replace("'", "'\\''");
-      //    QString editorcmd =
-      //      "GDK_BACKEND=x11 gvim --servername PYTHONSCAD--remote-silent --remote-send "
-      //      "'<Esc>:tabedit " + escapedFilename + "<CR>:b " + escapedFilename + "<CR>' 2>/dev/null"
-      //      " || GDK_BACKEND=x11 gvim --servername PYTHONSCAD --remote-silent '" + escapedFilename + "'
-      //      &";
-      QString editorcmd = "GDK_BACKEND=x11 gvim --servername PYTHONSCAD --remote-tab-silent '" +
-                          escapedFilename +
-                          "' 2>/dev/null || "
-                          "GDK_BACKEND=x11 gvim --servername PYTHONSCAD '" +
-                          escapedFilename + "' &";
-      const int gvimRc = system(editorcmd.toUtf8().constData());
-      (void)gvimRc;
-    }
+    launchGvimForFile(editor->filepath);
   }
   auto numberOfOpenTabs = tabWidget->count();
   // Hides all the closing button except the one on the currently focused editor
@@ -502,6 +502,9 @@ void TabManager::open(const QString& filename)
     // so recomputeLanguageActive() follows the opened file's extension (.scad vs .py).
     editor->resetLanguageDetection();
     openTabFile(filename);
+    if (use_gvim) {
+      launchGvimForFile(editor->filepath);
+    }
     editor->recomputeLanguageActive();
     parent->onLanguageActiveChanged(editor->language);
     updateTabIcon(editor);

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -391,18 +391,26 @@ void TabManager::tabSwitched(int x)
 
   parent->editActionUndo->setEnabled(editor->canUndo());
   parent->setWindowTitle(tabWidget->tabText(x).replace("&&", "&"));
+
   if (use_gvim) {
-    // **MCH*
     auto *tabEditor = (EditorInterface *)tabWidget->widget(x);
     std::string filename = tabEditor->filepath.toUtf8().constData();
-    QString editorcmd = "gvim --remote-send '<esc>:sb " + QString::fromStdString(filename) +
-                        "<cr>' || (gvim '" + QString::fromStdString(filename) + "' &)";
-    //   LOG("1. Opening file '%1$s'",editorcmd.toUtf8().constData());
-    const int gvimRc = system(editorcmd.toUtf8().constData());
-    (void)gvimRc;
-    // **MCH*
+    if (!filename.empty()) {
+      QString escapedFilename = QString::fromStdString(filename).replace("'", "'\\''");
+      //    QString editorcmd =
+      //      "GDK_BACKEND=x11 gvim --servername PYTHONSCAD--remote-silent --remote-send "
+      //      "'<Esc>:tabedit " + escapedFilename + "<CR>:b " + escapedFilename + "<CR>' 2>/dev/null"
+      //      " || GDK_BACKEND=x11 gvim --servername PYTHONSCAD --remote-silent '" + escapedFilename + "'
+      //      &";
+      QString editorcmd = "GDK_BACKEND=x11 gvim --servername PYTHONSCAD --remote-tab-silent '" +
+                          escapedFilename +
+                          "' 2>/dev/null || "
+                          "GDK_BACKEND=x11 gvim --servername PYTHONSCAD '" +
+                          escapedFilename + "' &";
+      const int gvimRc = system(editorcmd.toUtf8().constData());
+      (void)gvimRc;
+    }
   }
-
   auto numberOfOpenTabs = tabWidget->count();
   // Hides all the closing button except the one on the currently focused editor
   for (int idx = 0; idx < numberOfOpenTabs; ++idx) {
@@ -477,14 +485,10 @@ void TabManager::open(const QString& filename)
 {
   assert(!filename.isEmpty());
 
-  if (use_gvim) {
-    QString editorcmd =
-      "gvim --remote-tab-silent '" + filename.toUtf8() + "' || gvim '" + filename.toUtf8() + "' &";
-    editorcmd += filename.toUtf8();
-    //    LOG("2. Opening file '%1$s'",editorcmd.toUtf8().constData());
-    const int gvimRc = system(editorcmd.toUtf8().constData());
-    (void)gvimRc;
-  }
+  // Note: gvim is intentionally NOT called here.
+  // tabSwitched() is triggered by setCurrentWidget() or createTab() below,
+  // and handles opening/switching the file in gvim — calling it here too
+  // would result in gvim being invoked twice per tab switch.
   for (auto edt : editorList) {
     if (filename == edt->filepath) {
       tabWidget->setCurrentWidget(edt);


### PR DESCRIPTION
Use a dedicated gvim server name with X11 and remote-tab handling so tab switches open or focus the expected file. Avoid invoking gvim from both open() and tabSwitched(), which could start or switch the editor twice.

@mchendriks Thanks for reporting and fixing this issue.