### PR TITLE
feat(python): support single-file multitool 3MF export

### DIFF
--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -312,19 +312,30 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         """
         if single_file is not None:
             if _os.path.splitext(single_file)[1].casefold() != ".3mf":
-                raise ValueError("MultiToolExporter single-file export only supports .3mf")
+                raise ValueError(
+                    f"MultiToolExporter single-file export only supports .3mf: "
+                    f"{single_file!r}"
+                )
             if not self:
                 return
             self._check_unique_part_names()
             self._ensure_parent_dir(single_file)
-            export(dict(self.parts()), single_file)  # type: ignore[arg-type] # noqa: F405
+            export_multi = _typing.cast(
+                _typing.Callable[[_typing.Mapping[str, _typing.Any], str], None],
+                globals()["export"],
+            )
+            export_multi(dict(self.parts()), single_file)
             return
 
         self._check_unique_filenames()
+        export_one = _typing.cast(
+            _typing.Callable[[_typing.Any, str], None],
+            globals()["export"],
+        )
         for name, geometry in self.parts():
             filename = f"{self.prefix}{name}{self.suffix}"
             self._ensure_parent_dir(filename)
-            export(geometry, filename)  # noqa: F405
+            export_one(geometry, filename)
 
     def show(self) -> None:
         """Display each part in the PythonSCAD preview.

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -313,6 +313,8 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         if single_file is not None:
             if _os.path.splitext(single_file)[1].casefold() != ".3mf":
                 raise ValueError("MultiToolExporter single-file export only supports .3mf")
+            if not self:
+                return
             self._check_unique_part_names()
             self._ensure_parent_dir(single_file)
             export(dict(self.parts()), single_file)  # type: ignore[arg-type] # noqa: F405

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -292,7 +292,7 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         return [(self[i][0], self._part(i)) for i in range(len(self))]
 
     def export(self, single_file: _typing.Optional[str] = None) -> None:
-        """Export each part to a file via PythonSCAD.
+        """Export parts to per-part files or a single multi-object 3MF.
 
         By default, exports each result of :meth:`parts` to
         ``f"{prefix}{name}{suffix}"``. If ``single_file`` is given, exports

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -117,6 +117,7 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         >>> exporter.append(("base", base_geometry))
         >>> exporter.append(("overlay", overlay_geometry))
         >>> exporter.export()  # writes out/flag-base.stl and out/flag-overlay.stl
+        >>> exporter.export(single_file="out/flag.3mf")  # writes one multi-object 3MF
     """
 
     def __init__(
@@ -217,6 +218,14 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         """Return the output filename for part ``i``."""
         return f"{self.prefix}{self[i][0]}{self.suffix}"
 
+    def _ensure_parent_dir(self, filename: str) -> None:
+        """Create ``filename``'s parent directory if ``mkdir`` is enabled."""
+        if not self.mkdir:
+            return
+        directory = _os.path.dirname(filename)
+        if directory:
+            _os.makedirs(directory, exist_ok=True)
+
     def _part(self, i: int):
         """Return the geometry for part ``i``: ``self[i]``'s object minus all later parts.
 
@@ -252,6 +261,17 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
                 )
             seen[key] = (name, filename)
 
+    def _check_unique_part_names(self) -> None:
+        """Raise :class:`ValueError` if part names would collide in a dict export."""
+        seen: set[str] = set()
+        for name, _geometry in self:
+            if name in seen:
+                raise ValueError(
+                    f"MultiToolExporter items must have unique names for "
+                    f"single-file export: {name!r}"
+                )
+            seen.add(name)
+
     def parts(self) -> list[tuple[str, _typing.Any]]:
         """Return the computed ``(name, geometry)`` pairs in declaration order.
 
@@ -271,11 +291,13 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         """
         return [(self[i][0], self._part(i)) for i in range(len(self))]
 
-    def export(self) -> None:
+    def export(self, single_file: _typing.Optional[str] = None) -> None:
         """Export each part to a file via PythonSCAD.
 
