### PR TITLE
fix(python): refresh script import path on reinit

### DIFF
--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1234,7 +1234,10 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
 
     stream << sepchar << PlatformUtils::userPythonLibraryPath();
     stream << sepchar << PlatformUtils::userLibraryPath();
-    stream << sepchar << python_script_dir_for_sys_path(python_scriptpath);
+    const std::string scriptDir = python_script_dir_for_sys_path(python_scriptpath);
+    if (!scriptDir.empty()) {
+      stream << sepchar << scriptDir;
+    }
     stream << sepchar << ".";
 #endif
 #ifndef __EMSCRIPTEN__
@@ -1281,16 +1284,18 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
         }
         if (!python_scriptpath.empty()) {
           const std::string scriptDir = python_script_dir_for_sys_path(python_scriptpath);
-          PyObject *s = python_string_from_path(scriptDir);
-          if (s) {
-            if (PyList_Append(syspath, s) < 0) {
+          if (!scriptDir.empty()) {
+            PyObject *s = python_string_from_path(scriptDir);
+            if (s) {
+              if (PyList_Append(syspath, s) < 0) {
+                PyErr_Print();
+                PyErr_Clear();
+              }
+              Py_DECREF(s);
+            } else {
               PyErr_Print();
               PyErr_Clear();
             }
-            Py_DECREF(s);
-          } else {
-            PyErr_Print();
-            PyErr_Clear();
           }
         }
       }

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cctype>
 #include <cstdio>
 #include <filesystem>
 #include <string>
@@ -162,12 +163,29 @@ static std::string python_script_dir_for_sys_path(const fs::path& scriptpath)
   }
 
   const fs::path dir = script.parent_path();
-  if (dir.empty()) return ".";
+  if (dir.empty()) return "";
 
   const fs::path normalized = fs::weakly_canonical(dir, ec);
   if (!ec) return normalized.generic_string();
 
   return dir.lexically_normal().generic_string();
+}
+
+static std::string python_normalize_sys_path_for_compare(const std::string& path)
+{
+  fs::path p(path);
+  std::error_code ec;
+  if (p.is_absolute()) {
+    const fs::path canonical = fs::weakly_canonical(p, ec);
+    if (!ec) p = canonical;
+  }
+
+  std::string normalized = p.lexically_normal().generic_string();
+#ifdef _WIN32
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+#endif
+  return normalized;
 }
 
 static PyObject *python_string_from_path(const std::string& path)
@@ -189,7 +207,7 @@ static bool python_sys_path_entry_equals(PyObject *entry, const std::string& pat
     PyErr_Clear();
     return false;
   }
-  return entryStr == path;
+  return python_normalize_sys_path_for_compare(entryStr) == python_normalize_sys_path_for_compare(path);
 }
 
 static void python_update_script_sys_path(void)

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -25,6 +25,7 @@
  */
 #include <Python.h>
 #include "genlang/genlang.h"
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstdio>
@@ -81,6 +82,7 @@ PyMODINIT_FUNC PyInit__openscad(void);
 bool python_active;
 bool python_trusted;
 fs::path python_scriptpath;
+static std::string pythonManagedScriptDir;
 // https://docs.python.org/3.10/extending/newtypes.html
 
 void PyObjectDeleter(PyObject *pObject)
@@ -146,6 +148,92 @@ bool python_pyobject_to_utf8(PyObject *obj, std::string& out, const char *contex
   }
   out.assign(PyBytes_AS_STRING(bytes.get()), PyBytes_GET_SIZE(bytes.get()));
   return true;
