### PR TITLE
fix(windows): fix uninstall previous version on install not actually uninstalling

### DIFF
--- a/cmake/nsis/NSIS.template.in
+++ b/cmake/nsis/NSIS.template.in
@@ -1022,6 +1022,18 @@ interactive_uninst:
   StrCpy $3 $0 -$2
   ClearErrors
   ExecWait '"$0" /S _?="$3"' $1
+
+  ; Verify success by checking the ARP key rather than trusting exit code alone.
+  ; See the .onInit uninst block for the full explanation.
+  ${If} $InstallMode = 1
+    ReadRegStr $4 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_ALL_USERS}" "UninstallString"
+  ${Else}
+    ReadRegStr $4 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_CURRENT_USER}" "UninstallString"
+  ${EndIf}
+  ${If} $4 == ""
+    Return  ; ARP key is gone — uninstall succeeded regardless of exit code
+  ${EndIf}
+
   IfErrors interactive_uninst_failed
   ${If} $1 != 0
     Goto interactive_uninst_failed
@@ -1403,6 +1415,20 @@ uninst:
   StrLen $2 "\@CPACK_NSIS_UNINSTALL_NAME@.exe"
   StrCpy $3 $0 -$2 # remove "\@CPACK_NSIS_UNINSTALL_NAME@.exe" from UninstallString to get path
   ExecWait '"$0" /S _?="$3"' $1 ;Do not copy the uninstaller to a temp file
+
+  ; Some NSIS uninstallers (notably on Windows 11) return a non-zero exit code or
+  ; set the error flag when run with _?= because they cannot self-delete while
+  ; running in-place, even after a fully successful uninstall.  The only reliable
+  ; signal of success is that the ARP registry key is gone.  Check that first;
+  ; only treat it as a true failure when the key is still present.
+  ${If} $InstallMode = 1
+    ReadRegStr $4 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_ALL_USERS}" "UninstallString"
+  ${Else}
+    ReadRegStr $4 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_CURRENT_USER}" "UninstallString"
+  ${EndIf}
+  ${If} $4 == ""
+    Goto done_uninst_check  ; ARP key is gone — uninstall succeeded regardless of exit code
+  ${EndIf}
 
   IfErrors uninst_failed
   ${If} $1 != 0

--- a/cmake/nsis/NSIS.template.in
+++ b/cmake/nsis/NSIS.template.in
@@ -32,7 +32,7 @@
 ;General
 
   ;Name and file
-  Name "@CPACK_NSIS_PACKAGE_NAME@"
+  Name "@CPACK_NSIS_PACKAGE_NAME@ @CPACK_PACKAGE_VERSION@"
   OutFile "@CPACK_TOPLEVEL_DIRECTORY@/@CPACK_OUTPUT_FILE_NAME@"
 
   ;Set compression
@@ -59,6 +59,9 @@
   Var InstallMode
   Var InitialInstallMode
   Var AllUsersRadio
+  ; Set to 1 in un.onInit when /frominstaller is on the command line, so the
+  ; uninstall-confirm page can be skipped (user already confirmed in the installer).
+  Var UninstalledByInstaller
 
   ; Use distinct uninstall-subkey names per install scope so Windows Settings
   ; can surface both entries when per-user and all-users installs coexist.
@@ -627,7 +630,11 @@ FunctionEnd
   @CPACK_NSIS_INSTALLER_FINISH_TITLE_3LINES_CODE@
   !insertmacro MUI_PAGE_FINISH
 
+  ; Skip the "are you sure?" confirm page when the uninstaller was launched by
+  ; a newer PythonSCAD installer (the user already confirmed there).
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE un.SkipConfirmIfCalledByInstaller
   !insertmacro MUI_UNPAGE_CONFIRM
+  !undef MUI_PAGE_CUSTOMFUNCTION_PRE
   !insertmacro MUI_UNPAGE_INSTFILES
 
 ;--------------------------------
@@ -1018,22 +1025,11 @@ interactive_uninst:
   StrCmp $2 "$\"" 0 +2
   StrCpy $0 $0 -1
 
-  StrLen $2 "\@CPACK_NSIS_UNINSTALL_NAME@.exe"
-  StrCpy $3 $0 -$2
+  ; Run the old uninstaller WITHOUT /S and WITHOUT _?= — see the .onInit uninst
+  ; block for the full explanation.  Pass /frominstaller so PythonSCAD
+  ; uninstallers built from this template skip their own confirm page.
   ClearErrors
-  ExecWait '"$0" /S _?="$3"' $1
-
-  ; Verify success by checking the ARP key rather than trusting exit code alone.
-  ; See the .onInit uninst block for the full explanation.
-  ${If} $InstallMode = 1
-    ReadRegStr $4 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_ALL_USERS}" "UninstallString"
-  ${Else}
-    ReadRegStr $4 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_CURRENT_USER}" "UninstallString"
-  ${EndIf}
-  ${If} $4 == ""
-    Return  ; ARP key is gone — uninstall succeeded regardless of exit code
-  ${EndIf}
-
+  ExecWait '"$0" /frominstaller' $1
   IfErrors interactive_uninst_failed
   ${If} $1 != 0
     Goto interactive_uninst_failed
