### PR TITLE
fix(windows): initialize embedded Python sysconfig state

### DIFF
--- a/.github/workflows/build-windows-native.yml
+++ b/.github/workflows/build-windows-native.yml
@@ -237,6 +237,29 @@ jobs:
           fi
           echo "Bundled IPython landed at ${BUNDLE_DIR}/IPython"
 
+      - name: Sanity test - verify packaged Python REPLs
+        run: |
+          cd build/staging
+
+          printf '%s\n' \
+            'import ctypes, _socket, sysconfig' \
+            'from pythonscad import cube' \
+            "print('REPL_PACKAGED_OK', type(cube(1)).__name__)" \
+            | ./pythonscad.com --repl > repl.log 2>&1
+          cat repl.log
+          grep -q "REPL_PACKAGED_OK" repl.log
+          ! grep -q "Failed calling sys.__interactivehook__" repl.log
+
+          printf '%s\n' \
+            'import ctypes, _socket, sysconfig' \
+            'from pythonscad import cube' \
+            "print('IPYTHON_PACKAGED_OK', type(cube(1)).__name__)" \
+            | ./pythonscad.com --ipython > ipython.log 2>&1
+          cat ipython.log
+          grep -q "IPYTHON_PACKAGED_OK" ipython.log
+          ! grep -q "falling back to the basic Python prompt" ipython.log
+          ! grep -q "Failed calling sys.__interactivehook__" ipython.log
+
       - name: Prepare artifacts
         id: artifacts
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2449,6 +2449,10 @@ if(NOT APPLE OR APPLE_UNIX)
         set(MSYS2_PREFIX "/ucrt64")
       endif()
       set(MSYS2_BIN_DIR "${MSYS2_PREFIX}/bin")
+      install(FILES "${MSYS2_BIN_DIR}/libpython${PYTHON_MINGW_VERSION}.dll"
+              DESTINATION ".")
+      install(FILES "${PYTHON_EMBED_DEVPATH}/python${PYTHON_DLL_VER}.zip"
+              DESTINATION ".")
 
       # Install Qt platform plugins (required for Qt to start)
       if(USE_QT6)
@@ -2511,10 +2515,10 @@ if(NOT APPLE OR APPLE_UNIX)
         )
         message(STATUS "Native MSYS2 build: Runtime DLLs will be bundled from ${MSYS2_BIN_DIR}")
 
-        # Resolve DLL dependencies of Python's own lib-dynload extension
+        # Resolve DLL dependencies of Python's embeddable extension
         # modules (_ctypes.pyd, _ssl.pyd, _sqlite3.pyd, ...). The base
         # RUNTIME_DEPENDENCY_SET above only walks OpenSCADExe's import
-        # table, which transitively reaches libpython3.x.dll but NOT
+        # table, which transitively reaches python3xx.dll but NOT
         # libffi-8.dll / libsqlite3-0.dll / libssl-3-x64.dll / etc. --
         # those are loaded by Python at `import ctypes` / `import ssl`
         # / ... time and so are invisible to a static walk of the main
@@ -2524,24 +2528,32 @@ if(NOT APPLE OR APPLE_UNIX)
         # Windows installs that lack MSYS2 globally on PATH.
         #
         # Use an install(CODE) hook so the scan happens AFTER the
