### PR TITLE
fix(windows): add packaged Python runtime search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2417,6 +2417,16 @@ if(NOT APPLE OR APPLE_UNIX)
 	              PATTERN "tests" EXCLUDE
 	              PATTERN "*.pyc" EXCLUDE)
 
+	      # The executable is linked to the python.org embeddable DLL name
+	      # (pythonXY.dll). Ship the matching embeddable extension modules too;
+	      # MSYS2's lib-dynload modules use a different extension suffix and are
+	      # invisible to that runtime for imports such as socket -> _socket.
+	      install(DIRECTORY "${PYTHON_EMBED_DEVPATH}/"
+	              DESTINATION "."
+	              FILES_MATCHING
+	              PATTERN "*.pyd"
+	              PATTERN "python*.zip")
+
 	      message(STATUS "Native MSYS2 build: Python stdlib will be installed from ${_MSYS2_PYTHON_PREFIX}/lib/python${PYTHON_MINGW_VERSION}")
 	    endif()
     endif()

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1225,6 +1225,7 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
         stream << sepchar << fs::absolute(path).generic_string();
       }
     }
+    stream << sepchar << applicationPath.generic_string();
 #else
     char sepchar = ':';
     const auto pythonXY =

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1267,7 +1267,8 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
 #endif
 #ifndef __EMSCRIPTEN__
 #if defined(_WIN32)
-    PyConfig_SetBytesString(&config, &config.home, PlatformUtils::applicationPath().c_str());
+    const auto applicationPathString = applicationPath.generic_string();
+    PyConfig_SetBytesString(&config, &config.home, applicationPathString.c_str());
 #endif
     PyConfig_SetBytesString(&config, &config.pythonpath_env, stream.str().c_str());
 #endif

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1215,7 +1215,7 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     // the platform-independent libraries without needing a real python.exe.
     const auto pythonXY =
       "python" + std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION);
-    const auto windowsPythonLib = fs::path(PlatformUtils::applicationPath()) / "lib" / pythonXY;
+    const auto windowsPythonLib = applicationPath / "lib" / pythonXY;
     const std::array<fs::path, 2> windowsPythonRuntimePaths = {
       windowsPythonLib,
       windowsPythonLib / "lib-dynload",

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1226,6 +1226,10 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
       }
     }
     stream << sepchar << applicationPath.generic_string();
+    const auto windowsPythonDlls = applicationPath / "DLLs";
+    if (fs::is_directory(windowsPythonDlls)) {
+      stream << sepchar << fs::absolute(windowsPythonDlls).generic_string();
+    }
 #else
     char sepchar = ':';
     const auto pythonXY =

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -31,6 +31,7 @@
 #include <cctype>
 #include <cstdio>
 #include <filesystem>
+#include <sstream>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -1214,7 +1215,16 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     // the platform-independent libraries without needing a real python.exe.
     const auto pythonXY =
       "python" + std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION);
-    stream << sepchar << (applicationPath / "lib" / pythonXY).generic_string();
+    const auto windowsPythonLib = fs::path(PlatformUtils::applicationPath()) / "lib" / pythonXY;
+    const std::array<fs::path, 2> windowsPythonRuntimePaths = {
+      windowsPythonLib,
+      windowsPythonLib / "lib-dynload",
+    };
+    for (const auto& path : windowsPythonRuntimePaths) {
+      if (fs::is_directory(path)) {
+        stream << sepchar << fs::absolute(path).generic_string();
+      }
+    }
 #else
     char sepchar = ':';
     const auto pythonXY =
@@ -1251,6 +1261,9 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     stream << sepchar << ".";
 #endif
 #ifndef __EMSCRIPTEN__
+#if defined(_WIN32)
+    PyConfig_SetBytesString(&config, &config.home, PlatformUtils::applicationPath().c_str());
+#endif
     PyConfig_SetBytesString(&config, &config.pythonpath_env, stream.str().c_str());
 #endif
 


### PR DESCRIPTION
## Summary
- Add Windows packaged Python stdlib and lib-dynload paths before embedded Python initialization.
- Set the embedded Python home to the app root so packaged builds do not depend on CPython path probing.
- Ship the python.org embeddable `.pyd` modules and `python314.zip` beside the executable, and include app-root/`DLLs` search paths so stdlib imports like `socket` can load compatible native extensions.

## Test plan
- [x] `pre-commit run --files src/python/pyopenscad.cc CMakeLists.txt`
- [x] `cmake --build build -j4`
- [x] `cmake --install build --prefix build`
- [x] Direct Windows build-tree run of `tests/data/pythonscad-echo/asyncio-regression.py` outputs `asyncio_ok`
- [x] Staged Windows export of `cube(10).show()` to STL
- [x] Staged `--repl` startup smoke test
- [x] Staged `--ipython` startup smoke test