### PR TITLE
feat(release): add automated release smoke tooling

### DIFF
--- a/cmake/nsis/NSIS.template.in
+++ b/cmake/nsis/NSIS.template.in
@@ -56,6 +56,8 @@
   ; $InitialInstallMode: snapshot of $InstallMode taken at the end of .onInit,
   ; used by InstallModePage_Leave to detect when the user switched modes after
   ; the .onInit existing-install check ran, so we can re-check the *other* hive.
+  ; $IS_DEFAULT_INSTALLDIR: 1 when $INSTDIR still has the template default from
+  ; InstallDir, 0 when NSIS already applied an explicit command-line /D= path.
   Var InstallMode
   Var InitialInstallMode
   Var AllUsersRadio
@@ -938,7 +940,9 @@ Function InstallModePage_Leave
     ; Just for me
     StrCpy $InstallMode 0
     Call SetArpRegKeyFromInstallMode
-    StrCpy $INSTDIR "$LOCALAPPDATA\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+    ${If} $IS_DEFAULT_INSTALLDIR = 1
+      StrCpy $INSTDIR "$LOCALAPPDATA\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+    ${EndIf}
     SetShellVarContext current
     ; Clear the shield from the Next button
     GetDlgItem $0 $HWNDParent 1
@@ -956,9 +960,11 @@ Function InstallModePage_Leave
       ; Already elevated: just update mode and continue
       StrCpy $InstallMode 1
       Call SetArpRegKeyFromInstallMode
-      StrCpy $INSTDIR "$PROGRAMFILES64\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
-      StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" +2
-        StrCpy $INSTDIR "$PROGRAMFILES\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+      ${If} $IS_DEFAULT_INSTALLDIR = 1
+        StrCpy $INSTDIR "$PROGRAMFILES64\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+        StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" +2
+          StrCpy $INSTDIR "$PROGRAMFILES\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+      ${EndIf}
       SetShellVarContext all
       ; No UAC prompt will occur in this path, so clear any stale shield.
       GetDlgItem $0 $HWNDParent 1
@@ -1307,6 +1313,13 @@ Function .onInit
   StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" 0 +2
     SetRegView 64
 
+  ; NSIS applies /D=<dir> before .onInit. Preserve that explicit directory when
+  ; applying our per-user/all-users defaults below; otherwise silent installs
+  ; cannot choose a temporary install root.
+  StrCpy $IS_DEFAULT_INSTALLDIR 0
+  StrCmp $INSTDIR "@CPACK_NSIS_INSTALL_ROOT@\@CPACK_PACKAGE_INSTALL_DIRECTORY@" 0 +2
+    StrCpy $IS_DEFAULT_INSTALLDIR 1
+
   ; Plugin warmup with user feedback. Without this, the first nsDialogs::Create
   ; (in InstallModePage_Create after the License page) freezes the UI for ~10s
   ; while Windows AppCompat / Defender scans the freshly-extracted nsDialogs.dll.
@@ -1342,9 +1355,11 @@ Function .onInit
     ${If} $R1 = 1
       StrCpy $InstallMode 1
       Call SetArpRegKeyFromInstallMode
-      StrCpy $INSTDIR "$PROGRAMFILES64\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
-      StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" +2
-        StrCpy $INSTDIR "$PROGRAMFILES\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+      ${If} $IS_DEFAULT_INSTALLDIR = 1
+        StrCpy $INSTDIR "$PROGRAMFILES64\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+        StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" +2
+          StrCpy $INSTDIR "$PROGRAMFILES\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+      ${EndIf}
       SetShellVarContext all
       Goto done_init_mode
     ${EndIf}
@@ -1375,14 +1390,18 @@ Function .onInit
   ${If} $0 = 1
     StrCpy $InstallMode 1
     Call SetArpRegKeyFromInstallMode
-    StrCpy $INSTDIR "$PROGRAMFILES64\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
-    StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" +2
-      StrCpy $INSTDIR "$PROGRAMFILES\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+    ${If} $IS_DEFAULT_INSTALLDIR = 1
+      StrCpy $INSTDIR "$PROGRAMFILES64\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+      StrCmp "@CPACK_SYSTEM_NAME@" "windows-x86-64" +2
+        StrCpy $INSTDIR "$PROGRAMFILES\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+    ${EndIf}
     SetShellVarContext all
   ${Else}
     StrCpy $InstallMode 0
     Call SetArpRegKeyFromInstallMode
-    StrCpy $INSTDIR "$LOCALAPPDATA\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+    ${If} $IS_DEFAULT_INSTALLDIR = 1
+      StrCpy $INSTDIR "$LOCALAPPDATA\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+    ${EndIf}
     SetShellVarContext current
   ${EndIf}
 

--- a/scripts/release-smoke/common-smoke.ps1
+++ b/scripts/release-smoke/common-smoke.ps1
@@ -36,6 +36,44 @@ function Set-Utf8Content {
     [System.IO.File]::WriteAllText($Path, $Value, $encoding)
 }
 
+function Quote-WindowsArgument {
+    param([AllowNull()][string]$Argument)
+
+    if ($null -eq $Argument) {
+        return '""'
+    }
+    if ($Argument -notmatch '[\s"]') {
+        return $Argument
+    }
+
+    $quoted = '"'
+    $backslashes = 0
+    foreach ($char in $Argument.ToCharArray()) {
+        if ($char -eq '\') {
+            $backslashes += 1
+        } elseif ($char -eq '"') {
+            $quoted += ('\' * (($backslashes * 2) + 1)) + '"'
+            $backslashes = 0
+        } else {
+            if ($backslashes -gt 0) {
+                $quoted += '\' * $backslashes
+                $backslashes = 0
+            }
+            $quoted += $char
+        }
+    }
+    if ($backslashes -gt 0) {
+        $quoted += '\' * ($backslashes * 2)
+    }
+    $quoted += '"'
+    $quoted
+}
+
+function Join-WindowsArguments {
+    param([string[]]$Arguments)
+    ($Arguments | ForEach-Object { Quote-WindowsArgument -Argument $_ }) -join ' '
+}
+
 function Invoke-PythonSCAD {
     param(
         [Parameter(Mandatory = $true)][string]$ExecutablePath,
@@ -47,9 +85,7 @@ function Invoke-PythonSCAD {
 
     $psi = [System.Diagnostics.ProcessStartInfo]::new()
     $psi.FileName = $ExecutablePath
-    foreach ($arg in $Arguments) {
-        [void]$psi.ArgumentList.Add($arg)
-    }
+    $psi.Arguments = Join-WindowsArguments -Arguments $Arguments
     if ($WorkingDirectory) {
         $psi.WorkingDirectory = $WorkingDirectory
     }

--- a/scripts/release-smoke/common-smoke.ps1
+++ b/scripts/release-smoke/common-smoke.ps1
@@ -1,0 +1,165 @@
+$ErrorActionPreference = 'Stop'
+
+function Write-SmokeLog {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    Write-Host "==> $Message"
+}
+
+function Write-SmokeWarning {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    Write-Warning $Message
+}
+
+function Assert-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command not found: $Name"
+    }
+}
+
+function Assert-NonEmptyFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Expected output file does not exist: $Path"
+    }
+    if ((Get-Item -LiteralPath $Path).Length -le 0) {
+        throw "Expected non-empty output file: $Path"
+    }
+}
+
+function Invoke-PythonSCAD {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExecutablePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [string]$WorkingDirectory,
+        [string]$InputFile,
+        [string]$LogFile
+    )
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $ExecutablePath
+    foreach ($arg in $Arguments) {
+        [void]$psi.ArgumentList.Add($arg)
+    }
+    if ($WorkingDirectory) {
+        $psi.WorkingDirectory = $WorkingDirectory
+    }
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    if ($InputFile) {
+        $psi.RedirectStandardInput = $true
+    }
+
+    $process = [System.Diagnostics.Process]::Start($psi)
+    if ($InputFile) {
+        $inputText = Get-Content -LiteralPath $InputFile -Raw
+        $process.StandardInput.Write($inputText)
+        $process.StandardInput.Close()
+    }
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+
+    if ($LogFile) {
+        $parent = Split-Path -Parent $LogFile
+        if ($parent) {
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }
+        Set-Content -LiteralPath $LogFile -Value ($stdout + $stderr)
+    }
+
+    if ($process.ExitCode -ne 0) {
+        Write-Error "Smoke command failed with exit code $($process.ExitCode): $ExecutablePath $($Arguments -join ' ')" -ErrorAction Continue
+        if ($WorkingDirectory) {
+            Write-Error "Working directory: $WorkingDirectory" -ErrorAction Continue
+        }
+        if ($InputFile) {
+            Write-Error "Stdin: $InputFile" -ErrorAction Continue
+        }
+        if ($LogFile) {
+            Write-Error "Captured output: $LogFile" -ErrorAction Continue
+            if (Test-Path -LiteralPath $LogFile -PathType Leaf) {
+                Write-Error "--- begin command output: $LogFile ---" -ErrorAction Continue
+                Get-Content -LiteralPath $LogFile -Raw -ErrorAction SilentlyContinue | Write-Error -ErrorAction Continue
+                Write-Error "--- end command output: $LogFile ---" -ErrorAction Continue
+            } else {
+                Write-Error 'Command produced no captured output.' -ErrorAction Continue
+            }
+        }
+        throw "Smoke command failed with exit code $($process.ExitCode)"
+    }
+}
+
+function New-SmokeInputs {
+    param([Parameter(Mandatory = $true)][string]$TestDirectory)
+
+    New-Item -ItemType Directory -Force -Path $TestDirectory | Out-Null
+    Set-Content -LiteralPath (Join-Path $TestDirectory 'cube.scad') -Value 'cube(10);'
+    Set-Content -LiteralPath (Join-Path $TestDirectory 'cube.py') -Value @'
+from pythonscad import *
+
+cube(10).show()
+'@
+    Set-Content -LiteralPath (Join-Path $TestDirectory 'repl-smoke.py') -Value @'
+from pythonscad import *
+
+export(cube(10), "repl-cube.stl")
+raise SystemExit(0)
+'@
+    Set-Content -LiteralPath (Join-Path $TestDirectory 'ipython-smoke.py') -Value @'
+from pythonscad import *
+
+export(cube(10), "ipython-cube.stl")
+'@
+}
+
+function Invoke-SmokeTests {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExecutablePath,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Workdir
+    )
+
+    if (-not (Test-Path -LiteralPath $ExecutablePath -PathType Leaf)) {
+        throw "Executable not found: $ExecutablePath"
+    }
+
+    $safeLabel = $Label -replace '[^A-Za-z0-9_.-]', '_'
+    $testdir = Join-Path $Workdir "smoke-$safeLabel"
+    New-SmokeInputs -TestDirectory $testdir
+
+    Write-SmokeLog "Smoke testing $Label`: startup"
+    Invoke-PythonSCAD -ExecutablePath $ExecutablePath `
+        -Arguments @('--info') `
+        -LogFile (Join-Path $testdir 'info.log')
+
+    Write-SmokeLog "Smoke testing $Label`: OpenSCAD .scad export"
+    Invoke-PythonSCAD -ExecutablePath $ExecutablePath `
+        -Arguments @('-o', (Join-Path $testdir 'cube-scad.stl'), (Join-Path $testdir 'cube.scad')) `
+        -LogFile (Join-Path $testdir 'scad-export.log')
+    Assert-NonEmptyFile -Path (Join-Path $testdir 'cube-scad.stl')
+
+    Write-SmokeLog "Smoke testing $Label`: Python CLI export"
+    Invoke-PythonSCAD -ExecutablePath $ExecutablePath `
+        -Arguments @('--trust-python', '-o', (Join-Path $testdir 'cube-python.stl'), (Join-Path $testdir 'cube.py')) `
+        -LogFile (Join-Path $testdir 'python-export.log')
+    Assert-NonEmptyFile -Path (Join-Path $testdir 'cube-python.stl')
+
+    Write-SmokeLog "Smoke testing $Label`: basic Python REPL"
+    Invoke-PythonSCAD -ExecutablePath $ExecutablePath `
+        -Arguments @('--repl') `
+        -WorkingDirectory $testdir `
+        -InputFile (Join-Path $testdir 'repl-smoke.py') `
+        -LogFile (Join-Path $testdir 'repl.log')
+    Assert-NonEmptyFile -Path (Join-Path $testdir 'repl-cube.stl')
+
+    Write-SmokeLog "Smoke testing $Label`: IPython"
+    Invoke-PythonSCAD -ExecutablePath $ExecutablePath `
+        -Arguments @('--ipython', 'ipython-smoke.py') `
+        -WorkingDirectory $testdir `
+        -LogFile (Join-Path $testdir 'ipython.log')
+    Assert-NonEmptyFile -Path (Join-Path $testdir 'ipython-cube.stl')
+
+    Write-SmokeLog "Smoke testing $Label`: OK"
+}

