### PR TITLE
fix(customizer): defer text field preview until commit

### DIFF
--- a/src/gui/parameter/ParameterText.cc
+++ b/src/gui/parameter/ParameterText.cc
@@ -24,7 +24,7 @@ ParameterText::ParameterText(QWidget *parent, StringParameter *parameter,
 
 void ParameterText::valueApplied()
 {
-  lastApplied = lastSent;
+  lastApplied = parameter->value;
 }
 
 void ParameterText::onEdit(const QString& text)
@@ -34,7 +34,7 @@ void ParameterText::onEdit(const QString& text)
 #endif
   std::string value = text.toStdString();
   if (lastSent != value) {
-    lastSent = parameter->value = value;
+    lastSent = value;
   }
 }
 
@@ -43,8 +43,9 @@ void ParameterText::onEditingFinished()
 #ifdef DEBUG
   PRINTD("editing finished");
 #endif
-  if (lastApplied != parameter->value) {
-    lastSent = parameter->value = lineEdit->text().toStdString();
+  std::string value = lineEdit->text().toStdString();
+  if (lastApplied != value) {
+    lastSent = parameter->value = value;
     emit changed(true);
   }
 }

--- a/src/gui/parameter/ParameterText.cc
+++ b/src/gui/parameter/ParameterText.cc
@@ -35,7 +35,6 @@ void ParameterText::onEdit(const QString& text)
   std::string value = text.toStdString();
   if (lastSent != value) {
     lastSent = parameter->value = value;
-    emit changed(false);
   }
 }
 


### PR DESCRIPTION
## Summary
- Defer customizer string parameter previews until the text field commits via `editingFinished`.
- Keep the pending string value updated while typing so the committed preview uses the latest text.

Closes #829.

## Test plan
- Built locally with `cmake --build build -j$(nproc) --target pythonscad`.
- Manually verified that typing in a customizer text field no longer re-renders mid-edit and preview runs after committing the field.

Made with [Cursor](https://cursor.com)