### PR TITLE
fix: report unsafe fillet topology

### DIFF
--- a/src/core/FilletNode.cc
+++ b/src/core/FilletNode.cc
@@ -170,8 +170,9 @@ bool validateFilletEdgePairs(const std::vector<IndexedFace>& indices, EdgeKey& f
       if (ind1 == ind2) continue;
 
       EdgeKey edge(ind1, ind2);
-      if (edge_db.count(edge) == 0) edge_db[edge] = empty;
-      EdgeVal& value = edge_db[edge];
+      auto [edgeIt, inserted] = edge_db.emplace(edge, empty);
+      (void)inserted;
+      EdgeVal& value = edgeIt->second;
       if (ind2 > ind1) {
         if (value.facea != -1) {
           failedEdge = edge;

--- a/src/core/FilletNode.cc
+++ b/src/core/FilletNode.cc
@@ -149,6 +149,58 @@ void debug_pt(const char *msg, Vector3d pt)
   printf("%s %g/%g/%g\n", msg, pt[0], pt[1], pt[2]);
 }
 
+namespace {
+
+bool validateFilletEdgePairs(const std::vector<IndexedFace>& indices, EdgeKey& failedEdge)
+{
+  std::unordered_map<EdgeKey, EdgeVal, boost::hash<EdgeKey>> edge_db;
+  EdgeVal empty;
+  empty.sel = 0;
+  empty.facea = -1;
+  empty.faceb = -1;
+  empty.posa = -1;
+  empty.posb = -1;
+
+  for (size_t faceIndex = 0; faceIndex < indices.size(); faceIndex++) {
+    const auto& face = indices[faceIndex];
+    int n = face.size();
+    for (int pos = 0; pos < n; pos++) {
+      int ind1 = face[pos];
+      int ind2 = face[(pos + 1) % n];
+      if (ind1 == ind2) continue;
+
+      EdgeKey edge(ind1, ind2);
+      if (edge_db.count(edge) == 0) edge_db[edge] = empty;
+      EdgeVal& value = edge_db[edge];
+      if (ind2 > ind1) {
+        if (value.facea != -1) {
+          failedEdge = edge;
+          return false;
+        }
+        value.facea = faceIndex;
+        value.posa = pos;
+      } else {
+        if (value.faceb != -1) {
+          failedEdge = edge;
+          return false;
+        }
+        value.faceb = faceIndex;
+        value.posb = pos;
+      }
+    }
+  }
+
+  for (const auto& edge : edge_db) {
+    if (edge.second.facea == -1 || edge.second.faceb == -1) {
+      failedEdge = edge.first;
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
 std::unique_ptr<const Geometry> createFilletInt(std::shared_ptr<const PolySet> ps,
                                                 std::vector<bool> corner_selected, double r_, int bn,
                                                 double minang)
@@ -744,6 +796,16 @@ std::unique_ptr<const Geometry> FilletNode::createGeometry() const
     ps_merged->indices = mergeTriangles(ps->indices, normals, newnormals, faceParents, ps->vertices);
 
   } else return std::unique_ptr<PolySet>();
+
+  EdgeKey failedEdge;
+  if (!validateFilletEdgePairs(ps_merged->indices, failedEdge)) {
+    LOG(message_group::Error,
+        "fillet() cannot process the selected object: edge %1$d-%2$d is not shared by exactly two "
+        "oppositely-oriented faces. This often happens when the fillet radius collides with nearby "
+        "geometry; try reducing r or applying fillet() before unioning adjacent solids.",
+        failedEdge.ind1, failedEdge.ind2);
+    return PolySet::createEmpty();
+  }
 
   if (this->children.size() >= 2) {
     std::shared_ptr<const PolySet> sel = childToPolySet(this->children[1]);

--- a/src/core/FilletNode.cc
+++ b/src/core/FilletNode.cc
@@ -212,6 +212,16 @@ std::unique_ptr<const Geometry> createFilletInt(std::shared_ptr<const PolySet> p
   std::vector<IndexedFace> merged =
     mergeTriangles(ps->indices, normals, newnormals, faceParents, ps->vertices);
 
+  EdgeKey failedEdge;
+  if (!validateFilletEdgePairs(merged, failedEdge)) {
+    LOG(message_group::Error,
+        "fillet() cannot process the selected object: edge %1$d-%2$d is not shared by exactly two "
+        "oppositely-oriented faces. This can happen when the fillet radius collides with nearby "
+        "geometry; try reducing the fillet radius or applying fillet() before unioning adjacent solids.",
+        failedEdge.ind1, failedEdge.ind2);
+    return PolySet::createEmpty();
+  }
+
   if (bn < 2) bn = 2;
   // Create vertex2face db
   auto vertices_copy = ps->vertices;
@@ -796,17 +806,6 @@ std::unique_ptr<const Geometry> FilletNode::createGeometry() const
     ps_merged->indices = mergeTriangles(ps->indices, normals, newnormals, faceParents, ps->vertices);
 
   } else return std::unique_ptr<PolySet>();
-
-  EdgeKey failedEdge;
-  if (!validateFilletEdgePairs(ps_merged->indices, failedEdge)) {
-    LOG(message_group::Error,
-        "fillet() cannot process the selected object: edge %1$d-%2$d is not shared by exactly two "
-        "oppositely-oriented faces. This often happens when the fillet radius collides with nearby "
-        "geometry; try reducing r or applying fillet() before unioning adjacent solids.",
-        failedEdge.ind1, failedEdge.ind2);
-    return PolySet::createEmpty();
-  }
-
   if (this->children.size() >= 2) {
     std::shared_ptr<const PolySet> sel = childToPolySet(this->children[1]);
     if (sel != nullptr) {

--- a/src/core/FilletNode.cc
+++ b/src/core/FilletNode.cc
@@ -154,7 +154,7 @@ namespace {
 bool validateFilletEdgePairs(const std::vector<IndexedFace>& indices, EdgeKey& failedEdge)
 {
   std::unordered_map<EdgeKey, EdgeVal, boost::hash<EdgeKey>> edge_db;
-  EdgeVal empty;
+  EdgeVal empty{};
   empty.sel = 0;
   empty.facea = -1;
   empty.faceb = -1;

--- a/src/core/FilletNode.cc
+++ b/src/core/FilletNode.cc
@@ -151,15 +151,14 @@ void debug_pt(const char *msg, Vector3d pt)
 
 namespace {
 
+struct FilletEdgePair {
+  int facea = -1;
+  int faceb = -1;
+};
+
 bool validateFilletEdgePairs(const std::vector<IndexedFace>& indices, EdgeKey& failedEdge)
 {
-  std::unordered_map<EdgeKey, EdgeVal, boost::hash<EdgeKey>> edge_db;
-  EdgeVal empty{};
-  empty.sel = 0;
-  empty.facea = -1;
-  empty.faceb = -1;
-  empty.posa = -1;
-  empty.posb = -1;
+  std::unordered_map<EdgeKey, FilletEdgePair, boost::hash<EdgeKey>> edge_db;
 
   for (size_t faceIndex = 0; faceIndex < indices.size(); faceIndex++) {
     const auto& face = indices[faceIndex];
@@ -170,23 +169,20 @@ bool validateFilletEdgePairs(const std::vector<IndexedFace>& indices, EdgeKey& f
       if (ind1 == ind2) continue;
 
       EdgeKey edge(ind1, ind2);
-      auto [edgeIt, inserted] = edge_db.emplace(edge, empty);
-      (void)inserted;
-      EdgeVal& value = edgeIt->second;
+      auto edgeIt = edge_db.emplace(edge, FilletEdgePair{}).first;
+      FilletEdgePair& value = edgeIt->second;
       if (ind2 > ind1) {
         if (value.facea != -1) {
           failedEdge = edge;
           return false;
         }
         value.facea = faceIndex;
-        value.posa = pos;
       } else {
         if (value.faceb != -1) {
           failedEdge = edge;
           return false;
         }
         value.faceb = faceIndex;
-        value.posb = pos;
       }
     }
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ set(TEST_DATA_DIR       "${CCSD}/data")
 set(TEST_SCAD_DIR       "${CCSD}/data/scad")
 set(TEST_PYTHONSCAD_DIR "${CCSD}/data/pythonscad")
 set(TEST_PYTHONSCAD_ECHO_DIR "${CCSD}/data/pythonscad-echo")
+set(TEST_PYTHONSCAD_FAILING_DIR "${CCSD}/data/pythonscad-failing")
 set(TEST_PYTHONSCAD_LASER_DIR "${CCSD}/data/pythonscad-laser")
 set(TEST_PYTHONSCAD_3D_EXPORT_DIR "${CCSD}/data/pythonscad-3d-export")
 set(TEST_PYTHONSCAD_MULTITOOL_EXPORT_DIR "${CCSD}/data/pythonscad-multitool-export")
@@ -284,6 +285,7 @@ file(GLOB SCAD_DXF_FILES      ${TEST_SCAD_DIR}/dxf/*.scad
 file(GLOB SCAD_PDF_FILES      ${TEST_SCAD_DIR}/pdf/*.scad)
 file(GLOB PYTHONSCAD_FILES    ${TEST_PYTHONSCAD_DIR}/*.py)
 file(GLOB PYTHONSCAD_ECHO_FILES    ${TEST_PYTHONSCAD_ECHO_DIR}/*.py)
+file(GLOB PYTHONSCAD_FAILING_FILES ${TEST_PYTHONSCAD_FAILING_DIR}/*.py)
 file(GLOB PYTHONSCAD_LASER_FILES    ${TEST_PYTHONSCAD_LASER_DIR}/*.py)
 file(GLOB PYTHONSCAD_3D_EXPORT_FILES ${TEST_PYTHONSCAD_3D_EXPORT_DIR}/*.py)
 file(GLOB PYTHONSCAD_MULTITOOL_EXPORT_FILES ${TEST_PYTHONSCAD_MULTITOOL_EXPORT_DIR}/*.py)
@@ -1159,6 +1161,7 @@ add_cmdline_test(export-pdf-fill SCRIPT ${EXPORT_PNGTEST_PY} SUFFIX png FILES ${
 add_failing_test(stlfailedtest         SUFFIX stl  FILES ${TEST_SCAD_DIR}/misc/empty-union.scad ARGS --retval=1 --trust-python)
 add_failing_test(offfailedtest         SUFFIX off  FILES ${TEST_SCAD_DIR}/misc/empty-union.scad ARGS --retval=1 --trust-python)
 add_failing_test(parsererrors          SUFFIX stl  FILES ${FAILING_FILES} ARGS --retval=1 --trust-python)
+add_failing_test(pythonscadfailedtest  EXPERIMENTAL SUFFIX stl FILES ${PYTHONSCAD_FAILING_FILES} ARGS --retval=1 --trust-python)
 # Hardwarning Test
 add_failing_test(hardwarnings          SUFFIX echo FILES ${TEST_SCAD_DIR}/misc/errors-warnings.scad ARGS --retval=1 --hardwarnings --trust-python)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1161,7 +1161,9 @@ add_cmdline_test(export-pdf-fill SCRIPT ${EXPORT_PNGTEST_PY} SUFFIX png FILES ${
 add_failing_test(stlfailedtest         SUFFIX stl  FILES ${TEST_SCAD_DIR}/misc/empty-union.scad ARGS --retval=1 --trust-python)
 add_failing_test(offfailedtest         SUFFIX off  FILES ${TEST_SCAD_DIR}/misc/empty-union.scad ARGS --retval=1 --trust-python)
 add_failing_test(parsererrors          SUFFIX stl  FILES ${FAILING_FILES} ARGS --retval=1 --trust-python)
-add_failing_test(pythonscadfailedtest  EXPERIMENTAL SUFFIX stl FILES ${PYTHONSCAD_FAILING_FILES} ARGS --retval=1 --trust-python)
+if(EXPERIMENTAL)
+  add_failing_test(pythonscadfailedtest  SUFFIX stl FILES ${PYTHONSCAD_FAILING_FILES} ARGS --retval=1 --trust-python)
+endif()
 # Hardwarning Test
 add_failing_test(hardwarnings          SUFFIX echo FILES ${TEST_SCAD_DIR}/misc/errors-warnings.scad ARGS --retval=1 --hardwarnings --trust-python)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1163,6 +1163,7 @@ add_failing_test(offfailedtest         SUFFIX off  FILES ${TEST_SCAD_DIR}/misc/e
 add_failing_test(parsererrors          SUFFIX stl  FILES ${FAILING_FILES} ARGS --retval=1 --trust-python)
 if(EXPERIMENTAL)
   add_failing_test(pythonscadfailedtest  SUFFIX stl FILES ${PYTHONSCAD_FAILING_FILES} ARGS --retval=1 --trust-python)
+  set_property(TEST pythonscadfailedtest_issue-801-fillet-collision PROPERTY PASS_REGULAR_EXPRESSION "fillet\\(\\) cannot process")
 endif()
 # Hardwarning Test
 add_failing_test(hardwarnings          SUFFIX echo FILES ${TEST_SCAD_DIR}/misc/errors-warnings.scad ARGS --retval=1 --hardwarnings --trust-python)

--- a/tests/data/pythonscad-failing/issue-801-fillet-collision.py
+++ b/tests/data/pythonscad-failing/issue-801-fillet-collision.py
@@ -1,0 +1,18 @@
+from pythonscad import *
+
+# The cylinder overlaps the clearance needed by the masked base fillet. This
+# used to abort in createEdgeDb(); it should now fail with a diagnostic.
+x = 2.5
+y = 3.5
+
+solids = union([
+    cube([80, 47, 3]),
+    cylinder(d=7.5, h=5) + [x, y, 3],
+])
+remove = union(
+    cylinder(d=2.5, h=100) + [x, y, 0],
+    cylinder(d=3.7, h=100) + [x, y, 7.4],
+)
+tmp = difference(solids, remove)
+mask = cube([30, 1, 30], center=True)
+tmp.fillet(3, mask, fn=20).show()


### PR DESCRIPTION
## Summary
- Add a fillet preflight check for invalid edge pairing before the fillet planner reaches low-level assertions.
- Report a diagnostic suggesting reduced radius or filleting before unioning adjacent solids.
- Add an expected-failure regression for the issue #801 crash reproducer.

Fixes #801.

## Test plan
- `pre-commit run --files src/core/FilletNode.cc tests/CMakeLists.txt tests/data/pythonscad-failing/issue-801-fillet-collision.py`
- `deguix cmake -B build -DEXPERIMENTAL=ON -DENABLE_PYTHON=ON -DUSE_QT6=ON .`
- `nice cmake --build build -j6`
- `ctest --test-dir build -R "pythonscadfailedtest_issue-801-fillet-collision" --output-on-failure`
- `build/pythonscad -o build/issue801-ok.stl --trust-python tests/data/pythonscad/fillet.py`

Made with [Cursor](https://cursor.com)