### PR TITLE
fix(release): smoke test local Windows artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,9 +344,59 @@ make -j$(sysctl -n hw.ncpu)
 
 ### Windows Build
 
-- Typically cross-compiled from Linux using MXE
-- See `doc/win-build.md` for MSVC build instructions
-- Cross-build: `./scripts/mingw-x-build-dependencies.sh 64`
+The release packaging path is a native MSYS2 UCRT64 build. Start commands from
+the repo root with:
+
+```powershell
+C:/msys64/msys2_shell.cmd -defterm -here -no-start -ucrt64 -shell bash
+```
+
+Inside that shell, install/update the package set used by CI:
+
+```bash
+python3 ./scripts/get-dependencies.py --distro msys2 --profile pythonscad-qt6 \
+  --output-env /tmp/pythonscad-deps.env --env-var PACBOY_PACKAGES
+source /tmp/pythonscad-deps.env
+pacboy -S --noconfirm --needed $PACBOY_PACKAGES nsis:p python-psutil:p uv:p
+```
+
+Configure and build the native package target:
+
+```bash
+cmake -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DEXPERIMENTAL=ON \
+  -DSNAPSHOT=ON \
+  -DUSE_QT6=ON \
+  -DENABLE_PYTHON=ON \
+  -DENABLE_LIBFIVE=ON \
+  -DPORTABLE_BINARY=ON \
+  -DENABLE_TESTS=OFF \
+  -DPACKAGE_ARCH=windows-x86-64
+cmake --build build -j4
+```
+
+Before packaging, refresh the bundled runtime Python dependencies and staging
+tree, then generate ZIP and NSIS artifacts:
+
+```bash
+BUNDLE_PY_AUTO_INSTALL_PIP_LICENSES=1 \
+  ./scripts/bundle-runtime-python.sh build/pythonscad-bundled-py --python python
+cmake --install build --prefix build/staging
+cd build
+cpack -G ZIP
+cpack -G NSIS
+```
+
+Smoke-test local artifacts from PowerShell with:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\release-smoke\test-windows.ps1 `
+  --skip-download --artifact-dir build --keep-workdir
+```
+
+See `doc/win-build.md` for the older MSVC/vcpkg build notes. The historical MXE
+cross-build path is `./scripts/mingw-x-build-dependencies.sh 64`.
 
 ### WebAssembly Build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,9 +354,8 @@ C:/msys64/msys2_shell.cmd -defterm -here -no-start -ucrt64 -shell bash
 Inside that shell, install/update the package set used by CI:
 
 ```bash
-python3 ./scripts/get-dependencies.py --distro msys2 --profile pythonscad-qt6 \
-  --output-env /tmp/pythonscad-deps.env --env-var PACBOY_PACKAGES
-source /tmp/pythonscad-deps.env
+PACBOY_PACKAGES=$(python3 ./scripts/get-dependencies.py --distro msys2 \
+  --profile pythonscad-qt6 --list | tr '\n' ' ')
 pacboy -S --noconfirm --needed $PACBOY_PACKAGES nsis:p python-psutil:p uv:p
 ```
 

--- a/scripts/release-smoke/test-windows.ps1
+++ b/scripts/release-smoke/test-windows.ps1
@@ -229,8 +229,9 @@ try {
         Write-SmokeLog "Using existing Windows artifacts in $artifactDir"
     }
 
-    $zip = Get-ChildItem -LiteralPath $artifactDir -Recurse -File -Filter '*.zip' |
+    $zip = Get-ChildItem -LiteralPath $artifactDir -Recurse -File -Filter 'PythonSCAD-*.zip' |
         Where-Object { $_.Name -notlike '*Installer*' } |
+        Sort-Object LastWriteTime -Descending |
         Select-Object -First 1
     if (-not $zip) {
         throw "No ZIP deployable found in $artifactDir"
@@ -247,6 +248,7 @@ try {
         Write-SmokeLog 'Skipping NSIS installer smoke test'
     } else {
         $installer = Get-ChildItem -LiteralPath $artifactDir -Recurse -File -Filter '*-Installer.exe' |
+            Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
         if (-not $installer) {
             throw "No NSIS installer found in $artifactDir"
@@ -262,9 +264,12 @@ try {
         }
         New-Item -ItemType Directory -Force -Path $installDir | Out-Null
         Write-SmokeLog "Installing NSIS package $($installer.Name)"
-        & $installer.FullName /S "/D=$installDir"
-        if ($LASTEXITCODE -ne 0) {
-            throw "NSIS installer failed with exit code $LASTEXITCODE"
+        $installProcess = Start-Process -FilePath $installer.FullName `
+            -ArgumentList @('/S', "/D=$installDir") `
+            -Wait `
+            -PassThru
+        if ($installProcess.ExitCode -ne 0) {
+            throw "NSIS installer failed with exit code $($installProcess.ExitCode)"
         }
         $nsisExecutable = Find-PythonSCADExecutable -Root $installDir
         Invoke-SmokeTest -ExecutablePath $nsisExecutable -Label "NSIS $($installer.Name)" -Workdir $workdir


### PR DESCRIPTION
## Summary
- Select the newest PythonSCAD ZIP/NSIS artifacts when smoke-testing a local build directory.
- Wait on the NSIS installer process directly so silent installer failures and completions are reported reliably.
- Update local Windows packaging notes to document the current MSYS2 UCRT64 flow.

## Test plan
- `Invoke-ScriptAnalyzer -Path scripts\release-smoke\test-windows.ps1`
- `pre-commit run --files CLAUDE.md scripts/release-smoke/test-windows.ps1`
- Built local Windows ZIP and NSIS artifacts from `build` using MSYS2 UCRT64.
- `powershell -ExecutionPolicy Bypass -File scripts\release-smoke\test-windows.ps1 --skip-download --artifact-dir build --keep-workdir`