--- a/scripts/release-smoke/common-smoke.ps1
+++ b/scripts/release-smoke/common-smoke.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 
 function Write-SmokeLog {
     param([Parameter(Mandatory = $true)][string]$Message)
-    Write-Host "==> $Message"
+    Write-Information "==> $Message" -InformationAction Continue
 }
 
 function Write-SmokeWarning {
@@ -27,7 +27,7 @@ function Assert-NonEmptyFile {
     }
 }
 
-function Set-Utf8Content {
+function Write-Utf8Content {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
         [Parameter(Mandatory = $true)][string]$Value
@@ -36,7 +36,7 @@ function Set-Utf8Content {
     [System.IO.File]::WriteAllText($Path, $Value, $encoding)
 }
 
-function Quote-WindowsArgument {
+function ConvertTo-WindowsArgument {
     param([AllowNull()][string]$Argument)
 
     if ($null -eq $Argument) {
@@ -69,9 +69,9 @@ function Quote-WindowsArgument {
     $quoted
 }
 
-function Join-WindowsArguments {
+function Join-WindowsArgument {
     param([string[]]$Arguments)
-    ($Arguments | ForEach-Object { Quote-WindowsArgument -Argument $_ }) -join ' '
+    ($Arguments | ForEach-Object { ConvertTo-WindowsArgument -Argument $_ }) -join ' '
 }
 
 function Invoke-PythonSCAD {
@@ -85,7 +85,7 @@ function Invoke-PythonSCAD {
 
     $psi = [System.Diagnostics.ProcessStartInfo]::new()
     $psi.FileName = $ExecutablePath
-    $psi.Arguments = Join-WindowsArguments -Arguments $Arguments
+    $psi.Arguments = Join-WindowsArgument -Arguments $Arguments
     if ($WorkingDirectory) {
         $psi.WorkingDirectory = $WorkingDirectory
     }
@@ -113,7 +113,7 @@ function Invoke-PythonSCAD {
         if ($parent) {
             New-Item -ItemType Directory -Force -Path $parent | Out-Null
         }
-        Set-Utf8Content -Path $LogFile -Value ($stdout + $stderr)
+        Write-Utf8Content -Path $LogFile -Value ($stdout + $stderr)
     }
 
     if ($process.ExitCode -ne 0) {
@@ -138,30 +138,30 @@ function Invoke-PythonSCAD {
     }
 }
 
-function New-SmokeInputs {
+function Initialize-SmokeInput {
     param([Parameter(Mandatory = $true)][string]$TestDirectory)
 
     New-Item -ItemType Directory -Force -Path $TestDirectory | Out-Null
-    Set-Utf8Content -Path (Join-Path $TestDirectory 'cube.scad') -Value 'cube(10);'
-    Set-Utf8Content -Path (Join-Path $TestDirectory 'cube.py') -Value @'
+    Write-Utf8Content -Path (Join-Path $TestDirectory 'cube.scad') -Value 'cube(10);'
+    Write-Utf8Content -Path (Join-Path $TestDirectory 'cube.py') -Value @'
 from pythonscad import *
 
 cube(10).show()
 '@
-    Set-Utf8Content -Path (Join-Path $TestDirectory 'repl-smoke.py') -Value @'
+    Write-Utf8Content -Path (Join-Path $TestDirectory 'repl-smoke.py') -Value @'
 from pythonscad import *
 
 export(cube(10), "repl-cube.stl")
 raise SystemExit(0)
 '@
-    Set-Utf8Content -Path (Join-Path $TestDirectory 'ipython-smoke.py') -Value @'
+    Write-Utf8Content -Path (Join-Path $TestDirectory 'ipython-smoke.py') -Value @'
 from pythonscad import *
 
 export(cube(10), "ipython-cube.stl")
 '@
 }
 
-function Invoke-SmokeTests {
+function Invoke-SmokeTest {
     param(
         [Parameter(Mandatory = $true)][string]$ExecutablePath,
         [Parameter(Mandatory = $true)][string]$Label,
@@ -174,7 +174,7 @@ function Invoke-SmokeTests {
 
     $safeLabel = $Label -replace '[^A-Za-z0-9_.-]', '_'
     $testdir = Join-Path $Workdir "smoke-$safeLabel"
-    New-SmokeInputs -TestDirectory $testdir
+    Initialize-SmokeInput -TestDirectory $testdir
 
     Write-SmokeLog "Smoke testing $Label`: startup"
     Invoke-PythonSCAD -ExecutablePath $ExecutablePath `

--- a/scripts/release-smoke/common-smoke.ps1
+++ b/scripts/release-smoke/common-smoke.ps1
@@ -27,6 +27,15 @@ function Assert-NonEmptyFile {
     }
 }
 
+function Set-Utf8Content {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+    $encoding = New-Object System.Text.UTF8Encoding -ArgumentList $false
+    [System.IO.File]::WriteAllText($Path, $Value, $encoding)
+}
+
 function Invoke-PythonSCAD {
     param(
         [Parameter(Mandatory = $true)][string]$ExecutablePath,
@@ -52,21 +61,23 @@ function Invoke-PythonSCAD {
     }
 
     $process = [System.Diagnostics.Process]::Start($psi)
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
     if ($InputFile) {
         $inputText = Get-Content -LiteralPath $InputFile -Raw
         $process.StandardInput.Write($inputText)
         $process.StandardInput.Close()
     }
-    $stdout = $process.StandardOutput.ReadToEnd()
-    $stderr = $process.StandardError.ReadToEnd()
     $process.WaitForExit()
+    $stdout = $stdoutTask.Result
+    $stderr = $stderrTask.Result
 
     if ($LogFile) {
         $parent = Split-Path -Parent $LogFile
         if ($parent) {
             New-Item -ItemType Directory -Force -Path $parent | Out-Null
         }
-        Set-Content -LiteralPath $LogFile -Value ($stdout + $stderr)
+        Set-Utf8Content -Path $LogFile -Value ($stdout + $stderr)
     }
 
     if ($process.ExitCode -ne 0) {
@@ -95,19 +106,19 @@ function New-SmokeInputs {
     param([Parameter(Mandatory = $true)][string]$TestDirectory)
 
     New-Item -ItemType Directory -Force -Path $TestDirectory | Out-Null
-    Set-Content -LiteralPath (Join-Path $TestDirectory 'cube.scad') -Value 'cube(10);'
-    Set-Content -LiteralPath (Join-Path $TestDirectory 'cube.py') -Value @'
+    Set-Utf8Content -Path (Join-Path $TestDirectory 'cube.scad') -Value 'cube(10);'
+    Set-Utf8Content -Path (Join-Path $TestDirectory 'cube.py') -Value @'
 from pythonscad import *
 
 cube(10).show()
 '@
-    Set-Content -LiteralPath (Join-Path $TestDirectory 'repl-smoke.py') -Value @'
+    Set-Utf8Content -Path (Join-Path $TestDirectory 'repl-smoke.py') -Value @'
 from pythonscad import *
 
 export(cube(10), "repl-cube.stl")
 raise SystemExit(0)
 '@
-    Set-Content -LiteralPath (Join-Path $TestDirectory 'ipython-smoke.py') -Value @'
+    Set-Utf8Content -Path (Join-Path $TestDirectory 'ipython-smoke.py') -Value @'
 from pythonscad import *
 
 export(cube(10), "ipython-cube.stl")

--- a/scripts/release-smoke/common-smoke.sh
+++ b/scripts/release-smoke/common-smoke.sh
@@ -85,15 +85,6 @@ rs_download_run_artifact() {
   gh run download "$run_id" --repo "$repo" --pattern "$pattern" --dir "$dest"
 }
 
-rs_download_run_artifacts() {
-  local repo=$1
-  local run_id=$2
-  local dest=$3
-
-  mkdir -p "$dest"
-  gh run download "$run_id" --repo "$repo" --dir "$dest"
-}
-
 rs_make_workdir() {
   local explicit_workdir=$1
   if [[ -n "$explicit_workdir" ]]; then
@@ -138,12 +129,6 @@ from pythonscad import *
 
 export(cube(10), "ipython-cube.stl")
 PY
-}
-
-rs_run_pythonscad() {
-  local exe=$1
-  shift
-  QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}" "$exe" "$@"
 }
 
 rs_run_logged() {

--- a/scripts/release-smoke/common-smoke.sh
+++ b/scripts/release-smoke/common-smoke.sh
@@ -33,7 +33,9 @@ rs_file_nonempty() {
 
 rs_print_log_excerpt() {
   local log_file=$1
-  if [[ -s "$log_file" ]]; then
+  if [[ ! -e "$log_file" ]]; then
+    printf -- '--- command output log was not created: %s ---\n' "$log_file" >&2
+  elif [[ -s "$log_file" ]]; then
     printf -- '--- begin command output: %s ---\n' "$log_file" >&2
     cat "$log_file" >&2
     printf -- '--- end command output: %s ---\n' "$log_file" >&2

--- a/scripts/release-smoke/common-smoke.sh
+++ b/scripts/release-smoke/common-smoke.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rs_log() {
+  printf '==> %s\n' "$*"
+}
+
+rs_warn() {
+  printf 'WARNING: %s\n' "$*" >&2
+}
+
+rs_die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+rs_require_command() {
+  local cmd=$1
+  command -v "$cmd" >/dev/null 2>&1 || rs_die "required command not found: $cmd"
+}
+
+rs_file_nonempty() {
+  local path=$1
+  local phase=${2:-output verification}
+  if [[ ! -e "$path" ]]; then
+    rs_die "smoke test failed: $phase; expected output file does not exist: $path"
+  fi
+  if [[ ! -s "$path" ]]; then
+    rs_die "smoke test failed: $phase; expected non-empty output file: $path"
+  fi
+}
+
+rs_print_log_excerpt() {
+  local log_file=$1
+  if [[ -s "$log_file" ]]; then
+    printf -- '--- begin command output: %s ---\n' "$log_file" >&2
+    cat "$log_file" >&2
+    printf -- '--- end command output: %s ---\n' "$log_file" >&2
+  else
+    printf -- '--- command output was empty: %s ---\n' "$log_file" >&2
+  fi
+}
+
+rs_print_command() {
+  printf '%q' "$1"
+  shift
+  while (($#)); do
+    printf ' %q' "$1"
+    shift
+  done
+  printf '\n'
+}
+
+rs_repo_default() {
+  gh repo view --json nameWithOwner --jq .nameWithOwner
+}
+
+rs_latest_successful_run() {
+  local repo=$1
+  local workflow=$2
+  local ref=${3:-}
+  local args=(run list --repo "$repo" --workflow "$workflow" --status success --limit 1
+    --json databaseId --jq '.[0].databaseId')
+  if [[ -n "$ref" ]]; then
+    args+=(--branch "$ref")
+  fi
+  gh "${args[@]}"
+}
+
+rs_download_run_artifact() {
+  local repo=$1
+  local run_id=$2
+  local pattern=$3
+  local dest=$4
+
+  mkdir -p "$dest"
+  gh run download "$run_id" --repo "$repo" --pattern "$pattern" --dir "$dest"
+}
+
+rs_download_run_artifacts() {
+  local repo=$1
+  local run_id=$2
+  local dest=$3
+
+  mkdir -p "$dest"
+  gh run download "$run_id" --repo "$repo" --dir "$dest"
+}
+
+rs_make_workdir() {
+  local explicit_workdir=$1
+  if [[ -n "$explicit_workdir" ]]; then
+    mkdir -p "$explicit_workdir"
+    printf '%s\n' "$explicit_workdir"
+  else
+    mktemp -d "${TMPDIR:-/tmp}/pythonscad-release-smoke.XXXXXX"
+  fi
+}
+
+rs_cleanup_workdir() {
+  local workdir=$1
+  local keep_workdir=$2
+  local status=${3:-0}
+  if [[ "$keep_workdir" == "1" ]]; then
+    rs_log "Keeping workdir: $workdir"
+  elif [[ "$status" != "0" ]]; then
+    rs_warn "A failure occurred; keeping workdir for logs: $workdir"
+  else
+    rm -rf "$workdir"
+  fi
+}
+
+rs_write_common_test_inputs() {
+  local testdir=$1
+
+  mkdir -p "$testdir"
+  printf 'cube(10);\n' > "$testdir/cube.scad"
+  cat > "$testdir/cube.py" <<'PY'
+from pythonscad import *
+
+cube(10).show()
+PY
+  cat > "$testdir/repl-smoke.py" <<'PY'
+from pythonscad import *
+
+export(cube(10), "repl-cube.stl")
+raise SystemExit(0)
+PY
+  cat > "$testdir/ipython-smoke.py" <<'PY'
+from pythonscad import *
+
+export(cube(10), "ipython-cube.stl")
+PY
+}
+
+rs_run_pythonscad() {
+  local exe=$1
+  shift
+  QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}" "$exe" "$@"
+}
+
+rs_run_logged() {
+  local phase=$1
+  local log_file=$2
+  shift 2
+
+  set +e
+  QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}" "$@" > "$log_file" 2>&1
+  local status=$?
+  set -e
+
+  if [[ "$status" != "0" ]]; then
+    {
+      printf 'ERROR: smoke test failed: %s\n' "$phase"
+      printf 'Exit code: %s\n' "$status"
+      printf 'Command: '
+      rs_print_command "$@"
+    } >&2
+    rs_print_log_excerpt "$log_file"
+    return "$status"
+  fi
+}
+
+rs_run_logged_in_dir() {
+  local phase=$1
+  local workdir=$2
+  local log_file=$3
+  local stdin_file=$4
+  shift 4
+
+  set +e
+  if [[ -n "$stdin_file" ]]; then
+    (
+      cd "$workdir" &&
+        QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}" "$@" < "$stdin_file"
+    ) > "$log_file" 2>&1
+  else
+    (
+      cd "$workdir" &&
+        QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}" "$@"
+    ) > "$log_file" 2>&1
+  fi
+  local status=$?
+  set -e
+
+  if [[ "$status" != "0" ]]; then
+    {
+      printf 'ERROR: smoke test failed: %s\n' "$phase"
+      printf 'Working directory: %s\n' "$workdir"
+      if [[ -n "$stdin_file" ]]; then
+        printf 'Stdin: %s\n' "$stdin_file"
+      fi
+      printf 'Exit code: %s\n' "$status"
+      printf 'Command: '
+      rs_print_command "$@"
+    } >&2
+    rs_print_log_excerpt "$log_file"
+    return "$status"
+  fi
+}
+
+rs_smoke_binary() {
+  local exe=$1
+  local label=$2
+  local workdir=$3
+
+  [[ -x "$exe" ]] || rs_die "executable is not runnable: $exe"
+
+  local testdir="$workdir/smoke-${label//[^A-Za-z0-9_.-]/_}"
+  rs_write_common_test_inputs "$testdir"
+
+  rs_log "Smoke testing $label: startup"
+  rs_run_logged "$label: startup" "$testdir/info.log" "$exe" --info
+
+  rs_log "Smoke testing $label: OpenSCAD .scad export"
+  rs_run_logged "$label: OpenSCAD .scad export" "$testdir/scad-export.log" \
+    "$exe" -o "$testdir/cube-scad.stl" "$testdir/cube.scad"
+  rs_file_nonempty "$testdir/cube-scad.stl" "$label: OpenSCAD .scad export"
+
+  rs_log "Smoke testing $label: Python CLI export"
+  rs_run_logged "$label: Python CLI export" "$testdir/python-export.log" \
+    "$exe" --trust-python -o "$testdir/cube-python.stl" "$testdir/cube.py"
+  rs_file_nonempty "$testdir/cube-python.stl" "$label: Python CLI export"
+
+  rs_log "Smoke testing $label: basic Python REPL"
+  rs_run_logged_in_dir "$label: basic Python REPL" "$testdir" "$testdir/repl.log" \
+    "$testdir/repl-smoke.py" "$exe" --repl
+  rs_file_nonempty "$testdir/repl-cube.stl" "$label: basic Python REPL"
+
+  rs_log "Smoke testing $label: IPython"
+  rs_run_logged_in_dir "$label: IPython" "$testdir" "$testdir/ipython.log" "" \
+    "$exe" --ipython ipython-smoke.py
+  rs_file_nonempty "$testdir/ipython-cube.stl" "$label: IPython"
+
+  rs_log "Smoke testing $label: OK"
+}

--- a/scripts/release-smoke/common-smoke.sh
+++ b/scripts/release-smoke/common-smoke.sh
@@ -63,6 +63,11 @@ rs_latest_successful_run() {
   local args=(run list --repo "$repo" --workflow "$workflow" --status success
     --json 'databaseId,headBranch')
   if [[ -n "$ref" ]]; then
+    case "$ref" in
+      *\"*|*\\*|*$'\n'*|*$'\r'*)
+        rs_die "--ref contains characters that cannot be used in GitHub Actions jq filters"
+        ;;
+    esac
     args+=(--limit 50 --jq "map(select(.headBranch == \"$ref\")) | .[0].databaseId // \"\"")
   else
     args+=(--limit 1 --jq '.[0].databaseId')

--- a/scripts/release-smoke/common-smoke.sh
+++ b/scripts/release-smoke/common-smoke.sh
@@ -60,10 +60,12 @@ rs_latest_successful_run() {
   local repo=$1
   local workflow=$2
   local ref=${3:-}
-  local args=(run list --repo "$repo" --workflow "$workflow" --status success --limit 1
-    --json databaseId --jq '.[0].databaseId')
+  local args=(run list --repo "$repo" --workflow "$workflow" --status success
+    --json 'databaseId,headBranch')
   if [[ -n "$ref" ]]; then
-    args+=(--branch "$ref")
+    args+=(--limit 50 --jq "map(select(.headBranch == \"$ref\")) | .[0].databaseId // \"\"")
+  else
+    args+=(--limit 1 --jq '.[0].databaseId')
   fi
   gh "${args[@]}"
 }

--- a/scripts/release-smoke/test-appimages.sh
+++ b/scripts/release-smoke/test-appimages.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=common-smoke.sh
+source "$SCRIPT_DIR/common-smoke.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: test-appimages.sh [options]
+
+Download and smoke test the latest x86_64 AppImage artifacts.
+
+Options:
+  --repo <owner/name>       GitHub repository to query. Defaults to current repo.
+  --ref <branch-or-tag>     Branch used for latest-run filtering.
+  --run-id <id>             Use a specific build-appimage.yml run.
+  --workdir <path>          Working directory. Defaults to a temp directory.
+  --keep-workdir            Keep temporary files after the run.
+  --skip-download           Use artifacts already present in the artifact dir.
+  --artifact-dir <path>     Directory containing downloaded AppImages.
+  --help                    Show this help.
+EOF
+}
+
+repo=""
+ref=""
+run_id=""
+workdir_arg=""
+keep_workdir=0
+skip_download=0
+artifact_dir=""
+
+while (($#)); do
+  case "$1" in
+    --repo)
+      repo=${2:-}
+      [[ -n "$repo" ]] || rs_die "--repo requires a value"
+      shift 2
+      ;;
+    --ref)
+      ref=${2:-}
+      [[ -n "$ref" ]] || rs_die "--ref requires a value"
+      shift 2
+      ;;
+    --run-id)
+      run_id=${2:-}
+      [[ -n "$run_id" ]] || rs_die "--run-id requires a value"
+      shift 2
+      ;;
+    --workdir)
+      workdir_arg=${2:-}
+      [[ -n "$workdir_arg" ]] || rs_die "--workdir requires a value"
+      shift 2
+      ;;
+    --keep-workdir)
+      keep_workdir=1
+      shift
+      ;;
+    --skip-download)
+      skip_download=1
+      shift
+      ;;
+    --artifact-dir)
+      artifact_dir=${2:-}
+      [[ -n "$artifact_dir" ]] || rs_die "--artifact-dir requires a value"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      rs_die "unknown option: $1"
+      ;;
+  esac
+done
+
+rs_require_command find
+
+workdir=$(rs_make_workdir "$workdir_arg")
+trap 'rs_cleanup_workdir "$workdir" "$keep_workdir" "$?"' EXIT
+
+if [[ -z "$artifact_dir" ]]; then
+  artifact_dir="$workdir/artifacts"
+fi
+
+if [[ "$skip_download" == "0" ]]; then
+  rs_require_command gh
+  if [[ -z "$repo" ]]; then
+    repo=$(rs_repo_default)
+  fi
+
+  if [[ -z "$run_id" ]]; then
+    run_id=$(rs_latest_successful_run "$repo" build-appimage.yml "$ref")
+    [[ -n "$run_id" && "$run_id" != "null" ]] || rs_die "no successful build-appimage.yml run found"
+  fi
+  rs_log "Downloading AppImage artifacts from run $run_id"
+  rs_download_run_artifact "$repo" "$run_id" 'pythonscad-qt*-x86_64-appimage' "$artifact_dir"
+else
+  rs_log "Using existing AppImage artifacts in $artifact_dir"
+fi
+
+appimages=()
+while IFS= read -r -d '' appimage; do
+  appimages+=("$appimage")
+done < <(find "$artifact_dir" -type f -name '*.AppImage' ! -name '*aarch64*' ! -name '*arm64*' -print0)
+
+((${#appimages[@]} > 0)) || rs_die "no x86_64 AppImages found in $artifact_dir"
+
+export APPIMAGE_EXTRACT_AND_RUN="${APPIMAGE_EXTRACT_AND_RUN:-1}"
+
+for appimage in "${appimages[@]}"; do
+  chmod +x "$appimage"
+  rs_smoke_binary "$appimage" "$(basename "$appimage")" "$workdir"
+done
+
+rs_log "All AppImage smoke tests passed"

--- a/scripts/release-smoke/test-linux-packages.sh
+++ b/scripts/release-smoke/test-linux-packages.sh
@@ -291,9 +291,9 @@ run_rpm_package_test() {
     bash -c '
       set -euo pipefail
       if command -v dnf >/dev/null 2>&1; then
-        dnf install -y /tmp/pythonscad-package.rpm
+        dnf install -y --nogpgcheck /tmp/pythonscad-package.rpm
       else
-        yum install -y /tmp/pythonscad-package.rpm
+        yum install -y --nogpgcheck /tmp/pythonscad-package.rpm
       fi
       QT_QPA_PLATFORM=xcb xvfb-run -a bash -c '"'"'
         source /release-smoke/common-smoke.sh

--- a/scripts/release-smoke/test-linux-packages.sh
+++ b/scripts/release-smoke/test-linux-packages.sh
@@ -97,12 +97,7 @@ rs_require_command find
 rs_require_command python3
 rs_require_command realpath
 
-if [[ -n "$workdir_arg" ]]; then
-  workdir=$(rs_make_workdir "$workdir_arg")
-else
-  mkdir -p "$PROJECT_ROOT/build"
-  workdir=$(mktemp -d "$PROJECT_ROOT/build/pythonscad-release-smoke.XXXXXX")
-fi
+workdir=$(rs_make_workdir "$workdir_arg")
 trap 'rs_cleanup_workdir "$workdir" "$keep_workdir" "$?"' EXIT
 
 if [[ -z "$artifact_dir" ]]; then

--- a/scripts/release-smoke/test-linux-packages.sh
+++ b/scripts/release-smoke/test-linux-packages.sh
@@ -261,6 +261,7 @@ run_deb_package_test() {
     "$image" \
     bash -c '
       set -euo pipefail
+      apt-get update
       cd /tmp
       apt-get install -y ./pythonscad-package.deb
       QT_QPA_PLATFORM=xcb xvfb-run -a bash -c '"'"'

--- a/scripts/release-smoke/test-linux-packages.sh
+++ b/scripts/release-smoke/test-linux-packages.sh
@@ -248,6 +248,7 @@ DOCKERFILE
 run_deb_package_test() {
   local package=$1
   local base_image=$2
+  local smoke_dir=$3
   local image
   local package_file
   image=$(ensure_deb_smoke_image "$base_image")
@@ -255,6 +256,7 @@ run_deb_package_test() {
 
   docker run --rm \
     -v "$package:/tmp/pythonscad-package.deb:ro" \
+    -v "$smoke_dir:/tmp/pythonscad-smoke" \
     -v "$SCRIPT_DIR:/release-smoke:ro" \
     -e DEBIAN_FRONTEND=noninteractive \
     -e PACKAGE_FILE="$package_file" \
@@ -274,6 +276,7 @@ run_deb_package_test() {
 run_rpm_package_test() {
   local package=$1
   local base_image=$2
+  local smoke_dir=$3
   local image
   local package_file
   image=$(ensure_rpm_smoke_image "$base_image")
@@ -281,6 +284,7 @@ run_rpm_package_test() {
 
   docker run --rm \
     -v "$package:/tmp/pythonscad-package.rpm:ro" \
+    -v "$smoke_dir:/tmp/pythonscad-smoke" \
     -v "$SCRIPT_DIR:/release-smoke:ro" \
     -e PACKAGE_FILE="$package_file" \
     "$image" \
@@ -301,14 +305,16 @@ run_rpm_package_test() {
 for package in "${packages[@]}"; do
   package=$(realpath "$package")
   image=$(package_container_image "$package")
+  smoke_dir="$workdir/package-smoke-$(basename "$package")"
+  mkdir -p "$smoke_dir"
 
   rs_log "Smoke testing $(basename "$package") in $image"
   case "$package" in
     *.deb)
-      run_deb_package_test "$package" "$image"
+      run_deb_package_test "$package" "$image" "$smoke_dir"
       ;;
     *.rpm)
-      run_rpm_package_test "$package" "$image"
+      run_rpm_package_test "$package" "$image" "$smoke_dir"
       ;;
     *)
       rs_die "unsupported package type: $package"

--- a/scripts/release-smoke/test-linux-packages.sh
+++ b/scripts/release-smoke/test-linux-packages.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd)
+# shellcheck source=common-smoke.sh
+source "$SCRIPT_DIR/common-smoke.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: test-linux-packages.sh [options]
+
+Download and smoke test x86_64/amd64 .deb and .rpm package artifacts in Docker.
+
+Options:
+  --repo <owner/name>       GitHub repository to query. Defaults to current repo.
+  --ref <branch-or-tag>     Branch used for latest-run filtering.
+  --run-id <id>             Use the same workflow run id for both package types.
+  --deb-run-id <id>         Use a specific build-debian-packages.yml run.
+  --rpm-run-id <id>         Use a specific build-rpm-packages.yml run.
+  --workdir <path>          Working directory. Defaults to a temp directory.
+  --keep-workdir            Keep temporary files after the run.
+  --skip-download           Use artifacts already present in the artifact dir.
+  --artifact-dir <path>     Directory containing downloaded .deb/.rpm files.
+  --help                    Show this help.
+EOF
+}
+
+repo=""
+ref=""
+deb_run_id=""
+rpm_run_id=""
+workdir_arg=""
+keep_workdir=0
+skip_download=0
+artifact_dir=""
+
+while (($#)); do
+  case "$1" in
+    --repo)
+      repo=${2:-}
+      [[ -n "$repo" ]] || rs_die "--repo requires a value"
+      shift 2
+      ;;
+    --ref)
+      ref=${2:-}
+      [[ -n "$ref" ]] || rs_die "--ref requires a value"
+      shift 2
+      ;;
+    --run-id)
+      deb_run_id=${2:-}
+      rpm_run_id=${2:-}
+      [[ -n "$deb_run_id" ]] || rs_die "--run-id requires a value"
+      shift 2
+      ;;
+    --deb-run-id)
+      deb_run_id=${2:-}
+      [[ -n "$deb_run_id" ]] || rs_die "--deb-run-id requires a value"
+      shift 2
+      ;;
+    --rpm-run-id)
+      rpm_run_id=${2:-}
+      [[ -n "$rpm_run_id" ]] || rs_die "--rpm-run-id requires a value"
+      shift 2
+      ;;
+    --workdir)
+      workdir_arg=${2:-}
+      [[ -n "$workdir_arg" ]] || rs_die "--workdir requires a value"
+      shift 2
+      ;;
+    --keep-workdir)
+      keep_workdir=1
+      shift
+      ;;
+    --skip-download)
+      skip_download=1
+      shift
+      ;;
+    --artifact-dir)
+      artifact_dir=${2:-}
+      [[ -n "$artifact_dir" ]] || rs_die "--artifact-dir requires a value"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      rs_die "unknown option: $1"
+      ;;
+  esac
+done
+
+rs_require_command docker
+rs_require_command find
+rs_require_command python3
+rs_require_command realpath
+
+if [[ -n "$workdir_arg" ]]; then
+  workdir=$(rs_make_workdir "$workdir_arg")
+else
+  mkdir -p "$PROJECT_ROOT/build"
+  workdir=$(mktemp -d "$PROJECT_ROOT/build/pythonscad-release-smoke.XXXXXX")
+fi
+trap 'rs_cleanup_workdir "$workdir" "$keep_workdir" "$?"' EXIT
+
+if [[ -z "$artifact_dir" ]]; then
+  artifact_dir="$workdir/artifacts"
+fi
+
+if [[ "$skip_download" == "0" ]]; then
+  rs_require_command gh
+  if [[ -z "$repo" ]]; then
+    repo=$(rs_repo_default)
+  fi
+
+  if [[ -z "$deb_run_id" ]]; then
+    deb_run_id=$(rs_latest_successful_run "$repo" build-debian-packages.yml "$ref")
+    [[ -n "$deb_run_id" && "$deb_run_id" != "null" ]] || rs_die "no successful build-debian-packages.yml run found"
+  fi
+  if [[ -z "$rpm_run_id" ]]; then
+    rpm_run_id=$(rs_latest_successful_run "$repo" build-rpm-packages.yml "$ref")
+    [[ -n "$rpm_run_id" && "$rpm_run_id" != "null" ]] || rs_die "no successful build-rpm-packages.yml run found"
+  fi
+
+  rs_log "Downloading Debian package artifacts from run $deb_run_id"
+  rs_download_run_artifact "$repo" "$deb_run_id" 'pythonscad-*-deb' "$artifact_dir/deb"
+  rs_log "Downloading RPM package artifacts from run $rpm_run_id"
+  rs_download_run_artifact "$repo" "$rpm_run_id" 'pythonscad-*-rpm' "$artifact_dir/rpm"
+else
+  rs_log "Using existing Linux package artifacts in $artifact_dir"
+fi
+
+packages=()
+while IFS= read -r -d '' package; do
+  packages+=("$package")
+done < <(find "$artifact_dir" -type f \( -name '*.deb' -o -name '*.rpm' \) \
+  ! -name '*arm64*' ! -name '*aarch64*' -print0)
+
+((${#packages[@]} > 0)) || rs_die "no x86_64/amd64 Linux packages found in $artifact_dir"
+
+package_container_image() {
+  local package=$1
+  python3 - "$PROJECT_ROOT/supported-distributions.json" "$(basename "$package")" <<'PY'
+import json
+import re
+import sys
+
+config_path, package_name = sys.argv[1], sys.argv[2]
+with open(config_path, encoding="utf-8") as handle:
+    config = json.load(handle)
+
+target_family = None
+target_codename = None
+target_version = None
+
+deb_match = re.match(r"pythonscad_.+_([^_]+)_amd64\.deb$", package_name)
+if deb_match:
+    target_codename = deb_match.group(1)
+else:
+    rpm_match = re.search(r"\.(fc|el)([0-9]+)\.(x86_64|amd64)\.rpm$", package_name)
+    if rpm_match:
+        target_family = "fedora" if rpm_match.group(1) == "fc" else "el"
+        target_version = rpm_match.group(2)
+
+for dist in config["distributions"]:
+    if "amd64" not in dist.get("architectures", []):
+        continue
+    if target_codename and dist["codename"] == target_codename:
+        print(dist["docker_image"])
+        sys.exit(0)
+    if target_family and dist["family"] == target_family and dist["version"] == target_version:
+        print(dist["docker_image"])
+        sys.exit(0)
+
+raise SystemExit(f"no docker image mapping for {package_name}")
+PY
+}
+
+smoke_image_tag() {
+  local package_type=$1
+  local base_image=$2
+  python3 - "$package_type" "$base_image" <<'PY'
+import hashlib
+import re
+import sys
+
+package_type, base_image = sys.argv[1], sys.argv[2]
+digest = hashlib.sha256(base_image.encode("utf-8")).hexdigest()[:16]
+package_type = re.sub(r"[^a-z0-9_.-]", "-", package_type.lower())
+print(f"pythonscad-release-smoke-{package_type}:{digest}")
+PY
+}
+
+ensure_deb_smoke_image() {
+  local base_image=$1
+  local smoke_image
+  smoke_image=$(smoke_image_tag deb "$base_image")
+
+  if docker image inspect "$smoke_image" >/dev/null 2>&1; then
+    rs_log "Using cached Debian smoke image $smoke_image" >&2
+  else
+    rs_log "Building Debian smoke image $smoke_image" >&2
+    docker build --build-arg BASE_IMAGE="$base_image" -t "$smoke_image" - <<'DOCKERFILE'
+ARG BASE_IMAGE=debian:stable-slim
+FROM ${BASE_IMAGE}
+ENV DEBIAN_FRONTEND=noninteractive
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends ca-certificates libgl1-mesa-dri python3-ipython xauth xvfb
+DOCKERFILE
+  fi
+
+  printf '%s\n' "$smoke_image"
+}
+
+ensure_rpm_smoke_image() {
+  local base_image=$1
+  local smoke_image
+  smoke_image=$(smoke_image_tag rpm "$base_image")
+
+  if docker image inspect "$smoke_image" >/dev/null 2>&1; then
+    rs_log "Using cached RPM smoke image $smoke_image" >&2
+  else
+    rs_log "Building RPM smoke image $smoke_image" >&2
+    docker build --build-arg BASE_IMAGE="$base_image" -t "$smoke_image" - <<'DOCKERFILE'
+ARG BASE_IMAGE=fedora:latest
+FROM ${BASE_IMAGE}
+RUN set -eux; \
+  if command -v dnf >/dev/null 2>&1; then \
+    if [ -f /etc/redhat-release ] && ! [ -f /etc/fedora-release ]; then \
+      dnf install -y epel-release dnf-plugins-core || true; \
+      dnf config-manager --set-enabled crb || true; \
+    fi; \
+    dnf install -y mesa-dri-drivers python3-ipython xauth xorg-x11-server-Xvfb; \
+    dnf clean all; \
+  else \
+    yum install -y mesa-dri-drivers python3-ipython xauth xorg-x11-server-Xvfb; \
+    yum clean all; \
+  fi
+DOCKERFILE
+  fi
+
+  printf '%s\n' "$smoke_image"
+}
+
+run_deb_package_test() {
+  local package=$1
+  local base_image=$2
+  local image
+  local package_file
+  image=$(ensure_deb_smoke_image "$base_image")
+  package_file=$(basename "$package")
+
+  docker run --rm \
+    -v "$package:/tmp/pythonscad-package.deb:ro" \
+    -v "$SCRIPT_DIR:/release-smoke:ro" \
+    -e DEBIAN_FRONTEND=noninteractive \
+    -e PACKAGE_FILE="$package_file" \
+    "$image" \
+    bash -c '
+      set -euo pipefail
+      cd /tmp
+      apt-get install -y ./pythonscad-package.deb
+      QT_QPA_PLATFORM=xcb xvfb-run -a bash -c '"'"'
+        source /release-smoke/common-smoke.sh
+        rs_smoke_binary /usr/bin/pythonscad "$PACKAGE_FILE" /tmp/pythonscad-smoke
+      '"'"'
+    '
+}
+
+run_rpm_package_test() {
+  local package=$1
+  local base_image=$2
+  local image
+  local package_file
+  image=$(ensure_rpm_smoke_image "$base_image")
+  package_file=$(basename "$package")
+
+  docker run --rm \
+    -v "$package:/tmp/pythonscad-package.rpm:ro" \
+    -v "$SCRIPT_DIR:/release-smoke:ro" \
+    -e PACKAGE_FILE="$package_file" \
+    "$image" \
+    bash -c '
+      set -euo pipefail
+      if command -v dnf >/dev/null 2>&1; then
+        dnf install -y /tmp/pythonscad-package.rpm
+      else
+        yum install -y /tmp/pythonscad-package.rpm
+      fi
+      QT_QPA_PLATFORM=xcb xvfb-run -a bash -c '"'"'
+        source /release-smoke/common-smoke.sh
+        rs_smoke_binary /usr/bin/pythonscad "$PACKAGE_FILE" /tmp/pythonscad-smoke
+      '"'"'
+    '
+}
+
+for package in "${packages[@]}"; do
+  package=$(realpath "$package")
+  image=$(package_container_image "$package")
+
+  rs_log "Smoke testing $(basename "$package") in $image"
+  case "$package" in
+    *.deb)
+      run_deb_package_test "$package" "$image"
+      ;;
+    *.rpm)
+      run_rpm_package_test "$package" "$image"
+      ;;
+    *)
+      rs_die "unsupported package type: $package"
+      ;;
+  esac
+done
+
+rs_log "All Linux package smoke tests passed"

--- a/scripts/release-smoke/test-macos.sh
+++ b/scripts/release-smoke/test-macos.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=common-smoke.sh
+source "$SCRIPT_DIR/common-smoke.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: test-macos.sh [options]
+
+Download, mount, and smoke test the latest macOS DMG artifact.
+
+Options:
+  --repo <owner/name>       GitHub repository to query. Defaults to current repo.
+  --ref <branch-or-tag>     Branch used for latest-run filtering.
+  --run-id <id>             Use a specific build-macos-release.yml run.
+  --workdir <path>          Working directory. Defaults to a temp directory.
+  --keep-workdir            Keep temporary files after the run.
+  --skip-download           Use artifacts already present in the artifact dir.
+  --artifact-dir <path>     Directory containing a downloaded DMG.
+  --help                    Show this help.
+EOF
+}
+
+repo=""
+ref=""
+run_id=""
+workdir_arg=""
+keep_workdir=0
+skip_download=0
+artifact_dir=""
+mountpoint=""
+
+while (($#)); do
+  case "$1" in
+    --repo)
+      repo=${2:-}
+      [[ -n "$repo" ]] || rs_die "--repo requires a value"
+      shift 2
+      ;;
+    --ref)
+      ref=${2:-}
+      [[ -n "$ref" ]] || rs_die "--ref requires a value"
+      shift 2
+      ;;
+    --run-id)
+      run_id=${2:-}
+      [[ -n "$run_id" ]] || rs_die "--run-id requires a value"
+      shift 2
+      ;;
+    --workdir)
+      workdir_arg=${2:-}
+      [[ -n "$workdir_arg" ]] || rs_die "--workdir requires a value"
+      shift 2
+      ;;
+    --keep-workdir)
+      keep_workdir=1
+      shift
+      ;;
+    --skip-download)
+      skip_download=1
+      shift
+      ;;
+    --artifact-dir)
+      artifact_dir=${2:-}
+      [[ -n "$artifact_dir" ]] || rs_die "--artifact-dir requires a value"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      rs_die "unknown option: $1"
+      ;;
+  esac
+done
+
+rs_require_command find
+rs_require_command hdiutil
+
+workdir=$(rs_make_workdir "$workdir_arg")
+cleanup() {
+  local status=$?
+  if [[ -n "$mountpoint" && -d "$mountpoint" ]]; then
+    hdiutil detach "$mountpoint" >/dev/null 2>&1 || true
+  fi
+  rs_cleanup_workdir "$workdir" "$keep_workdir" "$status"
+  return "$status"
+}
+trap cleanup EXIT
+
+if [[ -z "$artifact_dir" ]]; then
+  artifact_dir="$workdir/artifacts"
+fi
+
+if [[ "$skip_download" == "0" ]]; then
+  rs_require_command gh
+  if [[ -z "$repo" ]]; then
+    repo=$(rs_repo_default)
+  fi
+
+  if [[ -z "$run_id" ]]; then
+    run_id=$(rs_latest_successful_run "$repo" build-macos-release.yml "$ref")
+    [[ -n "$run_id" && "$run_id" != "null" ]] || rs_die "no successful build-macos-release.yml run found"
+  fi
+  rs_log "Downloading macOS DMG artifact from run $run_id"
+  rs_download_run_artifact "$repo" "$run_id" 'PythonSCAD-*' "$artifact_dir"
+else
+  rs_log "Using existing macOS artifacts in $artifact_dir"
+fi
+
+dmgs=()
+while IFS= read -r -d '' dmg; do
+  dmgs+=("$dmg")
+done < <(find "$artifact_dir" -type f -name '*.dmg' -print0)
+
+((${#dmgs[@]} > 0)) || rs_die "no DMG found in $artifact_dir"
+((${#dmgs[@]} == 1)) || rs_die "expected exactly one DMG in $artifact_dir; found ${#dmgs[@]}"
+
+mountpoint="$workdir/dmg-mount"
+mkdir -p "$mountpoint"
+rs_log "Mounting $(basename "${dmgs[0]}")"
+hdiutil attach "${dmgs[0]}" -readonly -nobrowse -mountpoint "$mountpoint" >/dev/null
+
+apps=()
+while IFS= read -r -d '' app; do
+  apps+=("$app")
+done < <(find "$mountpoint" -maxdepth 1 -name '*.app' -type d -print0)
+
+((${#apps[@]} > 0)) || rs_die "no .app bundle found in mounted DMG"
+((${#apps[@]} == 1)) || rs_die "expected exactly one .app bundle in DMG; found ${#apps[@]}"
+
+app=${apps[0]}
+app_name=$(basename "$app" .app)
+exe=""
+if [[ -x "$app/Contents/MacOS/$app_name" ]]; then
+  exe="$app/Contents/MacOS/$app_name"
+elif [[ -x "$app/Contents/MacOS/pythonscad" ]]; then
+  exe="$app/Contents/MacOS/pythonscad"
+else
+  for candidate in "$app"/Contents/MacOS/*; do
+    if [[ -f "$candidate" && -x "$candidate" && "$candidate" != *-python ]]; then
+      exe=$candidate
+      break
+    fi
+  done
+fi
+
+[[ -n "$exe" ]] || rs_die "could not locate PythonSCAD executable inside $app"
+rs_smoke_binary "$exe" "$(basename "$app")" "$workdir"
+
+rs_log "macOS DMG smoke tests passed"

--- a/scripts/release-smoke/test-macos.sh
+++ b/scripts/release-smoke/test-macos.sh
@@ -125,10 +125,14 @@ mkdir -p "$mountpoint"
 rs_log "Mounting $(basename "${dmgs[0]}")"
 hdiutil attach "${dmgs[0]}" -readonly -nobrowse -mountpoint "$mountpoint" >/dev/null
 
+shopt -s nullglob
+app_candidates=("$mountpoint"/*.app)
+shopt -u nullglob
+
 apps=()
-while IFS= read -r -d '' app; do
-  apps+=("$app")
-done < <(find "$mountpoint" -maxdepth 1 -name '*.app' -type d -print0)
+for app in "${app_candidates[@]}"; do
+  [[ -d "$app" ]] && apps+=("$app")
+done
 
 ((${#apps[@]} > 0)) || rs_die "no .app bundle found in mounted DMG"
 ((${#apps[@]} == 1)) || rs_die "expected exactly one .app bundle in DMG; found ${#apps[@]}"

--- a/scripts/release-smoke/test-windows.ps1
+++ b/scripts/release-smoke/test-windows.ps1
@@ -58,7 +58,7 @@ function Get-LatestSuccessfulRun {
     $runId
 }
 
-function Parse-Options {
+function Get-SmokeOption {
     param([string[]]$Arguments)
 
     $options = [ordered]@{
@@ -144,7 +144,7 @@ function Find-PythonSCADExecutable {
     throw "Could not locate pythonscad executable under $Root"
 }
 
-function Split-CommandArguments {
+function Split-CommandArgument {
     param([string]$Arguments)
 
     if (-not $Arguments) {
@@ -162,7 +162,7 @@ function Split-CommandArguments {
     return $tokens
 }
 
-function Invoke-ExistingPythonSCADUninstallers {
+function Invoke-ExistingPythonSCADUninstaller {
     $registryRoots = @(
         'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
         'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
@@ -182,7 +182,7 @@ function Invoke-ExistingPythonSCADUninstallers {
             if ($uninstall -match '^\s*"(?<exe>[^"]+)"\s*(?<args>.*)$' -or
                 $uninstall -match '^\s*(?<exe>\S+?\.exe)\s*(?<args>.*)$') {
                 $exe = $Matches.exe
-                $argumentList = Split-CommandArguments -Arguments $Matches.args
+                $argumentList = Split-CommandArgument -Arguments $Matches.args
                 $argumentList += '/S'
                 Start-Process -FilePath $exe -ArgumentList $argumentList -Wait
             } else {
@@ -192,7 +192,7 @@ function Invoke-ExistingPythonSCADUninstallers {
     }
 }
 
-$options = Parse-Options -Arguments $args
+$options = Get-SmokeOption -Arguments $args
 if ($options.Help) {
     Show-Usage
     exit 0
@@ -241,7 +241,7 @@ try {
     Write-SmokeLog "Extracting ZIP $($zip.Name)"
     Expand-Archive -LiteralPath $zip.FullName -DestinationPath $zipExtractDir -Force
     $zipExecutable = Find-PythonSCADExecutable -Root $zipExtractDir
-    Invoke-SmokeTests -ExecutablePath $zipExecutable -Label "ZIP $($zip.Name)" -Workdir $workdir
+    Invoke-SmokeTest -ExecutablePath $zipExecutable -Label "ZIP $($zip.Name)" -Workdir $workdir
 
     if ($options.SkipNsisInstall) {
         Write-SmokeLog 'Skipping NSIS installer smoke test'
@@ -253,7 +253,7 @@ try {
         }
 
         if (-not $options.SkipUninstallExisting) {
-            Invoke-ExistingPythonSCADUninstallers
+            Invoke-ExistingPythonSCADUninstaller
         }
 
         $installDir = Join-Path $workdir 'nsis-install'
@@ -263,8 +263,11 @@ try {
         New-Item -ItemType Directory -Force -Path $installDir | Out-Null
         Write-SmokeLog "Installing NSIS package $($installer.Name)"
         & $installer.FullName /S "/D=$installDir"
+        if ($LASTEXITCODE -ne 0) {
+            throw "NSIS installer failed with exit code $LASTEXITCODE"
+        }
         $nsisExecutable = Find-PythonSCADExecutable -Root $installDir
-        Invoke-SmokeTests -ExecutablePath $nsisExecutable -Label "NSIS $($installer.Name)" -Workdir $workdir
+        Invoke-SmokeTest -ExecutablePath $nsisExecutable -Label "NSIS $($installer.Name)" -Workdir $workdir
     }
 
     Write-SmokeLog 'Windows smoke tests passed'

--- a/scripts/release-smoke/test-windows.ps1
+++ b/scripts/release-smoke/test-windows.ps1
@@ -140,6 +140,24 @@ function Find-PythonSCADExecutable {
     throw "Could not locate pythonscad executable under $Root"
 }
 
+function Split-CommandArguments {
+    param([string]$Arguments)
+
+    if (-not $Arguments) {
+        return @()
+    }
+
+    $tokens = @()
+    foreach ($match in [regex]::Matches($Arguments, '(?:"([^"]*)"|(\S+))')) {
+        if ($match.Groups[1].Success) {
+            $tokens += $match.Groups[1].Value
+        } else {
+            $tokens += $match.Groups[2].Value
+        }
+    }
+    return $tokens
+}
+
 function Invoke-ExistingPythonSCADUninstallers {
     $registryRoots = @(
         'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
@@ -156,14 +174,11 @@ function Invoke-ExistingPythonSCADUninstallers {
             Where-Object { $_.DisplayName -like '*PythonSCAD*' -and $_.UninstallString }
         foreach ($entry in $entries) {
             Write-SmokeLog "Uninstalling existing $($entry.DisplayName)"
-            $uninstall = $entry.UninstallString.Trim('"')
-            if ($uninstall -match '^(?<exe>.*?\.exe)(?<args>.*)$') {
-                $exe = $Matches.exe.Trim('"')
-                $extraArgs = $Matches.args.Trim()
-                $argumentList = @()
-                if ($extraArgs) {
-                    $argumentList += $extraArgs
-                }
+            $uninstall = $entry.UninstallString.Trim()
+            if ($uninstall -match '^\s*"(?<exe>[^"]+)"\s*(?<args>.*)$' -or
+                $uninstall -match '^\s*(?<exe>\S+?\.exe)\s*(?<args>.*)$') {
+                $exe = $Matches.exe
+                $argumentList = Split-CommandArguments -Arguments $Matches.args
                 $argumentList += '/S'
                 Start-Process -FilePath $exe -ArgumentList $argumentList -Wait
             } else {

--- a/scripts/release-smoke/test-windows.ps1
+++ b/scripts/release-smoke/test-windows.ps1
@@ -43,6 +43,9 @@ function Get-LatestSuccessfulRun {
         '--json', 'databaseId,headBranch'
     )
     if ($Ref) {
+        if ($Ref -match '["\\\r\n]') {
+            throw '--ref contains characters that cannot be used in GitHub Actions jq filters'
+        }
         $jq = 'map(select(.headBranch == "' + $Ref + '")) | .[0].databaseId // ""'
         $ghArgs += @('--limit', '50', '--jq', $jq)
     } else {

--- a/scripts/release-smoke/test-windows.ps1
+++ b/scripts/release-smoke/test-windows.ps1
@@ -1,0 +1,258 @@
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $ScriptDir 'common-smoke.ps1')
+
+function Show-Usage {
+    @'
+Usage: powershell -ExecutionPolicy Bypass -File test-windows.ps1 [options]
+
+Download and smoke test Windows ZIP and NSIS installer artifacts.
+MSIX artifacts are intentionally ignored for now.
+
+Options:
+  --repo <owner/name>          GitHub repository to query. Defaults to current repo.
+  --ref <branch-or-tag>        Branch used for latest-run filtering.
+  --run-id <id>                Use a specific build-windows-native.yml run.
+  --workdir <path>             Working directory. Defaults to a temp directory.
+  --keep-workdir               Keep temporary files after the run.
+  --skip-download              Use artifacts already present in the artifact dir.
+  --artifact-dir <path>        Directory containing ZIP/NSIS deployables.
+  --skip-nsis-install          Skip uninstall/install testing of the NSIS installer.
+  --skip-uninstall-existing    Do not uninstall an existing PythonSCAD first.
+  --help                       Show this help.
+'@
+}
+
+function Get-DefaultRepo {
+    (& gh repo view --json nameWithOwner --jq .nameWithOwner).Trim()
+}
+
+function Get-LatestSuccessfulRun {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repo,
+        [Parameter(Mandatory = $true)][string]$Workflow,
+        [string]$Ref
+    )
+
+    $ghArgs = @(
+        'run', 'list',
+        '--repo', $Repo,
+        '--workflow', $Workflow,
+        '--status', 'success',
+        '--limit', '1',
+        '--json', 'databaseId',
+        '--jq', '.[0].databaseId'
+    )
+    if ($Ref) {
+        $ghArgs += @('--branch', $Ref)
+    }
+    $runId = (& gh @ghArgs).Trim()
+    if (-not $runId -or $runId -eq 'null') {
+        throw "No successful $Workflow run found"
+    }
+    $runId
+}
+
+function Parse-Options {
+    param([string[]]$Arguments)
+
+    $options = [ordered]@{
+        Repo = ''
+        Ref = ''
+        RunId = ''
+        Workdir = ''
+        KeepWorkdir = $false
+        SkipDownload = $false
+        ArtifactDir = ''
+        SkipNsisInstall = $false
+        SkipUninstallExisting = $false
+        Help = $false
+    }
+
+    for ($i = 0; $i -lt $Arguments.Count; $i++) {
+        $arg = $Arguments[$i]
+        switch ($arg) {
+            '--repo' {
+                $i++
+                if ($i -ge $Arguments.Count) { throw '--repo requires a value' }
+                $options.Repo = $Arguments[$i]
+            }
+            '--ref' {
+                $i++
+                if ($i -ge $Arguments.Count) { throw '--ref requires a value' }
+                $options.Ref = $Arguments[$i]
+            }
+            '--run-id' {
+                $i++
+                if ($i -ge $Arguments.Count) { throw '--run-id requires a value' }
+                $options.RunId = $Arguments[$i]
+            }
+            '--workdir' {
+                $i++
+                if ($i -ge $Arguments.Count) { throw '--workdir requires a value' }
+                $options.Workdir = $Arguments[$i]
+            }
+            '--keep-workdir' {
+                $options.KeepWorkdir = $true
+            }
+            '--skip-download' {
+                $options.SkipDownload = $true
+            }
+            '--artifact-dir' {
+                $i++
+                if ($i -ge $Arguments.Count) { throw '--artifact-dir requires a value' }
+                $options.ArtifactDir = $Arguments[$i]
+            }
+            '--skip-nsis-install' {
+                $options.SkipNsisInstall = $true
+            }
+            '--skip-uninstall-existing' {
+                $options.SkipUninstallExisting = $true
+            }
+            { $_ -in @('--help', '-h') } {
+                $options.Help = $true
+            }
+            default {
+                throw "Unknown option: $arg"
+            }
+        }
+    }
+
+    [pscustomobject]$options
+}
+
+function Find-PythonSCADExecutable {
+    param([Parameter(Mandatory = $true)][string]$Root)
+
+    $consoleExe = Get-ChildItem -LiteralPath $Root -Recurse -File -Filter 'pythonscad.com' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($consoleExe) {
+        return $consoleExe.FullName
+    }
+
+    $guiExe = Get-ChildItem -LiteralPath $Root -Recurse -File -Filter 'pythonscad.exe' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($guiExe) {
+        return $guiExe.FullName
+    }
+
+    throw "Could not locate pythonscad executable under $Root"
+}
+
+function Invoke-ExistingPythonSCADUninstallers {
+    $registryRoots = @(
+        'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+    )
+
+    foreach ($root in $registryRoots) {
+        if (-not (Test-Path -LiteralPath $root)) {
+            continue
+        }
+        $entries = Get-ChildItem -LiteralPath $root |
+            Get-ItemProperty |
+            Where-Object { $_.DisplayName -like '*PythonSCAD*' -and $_.UninstallString }
+        foreach ($entry in $entries) {
+            Write-SmokeLog "Uninstalling existing $($entry.DisplayName)"
+            $uninstall = $entry.UninstallString.Trim('"')
+            if ($uninstall -match '^(?<exe>.*?\.exe)(?<args>.*)$') {
+                $exe = $Matches.exe.Trim('"')
+                $extraArgs = $Matches.args.Trim()
+                $argumentList = @()
+                if ($extraArgs) {
+                    $argumentList += $extraArgs
+                }
+                $argumentList += '/S'
+                Start-Process -FilePath $exe -ArgumentList $argumentList -Wait
+            } else {
+                Write-SmokeWarning "Could not parse uninstall command: $uninstall"
+            }
+        }
+    }
+}
+
+$options = Parse-Options -Arguments $args
+if ($options.Help) {
+    Show-Usage
+    exit 0
+}
+
+$workdir = $options.Workdir
+if (-not $workdir) {
+    $workdir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+}
+New-Item -ItemType Directory -Force -Path $workdir | Out-Null
+
+$scriptFailed = $false
+try {
+    $artifactDir = $options.ArtifactDir
+    if (-not $artifactDir) {
+        $artifactDir = Join-Path $workdir 'artifacts'
+    }
+    New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
+
+    if (-not $options.SkipDownload) {
+        Assert-Command -Name gh
+        $repo = $options.Repo
+        if (-not $repo) {
+            $repo = Get-DefaultRepo
+        }
+
+        $runId = $options.RunId
+        if (-not $runId) {
+            $runId = Get-LatestSuccessfulRun -Repo $repo -Workflow 'build-windows-native.yml' -Ref $options.Ref
+        }
+        Write-SmokeLog "Downloading Windows artifacts from run $runId"
+        & gh run download $runId --repo $repo --dir $artifactDir
+    } else {
+        Write-SmokeLog "Using existing Windows artifacts in $artifactDir"
+    }
+
+    $zip = Get-ChildItem -LiteralPath $artifactDir -Recurse -File -Filter '*.zip' |
+        Where-Object { $_.Name -notlike '*Installer*' } |
+        Select-Object -First 1
+    if (-not $zip) {
+        throw "No ZIP deployable found in $artifactDir"
+    }
+
+    $zipExtractDir = Join-Path $workdir 'zip-extract'
+    New-Item -ItemType Directory -Force -Path $zipExtractDir | Out-Null
+    Write-SmokeLog "Extracting ZIP $($zip.Name)"
+    Expand-Archive -LiteralPath $zip.FullName -DestinationPath $zipExtractDir -Force
+    $zipExecutable = Find-PythonSCADExecutable -Root $zipExtractDir
+    Invoke-SmokeTests -ExecutablePath $zipExecutable -Label "ZIP $($zip.Name)" -Workdir $workdir
+
+    if ($options.SkipNsisInstall) {
+        Write-SmokeLog 'Skipping NSIS installer smoke test'
+    } else {
+        $installer = Get-ChildItem -LiteralPath $artifactDir -Recurse -File -Filter '*-Installer.exe' |
+            Select-Object -First 1
+        if (-not $installer) {
+            throw "No NSIS installer found in $artifactDir"
+        }
+
+        if (-not $options.SkipUninstallExisting) {
+            Invoke-ExistingPythonSCADUninstallers
+        }
+
+        $installDir = Join-Path $workdir 'nsis-install'
+        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+        Write-SmokeLog "Installing NSIS package $($installer.Name)"
+        & $installer.FullName /S "/D=$installDir"
+        $nsisExecutable = Find-PythonSCADExecutable -Root $installDir
+        Invoke-SmokeTests -ExecutablePath $nsisExecutable -Label "NSIS $($installer.Name)" -Workdir $workdir
+    }
+
+    Write-SmokeLog 'Windows smoke tests passed'
+} catch {
+    $scriptFailed = $true
+    throw
+} finally {
+    if ($options.KeepWorkdir -or $scriptFailed) {
+        Write-SmokeLog "Keeping workdir: $workdir"
+    } else {
+        Remove-Item -LiteralPath $workdir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/release-smoke/test-windows.ps1
+++ b/scripts/release-smoke/test-windows.ps1
@@ -257,6 +257,9 @@ try {
         }
 
         $installDir = Join-Path $workdir 'nsis-install'
+        if ($installDir -match '\s') {
+            throw "NSIS silent install requires a space-free install path; rerun with --workdir under a path without whitespace: $installDir"
+        }
         New-Item -ItemType Directory -Force -Path $installDir | Out-Null
         Write-SmokeLog "Installing NSIS package $($installer.Name)"
         & $installer.FullName /S "/D=$installDir"

--- a/scripts/release-smoke/test-windows.ps1
+++ b/scripts/release-smoke/test-windows.ps1
@@ -40,12 +40,13 @@ function Get-LatestSuccessfulRun {
         '--repo', $Repo,
         '--workflow', $Workflow,
         '--status', 'success',
-        '--limit', '1',
-        '--json', 'databaseId',
-        '--jq', '.[0].databaseId'
+        '--json', 'databaseId,headBranch'
     )
     if ($Ref) {
-        $ghArgs += @('--branch', $Ref)
+        $jq = 'map(select(.headBranch == "' + $Ref + '")) | .[0].databaseId // ""'
+        $ghArgs += @('--limit', '50', '--jq', $jq)
+    } else {
+        $ghArgs += @('--limit', '1', '--jq', '.[0].databaseId')
     }
     $runId = (& gh @ghArgs).Trim()
     if (-not $runId -or $runId -eq 'null') {

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=common-smoke.sh
+source "$SCRIPT_DIR/common-smoke.sh"
+
+RELEASE_BRANCH="release-please--branches--master--components--pythonscad"
+
+usage() {
+  cat <<'EOF'
+Usage: trigger-release-builds.sh [options]
+
+Dispatch all packaging workflows needed for release smoke testing.
+
+Options:
+  --repo <owner/name>          GitHub repository to use. Defaults to current repo.
+  --ref <branch-or-tag>        Ref to dispatch. Defaults to the release-please
+                               branch when it exists, otherwise master.
+  --upload-to-release <tag>    Pass upload_to_release to packaging workflows.
+  --wait                       Wait until all dispatched workflows finish.
+  --dry-run                    Print workflow dispatch commands without running them.
+  --help                       Show this help.
+
+Triggered workflows:
+  build-appimage.yml
+  build-debian-packages.yml
+  build-rpm-packages.yml
+  build-windows-native.yml
+  build-macos-release.yml
+EOF
+}
+
+repo=""
+ref=""
+upload_to_release=""
+wait_for_runs=0
+dry_run=0
+
+while (($#)); do
+  case "$1" in
+    --repo)
+      repo=${2:-}
+      [[ -n "$repo" ]] || rs_die "--repo requires a value"
+      shift 2
+      ;;
+    --ref)
+      ref=${2:-}
+      [[ -n "$ref" ]] || rs_die "--ref requires a value"
+      shift 2
+      ;;
+    --upload-to-release)
+      upload_to_release=${2:-}
+      [[ -n "$upload_to_release" ]] || rs_die "--upload-to-release requires a value"
+      shift 2
+      ;;
+    --wait)
+      wait_for_runs=1
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      rs_die "unknown option: $1"
+      ;;
+  esac
+done
+
+rs_require_command gh
+
+if [[ -z "$repo" ]]; then
+  repo=$(rs_repo_default)
+fi
+
+if [[ -z "$ref" ]]; then
+  if gh api "repos/${repo}/branches/${RELEASE_BRANCH}" >/dev/null 2>&1; then
+    ref=$RELEASE_BRANCH
+  else
+    ref=master
+  fi
+fi
+
+workflows=(
+  build-appimage.yml
+  build-debian-packages.yml
+  build-rpm-packages.yml
+  build-windows-native.yml
+  build-macos-release.yml
+)
+
+find_dispatched_run_id() {
+  local workflow=$1
+  local created_after=$2
+
+  gh run list \
+    --repo "$repo" \
+    --workflow "$workflow" \
+    --branch "$ref" \
+    --event workflow_dispatch \
+    --limit 20 \
+    --json databaseId,createdAt \
+    --jq "map(select(.createdAt >= \"$created_after\")) | .[0].databaseId // \"\""
+}
+
+wait_for_dispatched_run_id() {
+  local workflow=$1
+  local created_after=$2
+  local run_id=""
+
+  for _ in {1..30}; do
+    run_id=$(find_dispatched_run_id "$workflow" "$created_after")
+    if [[ -n "$run_id" ]]; then
+      printf '%s\n' "$run_id"
+      return 0
+    fi
+    sleep 10
+  done
+
+  return 1
+}
+
+wait_for_workflows() {
+  local -A completed=()
+  local remaining=${#run_ids[@]}
+  local failures=0
+
+  rs_log "Waiting for $remaining workflow runs; polling once per minute"
+
+  while ((remaining > 0)); do
+    for workflow in "${workflows[@]}"; do
+      if [[ -n "${completed[$workflow]:-}" ]]; then
+        continue
+      fi
+
+      local run_id=${run_ids[$workflow]}
+      local run_info
+      run_info=$(gh run view "$run_id" \
+        --repo "$repo" \
+        --json status,conclusion,url,workflowName \
+        --jq '[.status, (.conclusion // ""), .url, .workflowName] | @tsv')
+
+      local status conclusion url workflow_name
+      IFS=$'\t' read -r status conclusion url workflow_name <<< "$run_info"
+
+      if [[ "$status" == "completed" ]]; then
+        completed[$workflow]=1
+        ((remaining -= 1))
+        rs_log "Finished $workflow_name ($workflow): ${conclusion:-unknown} - $url"
+        if [[ "$conclusion" != "success" ]]; then
+          failures=1
+        fi
+      fi
+    done
+
+    if ((remaining > 0)); then
+      rs_log "$remaining workflow run(s) still running"
+      sleep 60
+    fi
+  done
+
+  if ((failures)); then
+    rs_die "one or more dispatched workflows failed"
+  fi
+
+  rs_log "All dispatched workflows completed successfully"
+}
+
+rs_log "Repository: $repo"
+rs_log "Ref: $ref"
+if [[ -n "$upload_to_release" ]]; then
+  rs_log "upload_to_release: $upload_to_release"
+fi
+
+declare -A run_ids=()
+dispatch_started=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+for workflow in "${workflows[@]}"; do
+  cmd=(gh workflow run "$workflow" --repo "$repo" --ref "$ref")
+  if [[ -n "$upload_to_release" ]]; then
+    cmd+=(--field "upload_to_release=$upload_to_release")
+  fi
+
+  if [[ "$dry_run" == "1" ]]; then
+    printf 'DRY-RUN:'
+    printf ' %q' "${cmd[@]}"
+    printf '\n'
+  else
+    rs_log "Dispatching $workflow"
+    "${cmd[@]}"
+    if [[ "$wait_for_runs" == "1" ]]; then
+      if run_id=$(wait_for_dispatched_run_id "$workflow" "$dispatch_started"); then
+        run_ids[$workflow]=$run_id
+        rs_log "Tracking $workflow as run $run_id"
+      else
+        rs_die "could not find dispatched run for $workflow"
+      fi
+    fi
+  fi
+done
+
+if [[ "$wait_for_runs" == "1" && "$dry_run" == "0" ]]; then
+  wait_for_workflows
+fi

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -102,11 +102,10 @@ find_dispatched_run_id() {
   gh run list \
     --repo "$repo" \
     --workflow "$workflow" \
-    --branch "$ref" \
     --event workflow_dispatch \
     --limit 20 \
-    --json databaseId,createdAt \
-    --jq "map(select(.createdAt >= \"$created_after\")) | sort_by(.createdAt) | .[0].databaseId // \"\""
+    --json 'databaseId,createdAt,headBranch' \
+    --jq "map(select(.createdAt >= \"$created_after\" and .headBranch == \"$ref\")) | sort_by(.createdAt) | .[0].databaseId // \"\""
 }
 
 wait_for_dispatched_run_id() {

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -185,7 +185,9 @@ if [[ -n "$upload_to_release" ]]; then
   rs_log "upload_to_release: $upload_to_release"
 fi
 
-declare -A run_ids=()
+if [[ "$wait_for_runs" == "1" ]]; then
+  declare -A run_ids=()
+fi
 
 for workflow in "${workflows[@]}"; do
   cmd=(gh workflow run "$workflow" --repo "$repo" --ref "$ref")

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -87,6 +87,12 @@ if [[ -z "$ref" ]]; then
   fi
 fi
 
+case "$ref" in
+  *\"*|*\\*|*$'\n'*|*$'\r'*)
+    rs_die "--ref contains characters that cannot be used in GitHub Actions jq filters"
+    ;;
+esac
+
 workflows=(
   build-appimage.yml
   build-debian-packages.yml

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -14,6 +14,8 @@ Usage: trigger-release-builds.sh [options]
 
 Dispatch all packaging workflows needed for release smoke testing.
 
+Requires Bash 4 or newer for --wait progress tracking.
+
 Options:
   --repo <owner/name>          GitHub repository to use. Defaults to current repo.
   --ref <branch-or-tag>        Ref to dispatch. Defaults to the release-please

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -106,7 +106,7 @@ find_dispatched_run_id() {
     --event workflow_dispatch \
     --limit 20 \
     --json databaseId,createdAt \
-    --jq "map(select(.createdAt >= \"$created_after\")) | .[0].databaseId // \"\""
+    --jq "map(select(.createdAt >= \"$created_after\")) | sort_by(.createdAt) | .[0].databaseId // \"\""
 }
 
 wait_for_dispatched_run_id() {
@@ -179,7 +179,6 @@ if [[ -n "$upload_to_release" ]]; then
 fi
 
 declare -A run_ids=()
-dispatch_started=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 for workflow in "${workflows[@]}"; do
   cmd=(gh workflow run "$workflow" --repo "$repo" --ref "$ref")
@@ -193,6 +192,7 @@ for workflow in "${workflows[@]}"; do
     printf '\n'
   else
     rs_log "Dispatching $workflow"
+    dispatch_started=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     "${cmd[@]}"
     if [[ "$wait_for_runs" == "1" ]]; then
       if run_id=$(wait_for_dispatched_run_id "$workflow" "$dispatch_started"); then

--- a/web/docs/development/release-smoke-tests.md
+++ b/web/docs/development/release-smoke-tests.md
@@ -28,7 +28,8 @@ out of scope for the first automated pass.
 Install the tools needed for the platform you are testing:
 
 - `gh`, authenticated for the `pythonscad/pythonscad` repository.
-- Docker, for testing `.deb` and `.rpm` packages on Linux.
+- Docker, `python3`, and `realpath`, for testing `.deb` and `.rpm` packages
+  on Linux.
 - Bash, for Linux and macOS scripts.
 - PowerShell, for the Windows script.
 

--- a/web/docs/development/release-smoke-tests.md
+++ b/web/docs/development/release-smoke-tests.md
@@ -1,0 +1,151 @@
+# Release Smoke Tests
+
+The release smoke scripts check that packaged deployables are basically sound
+before publishing a release. They exercise the end-user packages on their target
+platforms and look for obvious packaging failures: missing shared libraries,
+broken Python startup, unusable REPL entry points, or failed exports.
+
+They are not intended to replace ctests. Detailed geometry and API behavior,
+such as whether a modeling function computes the exact expected result, is
+covered by the build and regression test suite.
+
+## What Is Tested
+
+Each deployable is tested in an isolated temporary directory:
+
+- `pythonscad --info` starts without crashing.
+- A plain OpenSCAD file containing `cube(10);` exports to STL.
+- A Python script using `from pythonscad import *` exports to STL with
+  `--trust-python`.
+- `pythonscad --repl` accepts a small piped Python script and exports a cube.
+- `pythonscad --ipython` runs a small Python script and exports a cube.
+
+The GUI smoke test is still manual for now. MSIX and arm64 deployables are also
+out of scope for the first automated pass.
+
+## Required Tools
+
+Install the tools needed for the platform you are testing:
+
+- `gh`, authenticated for the `pythonscad/pythonscad` repository.
+- Docker, for testing `.deb` and `.rpm` packages on Linux.
+- Bash, for Linux and macOS scripts.
+- PowerShell, for the Windows script.
+
+The scripts download artifacts from GitHub Actions by default. They can also run
+against already-downloaded deployables with `--skip-download --artifact-dir`.
+
+## Trigger Build Workflows
+
+From a Linux checkout, dispatch all packaging workflows:
+
+```bash
+scripts/release-smoke/trigger-release-builds.sh
+```
+
+By default, this uses the Release Please branch
+`release-please--branches--master--components--pythonscad` when it exists, and
+falls back to `master` otherwise. Override the ref explicitly when needed:
+
+```bash
+scripts/release-smoke/trigger-release-builds.sh --ref master
+```
+
+For a real release upload rehearsal, pass the release tag:
+
+```bash
+scripts/release-smoke/trigger-release-builds.sh --upload-to-release v0.20.0
+```
+
+Wait for the workflows to finish before running the platform smoke scripts.
+To have the trigger script wait and report progress automatically, pass
+`--wait`:
+
+```bash
+scripts/release-smoke/trigger-release-builds.sh --wait
+```
+
+With `--wait`, the script polls once per minute, prints each workflow as it
+finishes, and exits non-zero if any triggered workflow fails.
+
+## Linux
+
+Test AppImages on a Linux machine:
+
+```bash
+scripts/release-smoke/test-appimages.sh
+```
+
+Test `.deb` and `.rpm` packages in Docker containers:
+
+```bash
+scripts/release-smoke/test-linux-packages.sh
+```
+
+The package script maps each downloaded package to its Docker image using
+`supported-distributions.json`, installs the package, installs distro IPython
+packages, then runs the shared smoke checks.
+
+## Windows
+
+On a Windows 11 development VM, run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\release-smoke\test-windows.ps1
+```
+
+The script tests the ZIP distribution in place. It also uninstalls existing
+PythonSCAD installations found in the standard uninstall registry locations,
+installs the NSIS package silently into a temporary directory, and runs the same
+smoke checks against the installed executable.
+
+To skip installer testing and only test the ZIP:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\release-smoke\test-windows.ps1 --skip-nsis-install
+```
+
+MSIX is intentionally skipped for now because unsigned MSIX installation is
+policy-dependent and may require Developer Mode, certificate setup, or elevated
+PowerShell.
+
+## macOS
+
+On macOS, run:
+
+```bash
+scripts/release-smoke/test-macos.sh
+```
+
+The script downloads the latest DMG artifact, mounts it read-only, locates the
+`.app` bundle, and runs the smoke checks against the executable inside
+`Contents/MacOS`.
+
+## Common Options
+
+The scripts use the same option names where practical:
+
+- `--repo <owner/name>` selects the GitHub repository.
+- `--ref <branch-or-tag>` filters latest workflow runs or selects dispatch ref.
+- `--run-id <id>` tests a specific workflow run when a script uses one workflow.
+- `--wait` waits for dispatched workflow runs when using
+  `trigger-release-builds.sh`.
+- `--workdir <path>` uses an explicit working directory.
+- `--keep-workdir` preserves temporary files and logs for debugging.
+- `--skip-download` uses deployables already present locally.
+- `--artifact-dir <path>` points to already-downloaded artifacts.
+- `--help` prints script-specific usage.
+
+Some scripts have extra platform-specific flags. For example,
+`test-linux-packages.sh` accepts `--deb-run-id` and `--rpm-run-id`, and
+`test-windows.ps1` accepts `--skip-nsis-install`.
+
+## Troubleshooting
+
+Use `--keep-workdir` first. Each smoke check writes command logs next to its
+temporary input files, which makes it easier to see whether a failure came from
+startup, export, REPL, or IPython.
+
+If no artifacts are found, confirm that the matching workflow completed
+successfully and that the script is looking at the intended branch or run id.
+Use `--run-id` or the package-specific run-id flags to remove ambiguity.

--- a/web/mkdocs.yml
+++ b/web/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - Playground: https://www.pythonscad.org/playground/
   - Installation: installation.md
   - Development:
+      - Release Smoke Tests: development/release-smoke-tests.md
       - Upstream Sync: development/upstream-sync.md
   - Building: building.md
   - WebAssembly:


### PR DESCRIPTION
## Summary
- Add cross-platform release smoke scripts for AppImage, Linux packages, macOS, and Windows deployables.
- Add shared smoke harnesses for startup, `.scad` export, Python CLI export, REPL, and IPython checks with preserved logs on failure.
- Document the release smoke workflow on the website and add a workflow trigger helper with `--wait` support.

## Test plan
- `pre-commit run --files scripts/release-smoke/common-smoke.ps1 scripts/release-smoke/common-smoke.sh scripts/release-smoke/test-appimages.sh scripts/release-smoke/test-linux-packages.sh scripts/release-smoke/test-macos.sh scripts/release-smoke/test-windows.ps1 scripts/release-smoke/trigger-release-builds.sh web/docs/development/release-smoke-tests.md web/mkdocs.yml`
- Manual AppImage smoke test against release artifacts.
- Manual Linux package smoke test against Debian/RPM release artifacts.


Made with [Cursor](https://cursor.com)