### PR TITLE
fix(appimage): bundle GMP runtime library

### DIFF
--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -305,6 +305,14 @@ if [ "${QT_VERSION}" = "6" ]; then
     rm -f "${APPDIR}/usr/plugins/platformthemes/libqgtk3.so"
 fi
 
+# Ensure GMP is bundled with MPFR and exact-arithmetic geometry users.
+if ! compgen -G "${APPDIR}/usr/lib/libgmp.so*" >/dev/null; then
+    find /usr/lib -name "libgmp.so*" -exec cp -P {} "${APPDIR}/usr/lib/" \; 2>/dev/null || true
+fi
+if ! compgen -G "${APPDIR}/usr/lib/libgmp.so*" >/dev/null; then
+    die "Failed to bundle libgmp.so"
+fi
+
 # Bundle Python runtime and libraries
 info "Bundling Python runtime..."
 

--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -306,11 +306,11 @@ if [ "${QT_VERSION}" = "6" ]; then
 fi
 
 # Ensure GMP is bundled with MPFR and exact-arithmetic geometry users.
-if ! compgen -G "${APPDIR}/usr/lib/libgmp.so*" >/dev/null; then
-    find /usr/lib -name "libgmp.so*" -exec cp -P {} "${APPDIR}/usr/lib/" \; 2>/dev/null || true
+if ! compgen -G "${APPDIR}/usr/lib/libgmp.so.10*" >/dev/null; then
+    find /usr/lib -name "libgmp.so.10*" -exec cp -P {} "${APPDIR}/usr/lib/" \; 2>/dev/null || true
 fi
-if ! compgen -G "${APPDIR}/usr/lib/libgmp.so*" >/dev/null; then
-    die "Failed to bundle libgmp.so"
+if ! compgen -G "${APPDIR}/usr/lib/libgmp.so.10*" >/dev/null; then
+    die "Failed to bundle libgmp.so.10"
 fi
 
 # Bundle Python runtime and libraries

--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -306,10 +306,17 @@ if [ "${QT_VERSION}" = "6" ]; then
 fi
 
 # Ensure GMP is bundled with MPFR and exact-arithmetic geometry users.
-if ! compgen -G "${APPDIR}/usr/lib/libgmp.so.10*" >/dev/null; then
+GMP_SONAME="${APPDIR}/usr/lib/libgmp.so.10"
+if [ ! -e "${GMP_SONAME}" ]; then
     find /usr/lib -name "libgmp.so.10*" -exec cp -P {} "${APPDIR}/usr/lib/" \; 2>/dev/null || true
 fi
-if ! compgen -G "${APPDIR}/usr/lib/libgmp.so.10*" >/dev/null; then
+if [ ! -e "${GMP_SONAME}" ]; then
+    GMP_RUNTIME=$(find "${APPDIR}/usr/lib" -maxdepth 1 -type f -name "libgmp.so.10.*" | sort | head -1)
+    if [ -n "${GMP_RUNTIME}" ]; then
+        ln -sf "$(basename "${GMP_RUNTIME}")" "${GMP_SONAME}"
+    fi
+fi
+if [ ! -e "${GMP_SONAME}" ]; then
     die "Failed to bundle libgmp.so.10"
 fi
 


### PR DESCRIPTION
## Summary
- Ensure AppImage builds contain `libgmp.so*` alongside bundled MPFR.
- Fail AppImage packaging if GMP cannot be copied into `AppDir/usr/lib`.

Fixes #855.

## Test plan
- `bash -n scripts/create_appimage.sh`
- `pre-commit run --files scripts/create_appimage.sh`

Made with [Cursor](https://cursor.com)