### PR TITLE
fix(windows): resolve Python stdlib path and executable for --repl

### DIFF
--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1204,7 +1204,15 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
 #if defined(_WIN32)
     char sepchar = ';';
     sep = sepchar;
-    stream << PlatformUtils::applicationPath() << "\\..\\libraries\\python";
+    // Windows installer places pythonscad.exe at the install root (not in a
+    // bin/ subdirectory), so paths must be relative to applicationPath()
+    // directly — no "../" prefix.
+    stream << PlatformUtils::applicationPath() << "\\libraries\\python";
+    // Also add the bundled CPython stdlib so Py_InitializeFromConfig can find
+    // the platform-independent libraries without needing a real python.exe.
+    const auto pythonXY =
+      "python" + std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION);
+    stream << sepchar << PlatformUtils::applicationPath() << "\\lib\\" << pythonXY;
 #else
     char sepchar = ':';
     const auto pythonXY =
@@ -1246,7 +1254,24 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
 
 #ifndef __EMSCRIPTEN__
     if (!binDir.empty()) {
+#if defined(_WIN32)
+      // On Windows the shim is named pythonscad-python.exe; "python.exe" does
+      // not exist in the install tree.  Setting config.executable to a
+      // nonexistent path causes CPython's path-probing to fail with "Could not
+      // find platform independent libraries", so only set it when the file
+      // actually exists.
+      const std::string pythonExe = binDir + "/python.exe";
+      const std::string pythonScadExe = binDir + "/pythonscad-python.exe";
+      if (fs::exists(pythonExe)) {
+        PyConfig_SetBytesString(&config, &config.executable, pythonExe.c_str());
+      } else if (fs::exists(pythonScadExe)) {
+        PyConfig_SetBytesString(&config, &config.executable, pythonScadExe.c_str());
+      }
+      // If neither exists, leave config.executable unset — CPython will probe
+      // using its own heuristics, guided by pythonpath_env set above.
+#else
       PyConfig_SetBytesString(&config, &config.executable, (binDir + "/python").c_str());
+#endif
     }
 #endif
 

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -32,6 +32,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <string>
+#include <system_error>
 #include <vector>
 #include <glview/RenderSettings.h>
 #ifdef _WIN32
@@ -1207,12 +1208,13 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     // Windows installer places pythonscad.exe at the install root (not in a
     // bin/ subdirectory), so paths must be relative to applicationPath()
     // directly — no "../" prefix.
-    stream << PlatformUtils::applicationPath() << "\\libraries\\python";
+    const auto applicationPath = fs::path(PlatformUtils::applicationPath());
+    stream << (applicationPath / "libraries" / "python").generic_string();
     // Also add the bundled CPython stdlib so Py_InitializeFromConfig can find
     // the platform-independent libraries without needing a real python.exe.
     const auto pythonXY =
       "python" + std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION);
-    stream << sepchar << PlatformUtils::applicationPath() << "\\lib\\" << pythonXY;
+    stream << sepchar << (applicationPath / "lib" / pythonXY).generic_string();
 #else
     char sepchar = ':';
     const auto pythonXY =
@@ -1260,11 +1262,15 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
       // nonexistent path causes CPython's path-probing to fail with "Could not
       // find platform independent libraries", so only set it when the file
       // actually exists.
-      const std::string pythonExe = binDir + "/python.exe";
-      const std::string pythonScadExe = binDir + "/pythonscad-python.exe";
-      if (fs::exists(pythonExe)) {
+      const auto binPath = fs::path(binDir);
+      const auto pythonExePath = binPath / "python.exe";
+      const auto pythonScadExePath = binPath / "pythonscad-python.exe";
+      std::error_code ec;
+      if (fs::exists(pythonExePath, ec)) {
+        const auto pythonExe = pythonExePath.generic_string();
         PyConfig_SetBytesString(&config, &config.executable, pythonExe.c_str());
-      } else if (fs::exists(pythonScadExe)) {
+      } else if (fs::exists(pythonScadExePath, ec)) {
+        const auto pythonScadExe = pythonScadExePath.generic_string();
         PyConfig_SetBytesString(&config, &config.executable, pythonScadExe.c_str());
       }
       // If neither exists, leave config.executable unset — CPython will probe


### PR DESCRIPTION
Fixes #849

## Summary

- Fix Windows `pythonpath_env` to use `libraries\python` and `lib\python3.14` relative to `applicationPath()` directly, instead of `../libraries/python` which escapes the install tree when `pythonscad.exe` is at the root
- Fix `config.executable` to only be set when `python.exe` or `pythonscad-python.exe` actually exists, rather than unconditionally pointing at a nonexistent `python` which causes CPython's stdlib path-probing to fail

## Root cause

See #849 for full analysis. Short version:

1. The Windows installer places `pythonscad.exe` at the install root (not in `bin/`), so `applicationPath() + "\..\libraries\python"` was escaping the install tree.
2. `config.executable = binDir + "/python"` pointed at a nonexistent file. CPython uses the executable path to probe for its platform-independent stdlib, so this directly caused the "Could not find platform independent libraries" error.

## Test plan

- [ ] Build Windows installer from this branch
- [ ] Run `pythonscad.exe --repl` — should open a Python 3.14 REPL
- [ ] Run `pythonscad.exe --ipython` — should open IPython
- [ ] Verify `from pythonscad import *` works inside the REPL
- [ ] Verify normal GUI launch is unaffected