### PR TITLE
fix(ci): guard release-please PR output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,17 +31,33 @@ jobs:
       # release-please force-pushes its branch on every update, so this step
       # re-applies deterministically after each run; the generator is
       # idempotent and derives everything from CHANGELOG.md.
+      - name: Extract release PR branch
+        id: release_pr_branch
+        if: ${{ steps.release.outputs.pr != '' }}
+        env:
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          pr = json.loads(os.environ["RELEASE_PR"])
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"branch={pr['headBranchName']}\n")
+          PY
+
       - name: Checkout release PR branch
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.release_pr_branch.outputs.branch != '' }}
         uses: actions/checkout@v7
         with:
-          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          ref: ${{ steps.release_pr_branch.outputs.branch }}
           persist-credentials: false
 
       - name: Sync AppStream release list onto release PR
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.release_pr_branch.outputs.branch != '' }}
         env:
-          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_PR_BRANCH: ${{ steps.release_pr_branch.outputs.branch }}
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,8 +43,13 @@ jobs:
           import os
 
           pr = json.loads(os.environ["RELEASE_PR"])
+          branch = pr.get("headBranchName") if isinstance(pr, dict) else None
+          if not isinstance(branch, str) or not branch:
+              print("No release PR branch found; skipping AppStream release sync")
+              raise SystemExit(0)
+
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"branch={pr['headBranchName']}\n")
+              output.write(f"branch={branch}\n")
           PY
 
       - name: Checkout release PR branch


### PR DESCRIPTION
## Summary
- Avoid parsing `steps.release.outputs.pr` with `fromJSON(...)` in later workflow expressions.
- Extract the release PR branch in a guarded step and reuse that output for checkout and AppStream sync.
- Fix non-release Release Please runs failing when no release PR JSON output is present.

## Test plan
- `actionlint .github/workflows/release-please.yml`
- `git diff --check -- .github/workflows/release-please.yml`
- Pre-commit hooks during commit, including GitHub Actions workflow lint and `zizmor`

Fixes #837

Made with [Cursor](https://cursor.com)