@@ -1067,6 +1063,14 @@ Function InstallOptionsPage
   !insertmacro MUI_INSTALLOPTIONS_DISPLAY "NSIS.InstallOptions.ini"
 FunctionEnd
 
+; Called as MUI_UNPAGE_CONFIRM PRE function: skip the confirmation page when
+; the uninstaller was launched by a PythonSCAD installer (user already confirmed).
+Function un.SkipConfirmIfCalledByInstaller
+  ${If} $UninstalledByInstaller = 1
+    Abort
+  ${EndIf}
+FunctionEnd
+
 ;--------------------------------
 ; Uninstall init: read the InstallMode value written to the ARP key at install
 ; time to determine scope. Both InstallMode and InstallLocation are read from
@@ -1076,6 +1080,16 @@ FunctionEnd
 Function un.onInit
   StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" 0 +2
     SetRegView 64
+
+  ; Detect /frominstaller flag: set by a PythonSCAD installer running us as part
+  ; of uninstall-before-upgrade.  The user already confirmed the uninstall there,
+  ; so we skip our own confirm page.
+  StrCpy $UninstalledByInstaller 0
+  ClearErrors
+  ${GetOptions} $CMDLINE "/frominstaller" $R0
+  ${IfNot} ${Errors}
+    StrCpy $UninstalledByInstaller 1
+  ${EndIf}
 
   ; Check HKCU first. Verify InstallLocation matches $INSTDIR so the all-users
   ; uninstaller doesn't accidentally match a per-user entry.
@@ -1412,23 +1426,18 @@ uninst:
   StrCmp $2 "$\"" 0 +2  # if char is quote
   StrCpy $0 $0 -1       # remove last char
 
-  StrLen $2 "\@CPACK_NSIS_UNINSTALL_NAME@.exe"
-  StrCpy $3 $0 -$2 # remove "\@CPACK_NSIS_UNINSTALL_NAME@.exe" from UninstallString to get path
-  ExecWait '"$0" /S _?="$3"' $1 ;Do not copy the uninstaller to a temp file
-
-  ; Some NSIS uninstallers (notably on Windows 11) return a non-zero exit code or
-  ; set the error flag when run with _?= because they cannot self-delete while
-  ; running in-place, even after a fully successful uninstall.  The only reliable
-  ; signal of success is that the ARP registry key is gone.  Check that first;
-  ; only treat it as a true failure when the key is still present.
-  ${If} $InstallMode = 1
-    ReadRegStr $4 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_ALL_USERS}" "UninstallString"
-  ${Else}
-    ReadRegStr $4 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ARP_KEY_CURRENT_USER}" "UninstallString"
-  ${EndIf}
-  ${If} $4 == ""
-    Goto done_uninst_check  ; ARP key is gone — uninstall succeeded regardless of exit code
-  ${EndIf}
+  ; Run the old uninstaller WITHOUT /S and WITHOUT _?=.
+  ; - No /S: the uninstaller shows its own UI (progress bar) so the user has
+  ;   visual feedback during the ~10 second removal.  The user already confirmed
+  ;   the uninstall by clicking Yes in this installer, so the extra confirm page
+  ;   in the old uninstaller is a minor redundancy, not a problem.
+  ;   PythonSCAD uninstallers built from this template recognise /frominstaller
+  ;   and automatically skip their own confirm page.
+  ; - No _?=: using _?= (in-place execution) causes some NSIS uninstallers to
+  ;   return exit code 2 and abort without doing anything, because their
+  ;   un.onInit path-comparison logic behaves differently when $INSTDIR is set
+  ;   from the _?= parameter versus the default temp-copy behaviour.
+  ExecWait '"$0" /frominstaller' $1
 
   IfErrors uninst_failed
   ${If} $1 != 0


### PR DESCRIPTION
Fixes #859

## Summary

Three issues with the uninstall-before-install flow, all fixed:

- **Uninstall silently failed (exit code 2, nothing removed):** `ExecWait` was using `_?=` (in-place execution), which causes some NSIS uninstallers to return exit code 2 and abort without removing anything. Root cause: `_?=` sets `$INSTDIR` before `un.onInit` runs, and the `lstrcmpiW` path-comparison logic behaves differently in that mode. Fix: drop `_?=`.

- **No visual feedback during uninstall (~10s blank wait):** `ExecWait` was also passing `/S` (silent mode), so the old uninstaller ran with no UI at all. Fix: drop `/S` so the old uninstaller shows its own progress bar.

- **Old uninstaller shows a redundant confirm page:** The user already confirmed by clicking Yes in the new installer. Fix: pass `/frominstaller` to the old uninstaller. New uninstallers built from this template detect that flag in `un.onInit` and skip their `MUI_UNPAGE_CONFIRM` page automatically. Old uninstallers (pre-1.1.0) ignore the unknown flag harmlessly — users upgrading from v1.0.0 see the confirm page once more; from the next upgrade onwards it is skipped.

Also: the installer window title and welcome text now include the version number (`Name` directive appends `@CPACK_PACKAGE_VERSION@`).

## Test plan

- [x] Install v1.0.0 from the GitHub release
- [x] Run the new installer → click **Yes** on the "already installed" dialog
- [x] Old uninstaller UI appears (confirm page + progress bar), uninstall completes
- [x] New installer proceeds to its Welcome page with version in the title
- [x] Install a second time using two new-template builds: confirm page is skipped, only progress bar shown