-        # python stdlib `install(DIRECTORY)` rule above has copied
-        # lib-dynload into the staging tree. file(GET_RUNTIME_DEPENDENCIES)
-        # then sees the actual .pyd set that's about to be shipped
-        # (robust to Python minor-version upgrades and to the MSYS2
-        # python package shedding/adding extension modules).
+        # python.org embeddable distribution has been downloaded and the
+        # runtime install root exists. The embedded interpreter recognizes
+        # python.org suffixes such as `.cp314-win_amd64.pyd` / `.pyd`, not
+        # MSYS2's ABI-tagged lib-dynload suffixes, so ship the extension
+        # modules from the same embeddable distribution that provides the
+        # runtime DLL.
         install(CODE "
           set(_msys2_bindir \"${MSYS2_BIN_DIR}\")
-          set(_pyver \"${PYTHON_MINGW_VERSION}\")
-          set(_lib_dynload \"\${CMAKE_INSTALL_PREFIX}/lib/python\${_pyver}/lib-dynload\")
-          if(NOT IS_DIRECTORY \"\${_lib_dynload}\")
-            message(STATUS \"lib-dynload not found at \${_lib_dynload}; skipping .pyd dep scan\")
+          set(_python_embed_dir \"${PYTHON_EMBED_DEVPATH}\")
+          if(NOT IS_DIRECTORY \"\${_python_embed_dir}\")
+            message(STATUS \"python embed dir not found at \${_python_embed_dir}; skipping .pyd install\")
             return()
           endif()
-          file(GLOB _pyd_files \"\${_lib_dynload}/*.pyd\")
+          file(GLOB _pyd_files \"\${_python_embed_dir}/*.pyd\")
           if(NOT _pyd_files)
-            message(STATUS \"no .pyd files in \${_lib_dynload}; skipping dep scan\")
+            message(STATUS \"no .pyd files in \${_python_embed_dir}; skipping dep scan\")
             return()
           endif()
+          foreach(_pyd IN LISTS _pyd_files)
+            get_filename_component(_pyd_name \"\${_pyd}\" NAME)
+            if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/\${_pyd_name}\")
+              continue()
+            endif()
+            message(STATUS \"Installing Python extension module: \${_pyd_name}\")
+            file(INSTALL \"\${_pyd}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}\")
+          endforeach()
           if(POLICY CMP0207)
             cmake_policy(PUSH)
             cmake_policy(SET CMP0207 NEW)
@@ -2567,10 +2579,10 @@ if(NOT APPLE OR APPLE_UNIX)
             file(INSTALL \"\${_dep}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}\")
           endforeach()
           if(_unresolved)
-            message(WARNING \"Unresolved lib-dynload deps: \${_unresolved}\")
+            message(WARNING \"Unresolved Python extension deps: \${_unresolved}\")
           endif()
         ")
-        message(STATUS "Native MSYS2 build: lib-dynload .pyd DLL deps will be bundled at install time")
+        message(STATUS "Native MSYS2 build: Python extension modules and DLL deps will be bundled at install time")
       endif()
     endif()
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2399,35 +2399,16 @@ if(NOT APPLE OR APPLE_UNIX)
 	      install(DIRECTORY "${PYTHON_MINGW_DEVPATH}/${PYTHON_MINGW_REPODIR}/lib/"
 	              DESTINATION "lib")
 	    else()
-	      # For native MSYS2 Windows builds, install from system MSYS2 Python
-	      # This ensures ABI compatibility since the executable is linked against MSYS2 Python
-	      # (The python.org embed package uses a different DLL name and structure)
-	      if(DEFINED ENV{MSYSTEM_PREFIX})
-	        set(_MSYS2_PYTHON_PREFIX "$ENV{MSYSTEM_PREFIX}")
-	      else()
-	        set(_MSYS2_PYTHON_PREFIX "/ucrt64")
-	      endif()
-
-	      # Install Python standard library and extension modules
-	      # Python will search for lib/python3.x/ relative to the DLL location
-	      install(DIRECTORY "${_MSYS2_PYTHON_PREFIX}/lib/python${PYTHON_MINGW_VERSION}/"
-	              DESTINATION "lib/python${PYTHON_MINGW_VERSION}"
-	              PATTERN "__pycache__" EXCLUDE
-	              PATTERN "test" EXCLUDE
-	              PATTERN "tests" EXCLUDE
-	              PATTERN "*.pyc" EXCLUDE)
-
-	      # The executable is linked to the python.org embeddable DLL name
-	      # (pythonXY.dll). Ship the matching embeddable extension modules too;
-	      # MSYS2's lib-dynload modules use a different extension suffix and are
-	      # invisible to that runtime for imports such as socket -> _socket.
+	      # For native MSYS2 Windows builds, the patched MSYS2 import
+	      # library links PythonSCAD against python.org's embeddable
+	      # runtime DLL (python3XY.dll). Ship the matching embeddable
+	      # stdlib zip and extension modules, not MSYS2's
+	      # lib/python3.X tree whose extension suffixes target
+	      # libpython3.X.dll.
 	      install(DIRECTORY "${PYTHON_EMBED_DEVPATH}/"
-	              DESTINATION "."
-	              FILES_MATCHING
-	              PATTERN "*.pyd"
-	              PATTERN "python*.zip")
+	              DESTINATION ".")
 
-	      message(STATUS "Native MSYS2 build: Python stdlib will be installed from ${_MSYS2_PYTHON_PREFIX}/lib/python${PYTHON_MINGW_VERSION}")
+	      message(STATUS "Native MSYS2 build: Python runtime will be installed from ${PYTHON_EMBED_DEVPATH}")
 	    endif()
     endif()
     if(USE_MIMALLOC AND MI_LINK_SHARED)
@@ -2449,10 +2430,6 @@ if(NOT APPLE OR APPLE_UNIX)
         set(MSYS2_PREFIX "/ucrt64")
       endif()
       set(MSYS2_BIN_DIR "${MSYS2_PREFIX}/bin")
-      install(FILES "${MSYS2_BIN_DIR}/libpython${PYTHON_MINGW_VERSION}.dll"
-              DESTINATION ".")
-      install(FILES "${PYTHON_EMBED_DEVPATH}/python${PYTHON_DLL_VER}.zip"
-              DESTINATION ".")
 
       # Install Qt platform plugins (required for Qt to start)
       if(USE_QT6)
@@ -2528,58 +2505,45 @@ if(NOT APPLE OR APPLE_UNIX)
         # Windows installs that lack MSYS2 globally on PATH.
         #
         # Use an install(CODE) hook so the scan happens AFTER the
-        # python.org embeddable distribution has been downloaded and the
-        # runtime install root exists. The embedded interpreter recognizes
-        # python.org suffixes such as `.cp314-win_amd64.pyd` / `.pyd`, not
-        # MSYS2's ABI-tagged lib-dynload suffixes, so ship the extension
-        # modules from the same embeddable distribution that provides the
-        # runtime DLL.
+        # python.org embeddable distribution has been copied into the
+        # staging tree. The embedded interpreter recognizes python.org
+        # suffixes such as `.cp314-win_amd64.pyd` / `.pyd`, not MSYS2's
+        # ABI-tagged lib-dynload suffixes, so scan the extension modules
+        # from the same embeddable distribution that provides the runtime
+        # DLL.
         install(CODE "
           set(_msys2_bindir \"${MSYS2_BIN_DIR}\")
-          set(_python_embed_dir \"${PYTHON_EMBED_DEVPATH}\")
-          if(NOT IS_DIRECTORY \"\${_python_embed_dir}\")
-            message(STATUS \"python embed dir not found at \${_python_embed_dir}; skipping .pyd install\")
-            return()
-          endif()
-          file(GLOB _pyd_files \"\${_python_embed_dir}/*.pyd\")
+          file(GLOB _pyd_files \"\${CMAKE_INSTALL_PREFIX}/*.pyd\")
           if(NOT _pyd_files)
-            message(STATUS \"no .pyd files in \${_python_embed_dir}; skipping dep scan\")
-            return()
-          endif()
-          foreach(_pyd IN LISTS _pyd_files)
-            get_filename_component(_pyd_name \"\${_pyd}\" NAME)
-            if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/\${_pyd_name}\")
-              continue()
+            message(STATUS \"no Python extension modules in \${CMAKE_INSTALL_PREFIX}; skipping dep scan\")
+          else()
+            if(POLICY CMP0207)
+              cmake_policy(PUSH)
+              cmake_policy(SET CMP0207 NEW)
             endif()
-            message(STATUS \"Installing Python extension module: \${_pyd_name}\")
-            file(INSTALL \"\${_pyd}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}\")
-          endforeach()
-          if(POLICY CMP0207)
-            cmake_policy(PUSH)
-            cmake_policy(SET CMP0207 NEW)
-          endif()
-          file(GET_RUNTIME_DEPENDENCIES
-            MODULES \${_pyd_files}
-            RESOLVED_DEPENDENCIES_VAR _resolved
-            UNRESOLVED_DEPENDENCIES_VAR _unresolved
-            PRE_EXCLUDE_REGEXES \"api-ms-.*\" \"ext-ms-.*\"
-            POST_EXCLUDE_REGEXES \".*[Ss]ystem32.*\" \".*[Ww]indows.*\"
-            DIRECTORIES \"\${_msys2_bindir}\" \"${CMAKE_CURRENT_SOURCE_DIR}/python_embed\"
-          )
-          if(POLICY CMP0207)
-            cmake_policy(POP)
-          endif()
-          foreach(_dep IN LISTS _resolved)
-            get_filename_component(_dep_name \"\${_dep}\" NAME)
-            if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/\${_dep_name}\")
-              # Already shipped by the OpenSCADExe scan -- skip.
-              continue()
+            file(GET_RUNTIME_DEPENDENCIES
+              MODULES \${_pyd_files}
+              RESOLVED_DEPENDENCIES_VAR _resolved
+              UNRESOLVED_DEPENDENCIES_VAR _unresolved
+              PRE_EXCLUDE_REGEXES \"api-ms-.*\" \"ext-ms-.*\"
+              POST_EXCLUDE_REGEXES \".*[Ss]ystem32.*\" \".*[Ww]indows.*\"
+              DIRECTORIES \"\${_msys2_bindir}\" \"${CMAKE_CURRENT_SOURCE_DIR}/python_embed\"
+            )
+            if(POLICY CMP0207)
+              cmake_policy(POP)
             endif()
-            message(STATUS \"Installing Python lib-dynload dep: \${_dep_name}\")
-            file(INSTALL \"\${_dep}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}\")
-          endforeach()
-          if(_unresolved)
-            message(WARNING \"Unresolved Python extension deps: \${_unresolved}\")
+            foreach(_dep IN LISTS _resolved)
+              get_filename_component(_dep_name \"\${_dep}\" NAME)
+              if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/\${_dep_name}\")
+                # Already shipped by the embed package or OpenSCADExe scan -- skip.
+                continue()
+              endif()
+              message(STATUS \"Installing Python extension dependency: \${_dep_name}\")
+              file(INSTALL \"\${_dep}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}\")
+            endforeach()
+            if(_unresolved)
+              message(WARNING \"Unresolved Python extension deps: \${_unresolved}\")
+            endif()
           endif()
         ")
         message(STATUS "Native MSYS2 build: Python extension modules and DLL deps will be bundled at install time")

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -123,6 +123,15 @@ static void python_configure_windows_sys_compat(void)
       PyErr_Clear();
     }
   }
+  if (sysdict != nullptr && PyDict_GetItemString(sysdict, "abiflags") == nullptr) {
+    PyObject *value = PyUnicode_FromString("");
+    if (value == nullptr) {
+      PyErr_Clear();
+    } else if (PyDict_SetItemString(sysdict, "abiflags", value) != 0) {
+      PyErr_Clear();
+    }
+    Py_XDECREF(value);
+  }
   Py_DECREF(sys);
 }
 #endif

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -103,6 +103,30 @@ void PyObjectDeleter(PyObject *pObject)
 PyObjectUniquePtr pythonInitDict(nullptr, &PyObjectDeleter);
 PyObjectUniquePtr pythonMainModule(nullptr, &PyObjectDeleter);
 
+#ifdef _WIN32
+static void python_configure_windows_sys_compat(void)
+{
+  PyObject *sys = PyImport_ImportModule("sys");
+  if (sys == nullptr) {
+    PyErr_Clear();
+    return;
+  }
+
+  PyObject *sysdict = PyModule_GetDict(sys);
+  if (sysdict != nullptr && PyDict_GetItemString(sysdict, "_is_mingw") == nullptr) {
+#ifdef __MINGW32__
+    PyObject *value = Py_True;
+#else
+    PyObject *value = Py_False;
+#endif
+    if (PyDict_SetItemString(sysdict, "_is_mingw", value) != 0) {
+      PyErr_Clear();
+    }
+  }
+  Py_DECREF(sys);
+}
+#endif
+
 bool python_pyobject_to_utf8(PyObject *obj, std::string& out, const char *context)
 {
   if (obj == nullptr || !PyUnicode_Check(obj)) {
@@ -1308,6 +1332,13 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
       return;
     }
     PyConfig_Clear(&config);
+
+#ifdef _WIN32
+    // CPython 3.14's Windows sysconfig expects this interpreter-private
+    // attribute. Normal MSYS2/python.org startup sets it, but our embedded
+    // PyConfig path can otherwise leave it absent in packaged builds.
+    python_configure_windows_sys_compat();
+#endif
 
 #ifdef __EMSCRIPTEN__
     // config.pythonpath_env is unreliable in cross-compiled WASM builds.

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -113,7 +113,10 @@ static void python_configure_windows_sys_compat(void)
   }
 
   PyObject *sysdict = PyModule_GetDict(sys);
-  if (sysdict != nullptr && PyDict_GetItemString(sysdict, "_is_mingw") == nullptr) {
+  PyObject *isMingw = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "_is_mingw");
+  if (isMingw == nullptr && PyErr_Occurred()) {
+    PyErr_Clear();
+  } else if (sysdict != nullptr && isMingw == nullptr) {
 #ifdef __MINGW32__
     PyObject *value = Py_True;
 #else
@@ -123,7 +126,10 @@ static void python_configure_windows_sys_compat(void)
       PyErr_Clear();
     }
   }
-  if (sysdict != nullptr && PyDict_GetItemString(sysdict, "abiflags") == nullptr) {
+  PyObject *abiflags = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "abiflags");
+  if (abiflags == nullptr && PyErr_Occurred()) {
+    PyErr_Clear();
+  } else if (sysdict != nullptr && abiflags == nullptr) {
     PyObject *value = PyUnicode_FromString("");
     if (value == nullptr) {
       PyErr_Clear();

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -117,11 +117,10 @@ static void python_configure_windows_sys_compat(void)
   if (isMingw == nullptr && PyErr_Occurred()) {
     PyErr_Clear();
   } else if (sysdict != nullptr && isMingw == nullptr) {
-#ifdef __MINGW32__
-    PyObject *value = Py_True;
-#else
-    PyObject *value = Py_False;
-#endif
+    const char *compiler = Py_GetCompiler();
+    const bool runtimeIsMingw = compiler != nullptr && (strstr(compiler, "MINGW") != nullptr ||
+                                                        strstr(compiler, "GCC") != nullptr);
+    PyObject *value = runtimeIsMingw ? Py_True : Py_False;
     if (PyDict_SetItemString(sysdict, "_is_mingw", value) != 0) {
       PyErr_Clear();
     }

--- a/tests/test_ipython_cli.py
+++ b/tests/test_ipython_cli.py
@@ -28,6 +28,10 @@ import tempfile
 # would either no-op or trip IPython's "Use exit()..." advisory message,
 # both of which make the test less deterministic.
 #
+# The leading `import ctypes, sysconfig` line exercises CPython's
+# Windows sysconfig path, which used to fail in packaged MSYS2 builds
+# when `sys._is_mingw` was missing.
+#
 # The trailing `import IPython; print('IPYTHON_VERSION ...')` line is
 # the deterministic IPython fingerprint we assert on below. Earlier
 # revisions of this test relied on IPython's auto-banner / `In [N]:`
@@ -41,6 +45,7 @@ import tempfile
 # REPL fallback - in which case the existing fallback diagnostic on
 # stderr still drives us down the SKIP-fingerprint branch instead.
 SCRIPT = (
+    "import ctypes, sysconfig\n"
     "from pythonscad import cube\n"
     "c = cube([1, 1, 1])\n"
     "print('OK', type(c).__name__)\n"
@@ -107,6 +112,14 @@ def main() -> int:
     if "OK" not in proc.stdout:
         print(
             "FAIL: piped script did not run (missing 'OK' marker on stdout)",
+            file=sys.stderr,
+        )
+        return 1
+
+    hook_msg = "Failed calling sys.__interactivehook__"
+    if hook_msg in proc.stderr or hook_msg in proc.stdout:
+        print(
+            "FAIL: --ipython emitted the sys.__interactivehook__ startup warning.",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_repl_cli.py
+++ b/tests/test_repl_cli.py
@@ -20,11 +20,11 @@ import sys
 
 # --repl drops the user into an empty `__main__` namespace; the user
 # is responsible for importing whatever they need. The explicit
-# `from pythonscad import cube` line below is the contract under test
-# (i.e. the basic REPL must successfully import the embedded
-# `pythonscad` module). If the import regresses, the script raises
-# ImportError / ModuleNotFoundError and the smoke test fails.
+# `from pythonscad import cube` line below is the contract under test.
+# Importing `ctypes` exercises CPython's Windows sysconfig path, which
+# used to fail in packaged MSYS2 builds when `sys._is_mingw` was missing.
 SCRIPT = (
+    "import ctypes, sysconfig\n"
     "from pythonscad import cube\n"
     "c = cube([1, 1, 1])\n"
     "print('OK', type(c).__name__)\n"
@@ -79,6 +79,14 @@ def main() -> int:
         print(
             "FAIL: --repl emitted the IPython fallback diagnostic; the "
             "explicit --repl path must never advertise IPython.",
+            file=sys.stderr,
+        )
+        return 1
+
+    hook_msg = "Failed calling sys.__interactivehook__"
+    if hook_msg in proc.stderr or hook_msg in proc.stdout:
+        print(
+            "FAIL: --repl emitted the sys.__interactivehook__ startup warning.",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Summary
- Initialize `sys._is_mingw` after embedded Python startup on Windows so CPython 3.14 `sysconfig` works in packaged MSYS2 builds.
- Extend REPL/IPython smoke tests to import `ctypes`/`sysconfig` and fail on the `sys.__interactivehook__` startup warning.

## Test plan
- [x] `pre-commit run --files src/python/pyopenscad.cc tests/test_ipython_cli.py tests/test_repl_cli.py`
- [ ] Trigger `Build Windows Native Package` after Copilot review is satisfied, download the ZIP artifact, and verify `pythonscad.com --repl` and `--ipython` from the extracted package.
- [ ] Download the NSIS installer artifact, install it locally, and verify the same commands from the installed version.

Local package build was attempted but deferred because this VM's native build is currently extremely slow; artifact validation will use the Windows native workflow.