### PR TITLE
ci: upload Debian package artifacts

### DIFF
--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -352,10 +352,12 @@ jobs:
           retention-days: 7
 
       - name: Upload package artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: pythonscad-${{ matrix.family }}-${{ matrix.distro }}-${{ matrix.arch }}-deb
           path: /tmp/debs/*.deb
+          if-no-files-found: ignore
           retention-days: 30
 
       - name: Upload to GitHub Release

--- a/.github/workflows/build-debian-packages.yml
+++ b/.github/workflows/build-debian-packages.yml
@@ -351,6 +351,13 @@ jobs:
           path: /tmp/debs/*.log.txt
           retention-days: 7
 
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: pythonscad-${{ matrix.family }}-${{ matrix.distro }}-${{ matrix.arch }}-deb
+          path: /tmp/debs/*.deb
+          retention-days: 30
+
       - name: Upload to GitHub Release
         if: github.event_name == 'release' || github.event.inputs.upload_to_release != ''
         env:


### PR DESCRIPTION
## Summary
- Upload generated Debian packages as GitHub Actions artifacts.
- Match the artifact naming pattern used by the release smoke tooling.

## Test plan
- pre-commit run --files .github/workflows/build-debian-packages.yml


Made with [Cursor](https://cursor.com)