### PR TITLE
fix: use existing labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Create a report to help us improve
 title: "[Bug]: "
-labels: ["Type: Bug"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'Type: Enhancement'
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/other-development-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-development-issue.md
@@ -2,12 +2,13 @@
 name: Other development issue
 about: Development related issues
 title: ''
-labels: 'Type: Discussion'
+labels: 'question'
 assignees: ''
 
 ---
 
-Please first consider that general questions about using OpenSCAD or how to write code for specific models are better asked on the mailing list. See https://openscad.org/community.html for more details.
+Please first consider that general questions about using OpenSCAD or how to write code for specific models are
+better asked on the mailing list. See <https://openscad.org/community.html> for more details.
 
 **Environment**
 Which environment is the issue about, e.g. Compiling with MSYS2 on Windows


### PR DESCRIPTION
## Summary
- Update issue templates to reference existing repository labels (`bug`, `enhancement`, `question`) instead of missing `Type: *` labels.
- Fix markdownlint issues in the touched development issue template.

## Test plan
- `pre-commit run --files .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.md .github/ISSUE_TEMPLATE/other-development-issue.md`

Fixes #799.