### PR TITLE
fix(appimage): disable GTK platform theme for Qt6

### DIFF
--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -299,6 +299,12 @@ else
     die "linuxdeploy not found"
 fi
 
+if [ "${QT_VERSION}" = "6" ]; then
+    # Avoid GTK native dialogs in the Qt6 AppImage: they pull in
+    # host gdk-pixbuf loaders and can crash against bundled librsvg.
+    rm -f "${APPDIR}/usr/plugins/platformthemes/libqgtk3.so"
+fi
+
 # Bundle Python runtime and libraries
 info "Bundling Python runtime..."
 


### PR DESCRIPTION
## Summary
- Remove the Qt6 GTK platform theme plugin from AppImage bundles after linuxdeploy runs.
- Keep Qt6 AppImage file dialogs on Qt's non-GTK path so host gdk-pixbuf loaders are not loaded against bundled librsvg.

Fixes #853.

## Test plan
- `bash -n scripts/create_appimage.sh`
- `pre-commit run --files scripts/create_appimage.sh`

Made with [Cursor](https://cursor.com)