### PR TITLE
fix(appimage): isolate GIO modules from host runtime

### DIFF
--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -366,6 +366,10 @@ fi
 info "Found executable: ${MAIN_EXEC}"
 EXEC_NAME=$(basename "${MAIN_EXEC}")
 
+# Keep GIO from discovering host modules that may not match the
+# bundled GLib/GIO libraries.
+mkdir -p "${APPDIR}/usr/lib/gio/modules"
+
 # Create AppRun script
 info "Creating AppRun..."
 
@@ -385,6 +389,8 @@ export LD_LIBRARY_PATH="\${HERE}/usr/lib:\${LD_LIBRARY_PATH}"
 export PYTHONPATH="\${HERE}/usr/lib/python${PYTHON_VERSION}:\${HERE}/usr/lib/python${PYTHON_VERSION}/site-packages:\${PYTHONPATH}"
 export PYTHONHOME="\${HERE}/usr"
 export QT_PLUGIN_PATH="\${HERE}/usr/plugins"
+export GIO_USE_VFS=local
+export GIO_MODULE_DIR="\${HERE}/usr/lib/gio/modules"
 
 # Force X11 platform (xcb) for maximum compatibility
 # PythonSCAD uses OpenGL (QOpenGLWidget) which works better with XWayland on Wayland systems

--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -367,8 +367,22 @@ info "Found executable: ${MAIN_EXEC}"
 EXEC_NAME=$(basename "${MAIN_EXEC}")
 
 # Keep GIO from discovering host modules that may not match the
-# bundled GLib/GIO libraries.
-mkdir -p "${APPDIR}/usr/lib/gio/modules"
+# bundled GLib/GIO libraries. Copy the non-GVFS modules from the
+# build host so GIO features such as TLS still have matching modules.
+GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
+mkdir -p "${GIO_MODULE_DIR}"
+SYSTEM_GIO_MODULE_DIR=$(pkg-config --variable=giomoduledir gio-2.0 2>/dev/null || true)
+if [ -n "${SYSTEM_GIO_MODULE_DIR}" ] && [ -d "${SYSTEM_GIO_MODULE_DIR}" ]; then
+    find "${SYSTEM_GIO_MODULE_DIR}" -maxdepth 1 -type f -name "libgio*.so" \
+        ! -name "libgvfsdbus.so" \
+        ! -name "libgioremote-volume-monitor.so" \
+        -exec cp -P {} "${GIO_MODULE_DIR}/" \;
+fi
+if command_exists gio-querymodules; then
+    gio-querymodules "${GIO_MODULE_DIR}" || warn "Failed to generate GIO module cache"
+else
+    warn "gio-querymodules not found; GIO module cache will not be generated"
+fi
 
 # Create AppRun script
 info "Creating AppRun..."

--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -373,7 +373,7 @@ GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
 mkdir -p "${GIO_MODULE_DIR}"
 SYSTEM_GIO_MODULE_DIR=$(pkg-config --variable=giomoduledir gio-2.0 2>/dev/null || true)
 if [ -n "${SYSTEM_GIO_MODULE_DIR}" ] && [ -d "${SYSTEM_GIO_MODULE_DIR}" ]; then
-    find "${SYSTEM_GIO_MODULE_DIR}" -maxdepth 1 -type f -name "libgio*.so" \
+    find "${SYSTEM_GIO_MODULE_DIR}" -maxdepth 1 -type f -name "*.so" \
         ! -name "libgvfsdbus.so" \
         ! -name "libgioremote-volume-monitor.so" \
         -exec cp -P {} "${GIO_MODULE_DIR}/" \;


### PR DESCRIPTION
## Summary
- Keep AppImage GIO module lookup inside the AppDir so bundled GLib/GIO does not load incompatible host GVFS modules.
- Copy matching non-GVFS GIO modules into `usr/lib/gio/modules` and generate a module cache so GIO features such as TLS remain available.
- Force `GIO_USE_VFS=local` for AppImage runtime to disable GVFS backends that would otherwise try to use host GVFS components.

Fixes #852.

## Test plan
- `bash -n scripts/create_appimage.sh`
- `pre-commit run --files scripts/create_appimage.sh`