+}
+
+static std::string python_script_dir_for_sys_path(const fs::path& scriptpath)
+{
+  if (scriptpath.empty()) return "";
+
+  std::error_code ec;
+  fs::path script = scriptpath.is_absolute() ? scriptpath : fs::absolute(scriptpath, ec);
+  if (ec) {
+    script = scriptpath;
+    ec.clear();
+  }
+
+  const fs::path dir = script.parent_path();
+  if (dir.empty()) return ".";
+
+  const fs::path normalized = fs::weakly_canonical(dir, ec);
+  if (!ec) return normalized.generic_string();
+
+  return dir.lexically_normal().generic_string();
+}
+
+static PyObject *python_string_from_path(const std::string& path)
+{
+#ifdef _WIN32
+  const std::wstring wide = fs::path(path).wstring();
+  return PyUnicode_FromWideChar(wide.c_str(), static_cast<Py_ssize_t>(wide.size()));
+#else
+  return PyUnicode_DecodeFSDefaultAndSize(path.c_str(), static_cast<Py_ssize_t>(path.size()));
+#endif
+}
+
+static bool python_sys_path_entry_equals(PyObject *entry, const std::string& path)
+{
+  if (!PyUnicode_Check(entry)) return false;
+
+  std::string entryStr;
+  if (!python_pyobject_to_utf8(entry, entryStr, "initPython() sys.path entry")) {
+    PyErr_Clear();
+    return false;
+  }
+  return entryStr == path;
+}
+
+static void python_update_script_sys_path(void)
+{
+  const std::string scriptDir = python_script_dir_for_sys_path(python_scriptpath);
+  if (scriptDir.empty()) return;
+
+  PyObject *sysPath = PySys_GetObject("path");  // borrowed reference
+  if (sysPath == nullptr || !PyList_Check(sysPath)) {
+    PyErr_Clear();
+    return;
+  }
+
+  for (Py_ssize_t i = PyList_GET_SIZE(sysPath) - 1; i >= 0; --i) {
+    PyObject *entry = PyList_GET_ITEM(sysPath, i);  // borrowed reference
+    if ((!pythonManagedScriptDir.empty() &&
+         python_sys_path_entry_equals(entry, pythonManagedScriptDir)) ||
+        python_sys_path_entry_equals(entry, scriptDir)) {
+      if (PySequence_DelItem(sysPath, i) != 0) {
+        PyErr_Clear();
+      }
+    }
+  }
+
+  Py_ssize_t insertIndex = PyList_GET_SIZE(sysPath);
+  for (Py_ssize_t i = 0; i < PyList_GET_SIZE(sysPath); ++i) {
+    PyObject *entry = PyList_GET_ITEM(sysPath, i);  // borrowed reference
+    if (python_sys_path_entry_equals(entry, ".")) {
+      insertIndex = i;
+      break;
+    }
+  }
+
+  PyObject *entry = python_string_from_path(scriptDir);
+  if (entry == nullptr) {
+    PyErr_Clear();
+    return;
+  }
+  if (PyList_Insert(sysPath, insertIndex, entry) != 0) {
+    PyErr_Clear();
+  } else {
+    pythonManagedScriptDir = scriptDir;
+  }
+  Py_DECREF(entry);
 }
 
 static std::atomic<bool> openscad_py_atexit_registered{false};
@@ -1124,10 +1212,9 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
       stream << sepchar << fs::absolute(resourceLibPath).generic_string();
     }
 
-    fs::path scriptfile(python_scriptpath);
     stream << sepchar << PlatformUtils::userPythonLibraryPath();
     stream << sepchar << PlatformUtils::userLibraryPath();
-    stream << sepchar << scriptfile.parent_path().string();
+    stream << sepchar << python_script_dir_for_sys_path(python_scriptpath);
     stream << sepchar << ".";
 #endif
 #ifndef __EMSCRIPTEN__