-        For each item, exports the result of :meth:`parts` to
-        ``f"{prefix}{name}{suffix}"``.
+        By default, exports each result of :meth:`parts` to
+        ``f"{prefix}{name}{suffix}"``. If ``single_file`` is given, exports
+        all parts into that one 3MF file using PythonSCAD's multi-object
+        ``export({"part": geometry}, "out.3mf")`` form.
 
         If :attr:`mkdir` is ``True``, the parent directory of each output
         file is created beforehand (filenames without a directory component
@@ -284,15 +306,22 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         Raises:
             ValueError: If two or more items would write to the same
                 output path (raw duplicate names, path aliases, or, on
-                Windows/macOS, case-only collisions).
+                Windows/macOS, case-only collisions). Also raised when
+                ``single_file`` is not a ``.3mf`` path, or when duplicate
+                part names would collide in the single-file export dict.
         """
+        if single_file is not None:
+            if _os.path.splitext(single_file)[1].casefold() != ".3mf":
+                raise ValueError("MultiToolExporter single-file export only supports .3mf")
+            self._check_unique_part_names()
+            self._ensure_parent_dir(single_file)
+            export(dict(self.parts()), single_file)  # type: ignore[arg-type] # noqa: F405
+            return
+
         self._check_unique_filenames()
         for name, geometry in self.parts():
             filename = f"{self.prefix}{name}{self.suffix}"
-            if self.mkdir:
-                directory = _os.path.dirname(filename)
-                if directory:
-                    _os.makedirs(directory, exist_ok=True)
+            self._ensure_parent_dir(filename)
             export(geometry, filename)  # noqa: F405
 
     def show(self) -> None:

--- a/libraries/python/stubs/_openscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/_openscad-stubs/__init__.pyi
@@ -1,6 +1,6 @@
 """ PythonSCAD Stub File for use in editors like Visual Studio Code """
 from enum import Enum
-from typing import List, Optional, Self, Sequence, Union, overload
+from typing import List, Mapping, Optional, Self, Sequence, Union, overload
 
 PyOpenSCADs = Union["PyOpenSCAD", list["PyOpenSCAD"]]
 """Type for functions that accept either a single OpenSCAD object or a list of objects."""
@@ -1245,7 +1245,15 @@ def pull(obj: PyOpenSCAD, src: List[float], dst: List[float]) -> PyOpenSCAD:
     ...
 
 
+@overload
 def export(obj: PyOpenSCAD, file: str) -> None:
+    """Export the result to a file
+    file:  output file name, format is automatically detected from suffix
+    """
+    ...
+
+@overload
+def export(obj: Mapping[str, PyOpenSCADs], file: str) -> None:
     """Export the result to a file
     file:  output file name, format is automatically detected from suffix
     when obj is a dictionary, it allows 3mf export to export several paths

--- a/libraries/python/stubs/openscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/openscad-stubs/__init__.pyi
@@ -16,4 +16,5 @@ from _openscad import (  # noqa: F401
     Vector1,
     Vector2,
     Vector3,
+    export,
 )

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -83,7 +83,7 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         ...
 
     def export(self, single_file: str | None = ...) -> None:
-        """Export each part to a file via PythonSCAD."""
+        """Export each part separately, or all parts into one 3MF file."""
         ...
 
     def show(self) -> None:

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -30,12 +30,12 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
     Each item is a ``(name, object)`` 2-tuple (matching :func:`dict.items`
     and the multi-object form of :func:`export`). For each index ``i``,
     :meth:`export` writes the geometry obtained by subtracting every later
