### PR TITLE
chore: remove Fedora 42 distribution references

### DIFF
--- a/scripts/deps/profiles/base.json
+++ b/scripts/deps/profiles/base.json
@@ -138,12 +138,7 @@
         "tbb-devel",
         "xorg-x11-server-Xvfb"
       ],
-      "version_overrides": {
-        "42": {
-          "add": [],
-          "remove": []
-        }
-      }
+      "version_overrides": {}
     },
     "arch": {
       "manager": "pacman",

--- a/scripts/get-dependencies.py
+++ b/scripts/get-dependencies.py
@@ -24,7 +24,7 @@ Usage examples:
   scripts/get-dependencies.py --profile base --profile qt5        # multiple profiles combined in order
   scripts/get-dependencies.py --yes                               # auto-install without prompt
   scripts/get-dependencies.py --dry-run                           # show commands only
-  scripts/get-dependencies.py --distro fedora --version 42 --yes
+  scripts/get-dependencies.py --distro fedora --version 43 --yes
 
 Config schema (profiles/*.json):
   distros: {

--- a/supported-distributions.json
+++ b/supported-distributions.json
@@ -99,19 +99,6 @@
     {
       "family": "fedora",
       "name": "Fedora",
-      "version": "42",
-      "codename": "42",
-      "lts": false,
-      "eol_date": "2026-05",
-      "runner": "ubuntu-24.04",
-      "docker_image": "fedora@sha256:7c63468daf71fdc5bda3699cd483b169bb995b5137265d5ffe8f04e2ce87fbb8",
-      "architectures": [
-        "amd64"
-      ]
-    },
-    {
-      "family": "fedora",
-      "name": "Fedora",
       "version": "43",
       "codename": "43",
       "lts": false,


### PR DESCRIPTION
## Summary
- Remove the Fedora 42 entry from the supported distribution matrix (`supported-distributions.json`); it's EOL as of 2026-05.
- Update the usage example in `scripts/get-dependencies.py` to reference Fedora 43 instead of 42.
- Drop the now-unused Fedora 42 `version_overrides` entry from `scripts/deps/profiles/base.json`.
- The RPM package workflow matrix (`build-rpm-packages.yml`) is generated dynamically from `supported-distributions.json` and filtered by `eol_date`, so it no longer produces Fedora 42 jobs — no direct workflow edits were needed.

Fixes #818

## Test plan
- [x] Validated `supported-distributions.json` and `scripts/deps/profiles/base.json` parse as valid JSON.
- [x] Confirmed no remaining Fedora 42 references in JSON/Python/workflow files.
- [x] Ran `./scripts/beautify.sh` (no formatting changes needed).


---
_Generated by [Claude Code](https://claude.ai/code/session_0133mSSu6rUqBEyH7g5EKb6z)_