@@ -1173,7 +1260,8 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
           PyErr_Clear();
         }
         if (!python_scriptpath.empty()) {
-          PyObject *s = PyUnicode_FromString(fs::path(python_scriptpath).parent_path().string().c_str());
+          const std::string scriptDir = python_script_dir_for_sys_path(python_scriptpath);
+          PyObject *s = python_string_from_path(scriptDir);
           if (s) {
             if (PyList_Append(syspath, s) < 0) {
               PyErr_Print();
@@ -1322,6 +1410,11 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
       }
       pythonInventory.push_back(key_str);
     }
+  }
+  {
+    PyGILState_STATE pathGil = PyGILState_Ensure();
+    python_update_script_sys_path();
+    PyGILState_Release(pathGil);
   }
   std::ostringstream stream;
   if (r != nullptr) {

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -213,7 +213,6 @@ static bool python_sys_path_entry_equals(PyObject *entry, const std::string& pat
 static void python_update_script_sys_path(void)
 {
   const std::string scriptDir = python_script_dir_for_sys_path(python_scriptpath);
-  if (scriptDir.empty()) return;
 
   PyObject *sysPath = PySys_GetObject("path");  // borrowed reference
   if (sysPath == nullptr || !PyList_Check(sysPath)) {
@@ -231,6 +230,9 @@ static void python_update_script_sys_path(void)
       }
     }
   }
+  pythonManagedScriptDir.clear();
+
+  if (scriptDir.empty()) return;
 
   Py_ssize_t insertIndex = PyList_GET_SIZE(sysPath);
   for (Py_ssize_t i = 0; i < PyList_GET_SIZE(sysPath); ++i) {
@@ -997,7 +999,7 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
   if (alreadyTried) return;
   const auto name = PYTHON_EXECUTABLE_NAME;
   const auto exe = binDir + "/" + name;
-  if (scriptpath.size() > 0) python_scriptpath = scriptpath;
+  python_scriptpath = scriptpath;
   if (pythonInitDict) {
     /* Re-init path: remove user-added globals. Never call PyDict_DelItem* while iterating the same
      * dict with PyDict_Next — that invalidates the iteration and can crash (e.g. second initPython

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -224,7 +224,7 @@ static void python_update_script_sys_path(void)
     PyObject *entry = PyList_GET_ITEM(sysPath, i);  // borrowed reference
     if ((!pythonManagedScriptDir.empty() &&
          python_sys_path_entry_equals(entry, pythonManagedScriptDir)) ||
-        python_sys_path_entry_equals(entry, scriptDir)) {
+        (!scriptDir.empty() && python_sys_path_entry_equals(entry, scriptDir))) {
       if (PySequence_DelItem(sysPath, i) != 0) {
         PyErr_Clear();
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1552,6 +1552,13 @@ if(ENABLE_PYTHON)
   )
   set_property(TEST version-helpers PROPERTY ENVIRONMENT ${CTEST_ENVIRONMENT})
 
+  add_test(NAME python-sibling-import-cli CONFIGURATIONS Default
+    COMMAND ${Python3_EXECUTABLE} -Xutf8=1
+      ${CMAKE_CURRENT_SOURCE_DIR}/test_python_sibling_import_cli.py
+      ${OPENSCAD_BINPATH}
+  )
+  set_property(TEST python-sibling-import-cli PROPERTY ENVIRONMENT ${CTEST_ENVIRONMENT})
+
   # Layer-2: drive `pythonscad --ipython` through a real PTY (pexpect)
   # so we exercise the actual interactive prompt, not just the
   # non-interactive piped-stdin path covered by `ipython-smoke`. This

--- a/tests/test_python_sibling_import_cli.py
+++ b/tests/test_python_sibling_import_cli.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 TIMEOUT_SECONDS = 60
 MARKER_FILE = "sibling-import-marker.txt"
+HELPER_MODULE = "pythonscad_sibling_import_unique_helper"
+SENTINEL = "pythonscad-local-sibling-helper"
 
 
 def main() -> int:
@@ -30,7 +32,8 @@ def main() -> int:
         design_dir.mkdir()
         run_dir.mkdir()
 
-        (design_dir / "helper.py").write_text(
+        (design_dir / f"{HELPER_MODULE}.py").write_text(
+            f"SENTINEL = {SENTINEL!r}\n"
             "def side_length():\n"
             "    return 1\n",
             encoding="utf-8",
@@ -39,11 +42,12 @@ def main() -> int:
         main_py.write_text(
             "from openscad import cube, show\n"
             "from pathlib import Path\n"
-            "import helper\n\n"
+            f"import {HELPER_MODULE} as local_helper\n\n"
             "Path('" + MARKER_FILE + "').write_text(\n"
-            "    f'side={helper.side_length()}\\n', encoding='utf-8'\n"
+            "    f'{local_helper.SENTINEL}:side={local_helper.side_length()}\\n',\n"
+            "    encoding='utf-8',\n"
             ")\n"
-            "show(cube([helper.side_length()] * 3))\n",
+            "show(cube([local_helper.side_length()] * 3))\n",
             encoding="utf-8",
         )
 
@@ -76,7 +80,7 @@ def main() -> int:
         )
         return 1
 
-    if marker != "side=1\n":
+    if marker != f"{SENTINEL}:side=1\n":
         print(
             "FAIL: sibling helper import marker file was not written correctly",
             file=sys.stderr,

--- a/tests/test_python_sibling_import_cli.py
+++ b/tests/test_python_sibling_import_cli.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Regression test for script-local Python imports in CLI export mode."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+TIMEOUT_SECONDS = 60
+MARKER_FILE = "sibling-import-marker.txt"
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: test_python_sibling_import_cli.py <pythonscad-binary>", file=sys.stderr)
+        return 2
+
+    pythonscad = sys.argv[1]
+    if not os.path.isfile(pythonscad):
+        print(f"binary not found: {pythonscad}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="pythonscad-sibling-import-") as tmp:
+        root = Path(tmp)
+        design_dir = root / "design"
+        run_dir = root / "run-from-here"
+        design_dir.mkdir()
+        run_dir.mkdir()
+
+        (design_dir / "helper.py").write_text(
+            "def side_length():\n"
+            "    return 1\n",
+            encoding="utf-8",
+        )
+        main_py = design_dir / "main.py"
+        main_py.write_text(
+            "from openscad import cube, show\n"
+            "from pathlib import Path\n"
+            "import helper\n\n"
+            "Path('" + MARKER_FILE + "').write_text(\n"
+            "    f'side={helper.side_length()}\\n', encoding='utf-8'\n"
+            ")\n"
+            "show(cube([helper.side_length()] * 3))\n",
+            encoding="utf-8",
+        )
+
+        output_file = run_dir / "out.echo"
+        marker_file = run_dir / MARKER_FILE
+        proc = subprocess.run(
+            [
+                pythonscad,
+                "--trust-python",
+                "-o",
+                str(output_file),
+                str(main_py),
+            ],
+            cwd=run_dir,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+        marker = marker_file.read_text(encoding="utf-8") if marker_file.is_file() else None
+
+    print("===== stdout =====")
+    print(proc.stdout)
+    print("===== stderr =====", file=sys.stderr)
+    print(proc.stderr, file=sys.stderr)
+
+    if proc.returncode != 0:
+        print(
+            f"FAIL: pythonscad CLI export exited with {proc.returncode}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if marker != "side=1\n":
+        print(
+            "FAIL: sibling helper import marker file was not written correctly",
+            file=sys.stderr,
+        )
+        print(f"marker content: {marker!r}", file=sys.stderr)
+        return 1
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Refresh the active Python design directory in embedded `sys.path` on every `initPython()` call, not only first interpreter startup.
- Replace the previously managed script-directory entry when switching files so stale model directories do not accumulate.
- Add a CLI regression that runs a Python design from a different cwd and verifies a sibling `helper.py` import succeeds.

Fixes #842

## Test plan
- `cmake --build build --target pythonscad -j$(nproc)`
- `ctest --test-dir build -R '^(python-sibling-import-cli|version-helpers|pythonscadecho_)' --output-on-failure`

## Notes
- The GUI-specific reinit path was not automated with Qt; the fix is in the shared embedded Python path setup used by GUI and CLI.

Made with [Cursor](https://cursor.com)