-    item's object from ``self[i]``'s object into the file
-    ``f"{prefix}{name}{suffix}"``. The last entry is emitted as-is (no
-    degenerate one-child ``difference`` node). Output paths must be
-    unique; collisions (raw duplicate names, path aliases, or - on
-    Windows/macOS - case-only collisions) raise :class:`ValueError` at
-    export time.
+    item's object from ``self[i]``'s object into either per-part files
+    named ``f"{prefix}{name}{suffix}"`` or one multi-object 3MF file when
+    ``single_file`` is provided. The last entry is emitted as-is (no
+    degenerate one-child ``difference`` node). Output paths and
+    single-file part names must be unique; collisions raise
+    :class:`ValueError` at export time.
     """
 
     prefix: str
@@ -82,7 +82,7 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         """Return computed ``(name, geometry)`` pairs in declaration order."""
         ...
 
-    def export(self) -> None:
+    def export(self, single_file: str | None = ...) -> None:
         """Export each part to a file via PythonSCAD."""
         ...
 

--- a/tests/data/pythonscad-echo/multitool-exporter.py
+++ b/tests/data/pythonscad-echo/multitool-exporter.py
@@ -10,6 +10,8 @@ Exercises:
   * ``mkdir=True`` with a directory-less filename (must not raise)
   * end-to-end ``export()`` calling the underlying ``pythonscad.export``
     once per part with the expected filename
+  * ``export(single_file=...)`` calling the underlying ``pythonscad.export``
+    once with the expected dict of named parts
 
 The underlying ``pythonscad.export`` is monkey-patched to a deterministic
 recorder so the test does not depend on a render backend, file system
@@ -78,12 +80,25 @@ print("len after failed extend:", len(exp))
 # --- 4. Duplicate-name detection at export time ------------------------
 dup = MultiToolExporter("p-", ".stl", items=[("x", red), ("x", blue)])
 expect("export duplicate names", dup.export, ValueError)
+expect(
+    "single-file duplicate names",
+    lambda: dup.export(single_file="assembly.3mf"),
+    ValueError,
+)
+expect(
+    "single-file non-3mf",
+    lambda: exp.export(single_file="assembly.stl"),
+    ValueError,
+)
 
 # --- 5. End-to-end export(), with monkey-patched underlying export -----
 calls = []
 real_export = pythonscad.export
 def recording_export(obj, filename):
-    calls.append((obj is not None, filename))
+    if isinstance(obj, dict):
+        calls.append((list(obj.keys()), filename))
+    else:
+        calls.append((obj is not None, filename))
 pythonscad.export = recording_export
 try:
     # 5a. Two parts, no directory in prefix, mkdir=True -- must not crash
@@ -102,12 +117,18 @@ try:
         )
         e2.export()
         print("created nested dir:", os.path.isdir(os.path.join(tmp, "nested")))
+    # 5c. Single-file 3MF export -- one call with a dict of named parts
+    with tempfile.TemporaryDirectory() as tmp:
+        out_file = os.path.join(tmp, "assembly", "parts.3mf")
+        e3 = MultiToolExporter("", ".stl", mkdir=True, items=[("r", red), ("b", blue)])
+        e3.export(single_file=out_file)
+        print("created assembly dir:", os.path.isdir(os.path.join(tmp, "assembly")))
 finally:
     pythonscad.export = real_export
 
 # Print the recorded export calls (last filename only -- temp paths vary).
-for has_obj, filename in calls:
+for obj_info, filename in calls:
     if filename.startswith("nodir-"):
-        print("export call:", has_obj, filename)
+        print("export call:", obj_info, filename)
     else:
-        print("export call:", has_obj, "tmp/.../" + os.path.basename(filename))
+        print("export call:", obj_info, "tmp/.../" + os.path.basename(filename))

--- a/tests/data/pythonscad-echo/multitool-exporter.py
+++ b/tests/data/pythonscad-echo/multitool-exporter.py
@@ -90,6 +90,9 @@ expect(
     lambda: exp.export(single_file="assembly.stl"),
     ValueError,
 )
+empty = MultiToolExporter("p-", ".stl")
+empty.export(single_file="empty.3mf")
+print("single-file empty no-op: ok")
 
 # --- 5. End-to-end export(), with monkey-patched underlying export -----
 calls = []

--- a/tests/data/pythonscad-export-3mf/multitool-single-file.py
+++ b/tests/data/pythonscad-export-3mf/multitool-single-file.py
@@ -1,0 +1,15 @@
+"""Regression fixture for ``MultiToolExporter.export(single_file=...)``.
+
+This exercises the helper's single-file 3MF path, which computes named
+parts via ``MultiToolExporter.parts()`` and forwards them to PythonSCAD's
+dict-based multi-object 3MF export.
+"""
+from pythonscad import MultiToolExporter, cube
+
+red_part = cube([6, 6, 4]).color("red")
+blue_part = cube([6, 6, 4]).translate([8, 0, 0]).color("blue")
+
+MultiToolExporter("", ".stl", items=[
+    ("red", red_part),
+    ("blue", blue_part),
+]).export(single_file="multitool.3mf")

--- a/tests/regression/pythonscad-export-3mf/multitool-single-file/multitool.3mf
+++ b/tests/regression/pythonscad-export-3mf/multitool-single-file/multitool.3mf
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" unit="millimeter" xml:lang="en-US" xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02" xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06" xmlns:b="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" xmlns:s="http://schemas.microsoft.com/3dmanufacturing/slice/2015/07">
+	<metadata name="Title">multitool.3mf</metadata>
+	<metadata name="Application">OpenSCAD (https://www.openscad.org/)</metadata>
+	<metadata name="CreationDate">XXXX-XX-XXTXXXXXXXXZ</metadata>
+	<resources>
+		<basematerials id="1">
+			<base name="Default" displaycolor="#F9D72CFF" />
+			<base name="Color 1" displaycolor="#FF0000FF" />
+			<base name="Color 2" displaycolor="#0000FFFF" />
+		</basematerials>
+		<object id="2" name="red" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" pid="1" pindex="0">
+			<mesh>
+				<vertices>
+					<vertex x="0" y="0" z="0" />
+					<vertex x="0" y="0" z="4.000000" />
+					<vertex x="0" y="6.000000" z="0" />
+					<vertex x="0" y="6.000000" z="4.000000" />
+					<vertex x="6.000000" y="0" z="0" />
+					<vertex x="6.000000" y="0" z="4.000000" />
+					<vertex x="6.000000" y="6.000000" z="0" />
+					<vertex x="6.000000" y="6.000000" z="4.000000" />
+				</vertices>
+				<triangles>
+					<triangle v1="0" v2="1" v3="3" pid="1" p1="1" />
+					<triangle v1="0" v2="2" v3="6" pid="1" p1="1" />
+					<triangle v1="0" v2="3" v3="2" pid="1" p1="1" />
+					<triangle v1="0" v2="4" v3="5" pid="1" p1="1" />
+					<triangle v1="0" v2="5" v3="1" pid="1" p1="1" />
+					<triangle v1="0" v2="6" v3="4" pid="1" p1="1" />
+					<triangle v1="1" v2="5" v3="3" pid="1" p1="1" />
+					<triangle v1="2" v2="3" v3="6" pid="1" p1="1" />
+					<triangle v1="3" v2="5" v3="7" pid="1" p1="1" />
+					<triangle v1="3" v2="7" v3="6" pid="1" p1="1" />
+					<triangle v1="4" v2="6" v3="5" pid="1" p1="1" />
+					<triangle v1="5" v2="6" v3="7" pid="1" p1="1" />
+				</triangles>
+			</mesh>
+		</object>
+		<object id="3" name="blue" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" pid="1" pindex="0">
+			<mesh>
+				<vertices>
+					<vertex x="8.000000" y="0" z="0" />
+					<vertex x="8.000000" y="0" z="4.000000" />
+					<vertex x="8.000000" y="6.000000" z="0" />
+					<vertex x="8.000000" y="6.000000" z="4.000000" />
+					<vertex x="14.000000" y="0" z="0" />
+					<vertex x="14.000000" y="0" z="4.000000" />
+					<vertex x="14.000000" y="6.000000" z="0" />
+					<vertex x="14.000000" y="6.000000" z="4.000000" />
+				</vertices>
+				<triangles>
+					<triangle v1="0" v2="1" v3="3" pid="1" p1="2" />
+					<triangle v1="0" v2="2" v3="6" pid="1" p1="2" />
+					<triangle v1="0" v2="3" v3="2" pid="1" p1="2" />
+					<triangle v1="0" v2="4" v3="5" pid="1" p1="2" />
+					<triangle v1="0" v2="5" v3="1" pid="1" p1="2" />
+					<triangle v1="0" v2="6" v3="4" pid="1" p1="2" />
+					<triangle v1="1" v2="5" v3="3" pid="1" p1="2" />
+					<triangle v1="2" v2="3" v3="6" pid="1" p1="2" />
+					<triangle v1="3" v2="5" v3="7" pid="1" p1="2" />
+					<triangle v1="3" v2="7" v3="6" pid="1" p1="2" />
+					<triangle v1="4" v2="6" v3="5" pid="1" p1="2" />
+					<triangle v1="5" v2="6" v3="7" pid="1" p1="2" />
+				</triangles>
+			</mesh>
+		</object>
+	</resources>
+	<build p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX">
+		<item objectid="2" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" />
+		<item objectid="3" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" />
+	</build>
+</model>

--- a/tests/regression/pythonscadecho/multitool-exporter-expected.echo
+++ b/tests/regression/pythonscadecho/multitool-exporter-expected.echo
@@ -20,6 +20,7 @@ len after failed extend: 2
 export duplicate names: ValueError
 single-file duplicate names: ValueError
 single-file non-3mf: ValueError
+single-file empty no-op: ok
 created nested dir: True
 created assembly dir: True
 export call: True nodir-red.stl

--- a/tests/regression/pythonscadecho/multitool-exporter-expected.echo
+++ b/tests/regression/pythonscadecho/multitool-exporter-expected.echo
@@ -18,9 +18,14 @@ iadd mid-bad item: TypeError
 constructor bad item: ValueError
 len after failed extend: 2
 export duplicate names: ValueError
+single-file duplicate names: ValueError
+single-file non-3mf: ValueError
 created nested dir: True
+created assembly dir: True
 export call: True nodir-red.stl
 export call: True nodir-blue.stl
 export call: True nodir-green.stl
 export call: True tmp/.../x-a.3mf
 export call: True tmp/.../x-b.3mf
+export call: ['r', 'b'] tmp/.../parts.3mf
+


### PR DESCRIPTION
## Summary
- Adds `MultiToolExporter.export(single_file=...)` for writing all computed parts into one multi-object 3MF file.
- Keeps existing per-part export behavior unchanged and validates duplicate part names / non-3MF single-file targets.
- Adds echo coverage and a 3MF regression fixture proving the single file contains named red and blue objects.

## Test plan
- `./scripts/beautify.sh`
- `pre-commit run --files libraries/python/pythonscad/__init__.py tests/data/pythonscad-echo/multitool-exporter.py tests/data/pythonscad-export-3mf/multitool-single-file.py tests/regression/pythonscadecho/multitool-exporter-expected.echo tests/regression/pythonscad-export-3mf/multitool-single-file/multitool.3mf`
- `ctest -R '^pythonscadecho_multitool-exporter$' --output-on-failure`
- `python3 -Xutf8=1 tests/test_export_files.py --pythonscad /home/nomike/coding/pythonscad/build/pythonscad --testname pythonscad-export-3mf --basename multitool-single-file tests/data/pythonscad-export-3mf/multitool-single-file.py`


Made with [Cursor](https://cursor.com)