### PR TITLE
fix(python): preserve venv base executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,7 @@ if(ENABLE_PYTHON)
     src/python/py_ops.cc
     src/python/py_io.cc
     src/python/pyconversion.cc
+    src/python/python_runtime.cc
     src/core/node_clone.cc
     src/core/PullNode.cc
     src/core/WrapNode.cc
@@ -954,7 +955,7 @@ if(ENABLE_PYTHON)
 	      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PYTHON_EMBED_DEVPATH}/libssl-3.dll ${CMAKE_CURRENT_BINARY_DIR}/libssl-3.dll
 	      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PYTHON_EMBED_DEVPATH}/libcrypto-3.dll ${CMAKE_CURRENT_BINARY_DIR}/libcrypto-3.dll
 	      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PYTHON_EMBED_DEVPATH}/sqlite3.dll ${CMAKE_CURRENT_BINARY_DIR}/sqlite3.dll
-	      DEPENDS OpenSCADExe
+	      DEPENDS OpenSCADExe tgt_python_embed
       )
       else()
         add_custom_target(OpenSCADPython ALL COMMAND ${CMAKE_COMMAND} -E create_symlink ${EXECUTABLE_NAME} ${PYTHON_EXECUTABLE_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,10 +945,16 @@ if(ENABLE_PYTHON)
   # On other platforms, create it in the build directory
   if(NOT (APPLE AND NOT APPLE_UNIX))
     if(WIN32)
-      # On Windows, copy the executable instead of symlinking (symlinks are problematic)
+      # On Windows, copy the executable instead of symlinking (symlinks are problematic).
+      # CPython's venv launcher also probes <home>/python.exe, so provide that
+      # conventional name alongside PythonSCAD's explicit shim name.
       add_custom_target(OpenSCADPython ALL
-	      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:OpenSCADLibInternal> ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_EXECUTABLE_NAME}.exe
-	      DEPENDS OpenSCADLibInternal
+	      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:OpenSCADExe> ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_EXECUTABLE_NAME}.exe
+	      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:OpenSCADExe> ${CMAKE_CURRENT_BINARY_DIR}/python.exe
+	      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PYTHON_EMBED_DEVPATH}/libssl-3.dll ${CMAKE_CURRENT_BINARY_DIR}/libssl-3.dll
+	      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PYTHON_EMBED_DEVPATH}/libcrypto-3.dll ${CMAKE_CURRENT_BINARY_DIR}/libcrypto-3.dll
+	      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PYTHON_EMBED_DEVPATH}/sqlite3.dll ${CMAKE_CURRENT_BINARY_DIR}/sqlite3.dll
+	      DEPENDS OpenSCADExe
       )
       else()
         add_custom_target(OpenSCADPython ALL COMMAND ${CMAKE_COMMAND} -E create_symlink ${EXECUTABLE_NAME} ${PYTHON_EXECUTABLE_NAME})
@@ -2358,6 +2364,7 @@ if(NOT APPLE OR APPLE_UNIX)
   if(ENABLE_PYTHON)
     if(WIN32)
       install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_EXECUTABLE_NAME}.exe DESTINATION "${OPENSCAD_BINDIR}")
+      install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/python.exe DESTINATION "${OPENSCAD_BINDIR}")
     else()
       install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pythonscad-python DESTINATION "${OPENSCAD_BINDIR}")
     endif()

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1855,7 +1855,16 @@ void MainWindow::on_fileActionPythonCreateVenv_triggered()
 
   const auto& path = venvDir.absolutePath().toStdString();
   LOG("Creating Python virtual environment in '%1$s'...", path);
+  QProgressDialog progress(_("Creating Python virtual environment. Please wait..."), QString(), 0, 0,
+                           this);
+  progress.setWindowTitle(_("Create Virtual Environment"));
+  progress.setCancelButton(nullptr);
+  progress.setWindowModality(Qt::ApplicationModal);
+  progress.setMinimumDuration(0);
+  progress.show();
+  QApplication::processEvents();
   int result = pythonCreateVenv(path);
+  progress.close();
 
   if (result == 0) {
     Settings::SettingsPython::pythonVirtualEnv.setValue(path);

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -158,7 +158,7 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
 {
   PyStatus status;
   const auto name = PYTHON_EXECUTABLE_NAME;
-  const auto exe = PlatformUtils::applicationPath() + "/" + name;
+  const auto exe = pythonShimExecutablePath();
 
   PyPreConfig preconfig;
   PyPreConfig_InitPythonConfig(&preconfig);
@@ -225,6 +225,9 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
 
 done:
   PyConfig_Clear(&config);
+  if (!PyStatus_IsExit(status) && PyStatus_Exception(status)) {
+    return 1;
+  }
   return status.exitcode;
 }
 

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -42,6 +42,15 @@ namespace fs = std::filesystem;
 
 using SP = Settings::SettingsPython;
 
+static std::string pythonShimExecutablePath()
+{
+  auto path = fs::path(PlatformUtils::applicationPath()) / PYTHON_EXECUTABLE_NAME;
+#if defined(_WIN32)
+  path += ".exe";
+#endif
+  return path.generic_string();
+}
+
 std::string venvBinDirFromSettings()
 {
   const auto& venv = fs::path(SP::pythonVirtualEnv.value()) / "bin";
@@ -81,6 +90,15 @@ int pythonRunArgs(int argc, char **argv)
   status = PyConfig_SetBytesArgv(&config, argc, argv);
   if (PyStatus_Exception(status)) {
     goto fail;
+  }
+  {
+    const auto baseExecutable = pythonShimExecutablePath();
+    if (fs::exists(baseExecutable)) {
+      status = PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
+      if (PyStatus_Exception(status)) {
+        goto fail;
+      }
+    }
   }
 
   status = Py_InitializeFromConfig(&config);
@@ -152,6 +170,15 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
 
   PyConfig config;
   PyConfig_InitPythonConfig(&config);
+  {
+    const auto baseExecutable = pythonShimExecutablePath();
+    if (fs::exists(baseExecutable)) {
+      status = PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
+      if (PyStatus_Exception(status)) {
+        goto done;
+      }
+    }
+  }
 
   status = PyConfig_SetBytesString(&config, &config.program_name, name);
   if (PyStatus_Exception(status)) {

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -42,7 +42,7 @@ namespace fs = std::filesystem;
 
 using SP = Settings::SettingsPython;
 
-static std::string pythonShimExecutablePath()
+std::string pythonShimExecutablePath()
 {
   auto path = fs::path(PlatformUtils::applicationPath()) / PYTHON_EXECUTABLE_NAME;
 #if defined(_WIN32)

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -80,8 +80,11 @@ static std::string pythonWindowsRuntimePath()
   std::ostringstream stream;
   std::string sep;
   for (const auto& path : paths) {
-    if (!fs::is_directory(path)) continue;
-    stream << sep << fs::absolute(path).generic_string();
+    std::error_code ec;
+    if (!fs::is_directory(path, ec) || ec) continue;
+    const auto absolutePath = fs::absolute(path, ec);
+    if (ec) continue;
+    stream << sep << absolutePath.generic_string();
     sep = ";";
   }
   return stream.str();
@@ -171,6 +174,18 @@ int pythonRunModule(const std::string&, const std::string&, const std::vector<st
 #else
 
 static int pythonRunCommand(const std::string& command, const std::vector<std::string>& args);
+
+static bool pythonAppendConfigArg(PyConfig& config, const std::string& arg, PyStatus& status)
+{
+  wchar_t *warg = Py_DecodeLocale(arg.c_str(), nullptr);
+  if (warg == nullptr) {
+    status = PyStatus_Error("failed to decode Python argument");
+    return false;
+  }
+  status = PyWideStringList_Append(&config.argv, warg);
+  PyMem_RawFree(warg);
+  return !PyStatus_Exception(status);
+}
 
 int pythonRunArgs(int argc, char **argv)
 {
@@ -373,10 +388,7 @@ static int pythonRunCommand(const std::string& command, const std::vector<std::s
   }
 
   for (const auto& arg : args) {
-    std::wstring warg(arg.size(), L' ');
-    warg.resize(std::mbstowcs(&warg[0], arg.c_str(), arg.size()));
-    status = PyWideStringList_Append(&config.argv, warg.c_str());
-    if (PyStatus_Exception(status)) {
+    if (!pythonAppendConfigArg(config, arg, status)) {
       goto done;
     }
   }
@@ -395,6 +407,7 @@ static int pythonRunCommand(const std::string& command, const std::vector<std::s
   pythonConfigureHiddenConsoleSubprocesses();
 #endif
 
+  PyConfig_Clear(&config);
   return Py_RunMain();
 
 done:
@@ -471,10 +484,7 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
   }
 
   for (const auto& arg : args) {
-    std::wstring warg(arg.size(), L' ');
-    warg.resize(std::mbstowcs(&warg[0], arg.c_str(), arg.size()));
-    status = PyWideStringList_Append(&config.argv, warg.c_str());
-    if (PyStatus_Exception(status)) {
+    if (!pythonAppendConfigArg(config, arg, status)) {
       goto done;
     }
   }
@@ -494,6 +504,7 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
   pythonConfigureHiddenConsoleSubprocesses();
 #endif
 
+  PyConfig_Clear(&config);
   return Py_RunMain();
 
 done:

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -25,8 +25,11 @@
  */
 #include <Python.h>
 
+#include <array>
+#include <cstring>
 #include <cstdlib>
 #include <filesystem>
+#include <sstream>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -60,6 +63,93 @@ std::string venvBinDirFromSettings()
   return "";
 }
 
+#if defined(_WIN32)
+static std::string pythonWindowsRuntimePath()
+{
+  const auto applicationPath = fs::path(PlatformUtils::applicationPath());
+  const auto pythonXY =
+    "python" + std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION);
+  const auto windowsPythonLib = applicationPath / "lib" / pythonXY;
+  const std::array<fs::path, 4> paths = {
+    windowsPythonLib,
+    windowsPythonLib / "lib-dynload",
+    applicationPath,
+    applicationPath / "DLLs",
+  };
+
+  std::ostringstream stream;
+  std::string sep;
+  for (const auto& path : paths) {
+    if (!fs::is_directory(path)) continue;
+    stream << sep << fs::absolute(path).generic_string();
+    sep = ";";
+  }
+  return stream.str();
+}
+
+static void pythonConfigureWindowsSysCompat()
+{
+  PyObject *sys = PyImport_ImportModule("sys");
+  if (sys == nullptr) {
+    PyErr_Clear();
+    return;
+  }
+
+  PyObject *sysdict = PyModule_GetDict(sys);
+  PyObject *isMingw = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "_is_mingw");
+  if (isMingw == nullptr && PyErr_Occurred()) {
+    PyErr_Clear();
+  } else if (sysdict != nullptr && isMingw == nullptr) {
+    const char *compiler = Py_GetCompiler();
+    const bool runtimeIsMingw = compiler != nullptr && (strstr(compiler, "MINGW") != nullptr ||
+                                                        strstr(compiler, "GCC") != nullptr);
+    PyObject *value = runtimeIsMingw ? Py_True : Py_False;
+    if (PyDict_SetItemString(sysdict, "_is_mingw", value) != 0) {
+      PyErr_Clear();
+    }
+  }
+  PyObject *abiflags = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "abiflags");
+  if (abiflags == nullptr && PyErr_Occurred()) {
+    PyErr_Clear();
+  } else if (sysdict != nullptr && abiflags == nullptr) {
+    PyObject *value = PyUnicode_FromString("");
+    if (value == nullptr) {
+      PyErr_Clear();
+    } else if (PyDict_SetItemString(sysdict, "abiflags", value) != 0) {
+      PyErr_Clear();
+    }
+    Py_XDECREF(value);
+  }
+  Py_DECREF(sys);
+}
+
+static void pythonConfigureHiddenConsoleSubprocesses()
+{
+  if (getenv("PYTHONSCAD_HIDE_CONSOLE_SUBPROCESSES") == nullptr) {
+    return;
+  }
+  if (PyRun_SimpleString(R"PYTHON(
+import subprocess as _pythonscad_subprocess
+if not getattr(_pythonscad_subprocess, "_pythonscad_hidden_console", False):
+    _pythonscad_original_popen = _pythonscad_subprocess.Popen
+    class _PythonSCADHiddenPopen(_pythonscad_original_popen):
+        def __init__(self, args, *popen_args, **kwargs):
+            kwargs["creationflags"] = kwargs.get("creationflags", 0) | getattr(_pythonscad_subprocess, "CREATE_NO_WINDOW", 0)
+            startupinfo = kwargs.get("startupinfo")
+            if startupinfo is None:
+                startupinfo = _pythonscad_subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= _pythonscad_subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = 0
+            kwargs["startupinfo"] = startupinfo
+            super().__init__(args, *popen_args, **kwargs)
+    _pythonscad_subprocess.Popen = _PythonSCADHiddenPopen
+    _pythonscad_subprocess._pythonscad_hidden_console = True
+)PYTHON") != 0) {
+    PyErr_Clear();
+  }
+}
+#endif
+
 #ifdef __EMSCRIPTEN__
 // These functions manage Python runtime lifecycle for CLI / AppImage use cases.
 // They are never called in WASM builds but must exist to satisfy the linker.
@@ -80,6 +170,8 @@ int pythonRunModule(const std::string&, const std::string&, const std::vector<st
 }
 #else
 
+static int pythonRunCommand(const std::string& command, const std::vector<std::string>& args);
+
 int pythonRunArgs(int argc, char **argv)
 {
   PyStatus status;
@@ -91,6 +183,22 @@ int pythonRunArgs(int argc, char **argv)
   if (PyStatus_Exception(status)) {
     goto fail;
   }
+#if defined(_WIN32)
+  {
+    const auto applicationPath = fs::path(PlatformUtils::applicationPath()).generic_string();
+    status = PyConfig_SetBytesString(&config, &config.home, applicationPath.c_str());
+    if (PyStatus_Exception(status)) {
+      goto fail;
+    }
+    const auto pythonPath = pythonWindowsRuntimePath();
+    if (!pythonPath.empty()) {
+      status = PyConfig_SetBytesString(&config, &config.pythonpath_env, pythonPath.c_str());
+      if (PyStatus_Exception(status)) {
+        goto fail;
+      }
+    }
+  }
+#endif
   {
     const auto baseExecutable = pythonShimExecutablePath();
     std::error_code ec;
@@ -106,6 +214,10 @@ int pythonRunArgs(int argc, char **argv)
   if (PyStatus_Exception(status)) {
     goto fail;
   }
+#if defined(_WIN32)
+  pythonConfigureWindowsSysCompat();
+  pythonConfigureHiddenConsoleSubprocesses();
+#endif
   PyConfig_Clear(&config);
 
   return Py_RunMain();
@@ -120,10 +232,53 @@ fail:
 
 int pythonCreateVenv(const std::string& path)
 {
+#if defined(_WIN32)
+  static const char *const hiddenVenvCommand = R"PYTHON(
+import os
+import subprocess
+import sys
+import venv
+
+class PythonSCADEnvBuilder(venv.EnvBuilder):
+    def _call_new_python(self, context, *py_args, **kwargs):
+        args = [context.env_exec_cmd, *py_args]
+        kwargs["env"] = env = os.environ.copy()
+        env["VIRTUAL_ENV"] = context.env_dir
+        env["PYTHONSCAD_HIDE_CONSOLE_SUBPROCESSES"] = "1"
+        env.pop("PYTHONHOME", None)
+        env.pop("PYTHONPATH", None)
+        kwargs["cwd"] = context.env_dir
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = 0
+        kwargs["startupinfo"] = startupinfo
+        subprocess.check_output(args, **kwargs)
+
+PythonSCADEnvBuilder(with_pip=True, scm_ignore_files=frozenset(["git"])).create(sys.argv[1])
+)PYTHON";
+  int result = pythonRunCommand(hiddenVenvCommand, {path});
+#else
   int result = pythonRunModule("", "venv", {path});
+#endif
   if (result != 0) {
     return result;
   }
+
+#if defined(_WIN32)
+  {
+    const auto scriptsDir = fs::path{path} / "Scripts";
+    const auto pythonExe = scriptsDir / "python.exe";
+    const auto pythonScadExe = scriptsDir / (std::string(PYTHON_EXECUTABLE_NAME) + ".exe");
+    std::error_code ec;
+    if (!fs::exists(pythonScadExe, ec) && fs::exists(pythonExe, ec)) {
+      fs::copy_file(pythonExe, pythonScadExe, fs::copy_options::overwrite_existing, ec);
+      if (ec.value() > 0) {
+        return ec.value();
+      }
+    }
+  }
+#endif
 
   // The created VENV points to the temporary mount point of the
   // AppImage, e.g. /tmp/.mount_OpenSCCpPaio - that is obviously
@@ -154,6 +309,102 @@ int pythonCreateVenv(const std::string& path)
   return 0;
 }
 
+static int pythonRunCommand(const std::string& command, const std::vector<std::string>& args)
+{
+  PyStatus status;
+  const auto name = PYTHON_EXECUTABLE_NAME;
+  const auto exe = pythonShimExecutablePath();
+
+  PyPreConfig preconfig;
+  PyPreConfig_InitPythonConfig(&preconfig);
+
+  status = Py_PreInitialize(&preconfig);
+  if (PyStatus_Exception(status)) {
+    Py_ExitStatusException(status);
+  }
+
+  PyConfig config;
+  PyConfig_InitPythonConfig(&config);
+#if defined(_WIN32)
+  {
+    const auto applicationPath = fs::path(PlatformUtils::applicationPath()).generic_string();
+    status = PyConfig_SetBytesString(&config, &config.home, applicationPath.c_str());
+    if (PyStatus_Exception(status)) {
+      goto done;
+    }
+    const auto pythonPath = pythonWindowsRuntimePath();
+    if (!pythonPath.empty()) {
+      status = PyConfig_SetBytesString(&config, &config.pythonpath_env, pythonPath.c_str());
+      if (PyStatus_Exception(status)) {
+        goto done;
+      }
+    }
+  }
+#endif
+  {
+    const auto baseExecutable = pythonShimExecutablePath();
+    std::error_code ec;
+    if (fs::exists(baseExecutable, ec)) {
+      status = PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
+      if (PyStatus_Exception(status)) {
+        goto done;
+      }
+    }
+  }
+
+  status = PyConfig_SetBytesString(&config, &config.program_name, name);
+  if (PyStatus_Exception(status)) {
+    goto done;
+  }
+
+  status = PyConfig_SetBytesString(&config, &config.executable, exe.c_str());
+  if (PyStatus_Exception(status)) {
+    goto done;
+  }
+
+  status = PyConfig_SetBytesString(&config, &config.run_command, command.c_str());
+  if (PyStatus_Exception(status)) {
+    goto done;
+  }
+
+  status = PyConfig_Read(&config);
+  if (PyStatus_Exception(status)) {
+    goto done;
+  }
+
+  for (const auto& arg : args) {
+    std::wstring warg(arg.size(), L' ');
+    warg.resize(std::mbstowcs(&warg[0], arg.c_str(), arg.size()));
+    status = PyWideStringList_Append(&config.argv, warg.c_str());
+    if (PyStatus_Exception(status)) {
+      goto done;
+    }
+  }
+
+  status = PyConfig_SetBytesString(&config, &config.executable, exe.c_str());
+  if (PyStatus_Exception(status)) {
+    goto done;
+  }
+
+  status = Py_InitializeFromConfig(&config);
+  if (PyStatus_Exception(status)) {
+    goto done;
+  }
+#if defined(_WIN32)
+  pythonConfigureWindowsSysCompat();
+  pythonConfigureHiddenConsoleSubprocesses();
+#endif
+
+  return Py_RunMain();
+
+done:
+  PyConfig_Clear(&config);
+  if (!PyStatus_IsExit(status) && PyStatus_Exception(status)) {
+    return 1;
+  }
+  return status.exitcode;
+}
+
 int pythonRunModule(const std::string& appPath, const std::string& module,
                     const std::vector<std::string>& args)
 {
@@ -171,6 +422,22 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
 
   PyConfig config;
   PyConfig_InitPythonConfig(&config);
+#if defined(_WIN32)
+  {
+    const auto applicationPath = fs::path(PlatformUtils::applicationPath()).generic_string();
+    status = PyConfig_SetBytesString(&config, &config.home, applicationPath.c_str());
+    if (PyStatus_Exception(status)) {
+      goto done;
+    }
+    const auto pythonPath = pythonWindowsRuntimePath();
+    if (!pythonPath.empty()) {
+      status = PyConfig_SetBytesString(&config, &config.pythonpath_env, pythonPath.c_str());
+      if (PyStatus_Exception(status)) {
+        goto done;
+      }
+    }
+  }
+#endif
   {
     const auto baseExecutable = pythonShimExecutablePath();
     std::error_code ec;
@@ -222,6 +489,10 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
   if (PyStatus_Exception(status)) {
     goto done;
   }
+#if defined(_WIN32)
+  pythonConfigureWindowsSysCompat();
+  pythonConfigureHiddenConsoleSubprocesses();
+#endif
 
   return Py_RunMain();
 

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -93,7 +93,8 @@ int pythonRunArgs(int argc, char **argv)
   }
   {
     const auto baseExecutable = pythonShimExecutablePath();
-    if (fs::exists(baseExecutable)) {
+    std::error_code ec;
+    if (fs::exists(baseExecutable, ec)) {
       status = PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
       if (PyStatus_Exception(status)) {
         goto fail;
@@ -172,7 +173,8 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
   PyConfig_InitPythonConfig(&config);
   {
     const auto baseExecutable = pythonShimExecutablePath();
-    if (fs::exists(baseExecutable)) {
+    std::error_code ec;
+    if (fs::exists(baseExecutable, ec)) {
       status = PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
       if (PyStatus_Exception(status)) {
         goto done;

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -40,6 +40,7 @@
 #endif
 #include "platform/PlatformUtils.h"
 #include "pyopenscad.h"
+#include "python_runtime.h"
 
 namespace fs = std::filesystem;
 
@@ -88,42 +89,6 @@ static std::string pythonWindowsRuntimePath()
     sep = ";";
   }
   return stream.str();
-}
-
-static void pythonConfigureWindowsSysCompat()
-{
-  PyObject *sys = PyImport_ImportModule("sys");
-  if (sys == nullptr) {
-    PyErr_Clear();
-    return;
-  }
-
-  PyObject *sysdict = PyModule_GetDict(sys);
-  PyObject *isMingw = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "_is_mingw");
-  if (isMingw == nullptr && PyErr_Occurred()) {
-    PyErr_Clear();
-  } else if (sysdict != nullptr && isMingw == nullptr) {
-    const char *compiler = Py_GetCompiler();
-    const bool runtimeIsMingw = compiler != nullptr && (strstr(compiler, "MINGW") != nullptr ||
-                                                        strstr(compiler, "GCC") != nullptr);
-    PyObject *value = runtimeIsMingw ? Py_True : Py_False;
-    if (PyDict_SetItemString(sysdict, "_is_mingw", value) != 0) {
-      PyErr_Clear();
-    }
-  }
-  PyObject *abiflags = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "abiflags");
-  if (abiflags == nullptr && PyErr_Occurred()) {
-    PyErr_Clear();
-  } else if (sysdict != nullptr && abiflags == nullptr) {
-    PyObject *value = PyUnicode_FromString("");
-    if (value == nullptr) {
-      PyErr_Clear();
-    } else if (PyDict_SetItemString(sysdict, "abiflags", value) != 0) {
-      PyErr_Clear();
-    }
-    Py_XDECREF(value);
-  }
-  Py_DECREF(sys);
 }
 
 static void pythonConfigureHiddenConsoleSubprocesses()
@@ -230,7 +195,7 @@ int pythonRunArgs(int argc, char **argv)
     goto fail;
   }
 #if defined(_WIN32)
-  pythonConfigureWindowsSysCompat();
+  python_configure_windows_sys_compat();
   pythonConfigureHiddenConsoleSubprocesses();
 #endif
   PyConfig_Clear(&config);
@@ -286,7 +251,15 @@ PythonSCADEnvBuilder(with_pip=True, scm_ignore_files=frozenset(["git"])).create(
     const auto pythonExe = scriptsDir / "python.exe";
     const auto pythonScadExe = scriptsDir / (std::string(PYTHON_EXECUTABLE_NAME) + ".exe");
     std::error_code ec;
-    if (!fs::exists(pythonScadExe, ec) && fs::exists(pythonExe, ec)) {
+    const bool pythonScadExists = fs::exists(pythonScadExe, ec);
+    if (ec.value() > 0) {
+      return ec.value();
+    }
+    const bool pythonExists = fs::exists(pythonExe, ec);
+    if (ec.value() > 0) {
+      return ec.value();
+    }
+    if (!pythonScadExists && pythonExists) {
       fs::copy_file(pythonExe, pythonScadExe, fs::copy_options::overwrite_existing, ec);
       if (ec.value() > 0) {
         return ec.value();
@@ -403,7 +376,7 @@ static int pythonRunCommand(const std::string& command, const std::vector<std::s
     goto done;
   }
 #if defined(_WIN32)
-  pythonConfigureWindowsSysCompat();
+  python_configure_windows_sys_compat();
   pythonConfigureHiddenConsoleSubprocesses();
 #endif
 
@@ -500,7 +473,7 @@ int pythonRunModule(const std::string& appPath, const std::string& module,
     goto done;
   }
 #if defined(_WIN32)
-  pythonConfigureWindowsSysCompat();
+  python_configure_windows_sys_compat();
   pythonConfigureHiddenConsoleSubprocesses();
 #endif
 

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1231,14 +1231,19 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
 #ifndef __EMSCRIPTEN__
     {
       const auto baseExecutable = pythonShimExecutablePath();
-      if (fs::exists(baseExecutable)) {
+      std::error_code ec;
+      if (fs::exists(baseExecutable, ec)) {
         status = PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
         if (PyStatus_Exception(status)) {
           alreadyTried = true;
           PyConfig_Clear(&config);
-          LOG(message_group::Error, "Failed to configure Python base executable.");
+          LOG(message_group::Error, "Failed to configure Python base executable '%1$s': %2$s",
+              baseExecutable, status.err_msg != nullptr ? status.err_msg : "unknown error");
           return;
         }
+      } else if (ec) {
+        LOG(message_group::Error, "Failed to inspect Python base executable '%1$s': %2$s",
+            baseExecutable, ec.message());
       }
     }
 #endif

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -55,6 +55,7 @@
 
 #include "pyopenscad.h"
 #include "pydata.h"
+#include "python_runtime.h"
 #include "core/CsgOpNode.h"
 #include "Value.h"
 #ifndef PYTHON_EXECUTABLE_NAME
@@ -102,44 +103,6 @@ void PyObjectDeleter(PyObject *pObject)
 
 PyObjectUniquePtr pythonInitDict(nullptr, &PyObjectDeleter);
 PyObjectUniquePtr pythonMainModule(nullptr, &PyObjectDeleter);
-
-#ifdef _WIN32
-static void python_configure_windows_sys_compat(void)
-{
-  PyObject *sys = PyImport_ImportModule("sys");
-  if (sys == nullptr) {
-    PyErr_Clear();
-    return;
-  }
-
-  PyObject *sysdict = PyModule_GetDict(sys);
-  PyObject *isMingw = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "_is_mingw");
-  if (isMingw == nullptr && PyErr_Occurred()) {
-    PyErr_Clear();
-  } else if (sysdict != nullptr && isMingw == nullptr) {
-    const char *compiler = Py_GetCompiler();
-    const bool runtimeIsMingw = compiler != nullptr && (strstr(compiler, "MINGW") != nullptr ||
-                                                        strstr(compiler, "GCC") != nullptr);
-    PyObject *value = runtimeIsMingw ? Py_True : Py_False;
-    if (PyDict_SetItemString(sysdict, "_is_mingw", value) != 0) {
-      PyErr_Clear();
-    }
-  }
-  PyObject *abiflags = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "abiflags");
-  if (abiflags == nullptr && PyErr_Occurred()) {
-    PyErr_Clear();
-  } else if (sysdict != nullptr && abiflags == nullptr) {
-    PyObject *value = PyUnicode_FromString("");
-    if (value == nullptr) {
-      PyErr_Clear();
-    } else if (PyDict_SetItemString(sysdict, "abiflags", value) != 0) {
-      PyErr_Clear();
-    }
-    Py_XDECREF(value);
-  }
-  Py_DECREF(sys);
-}
-#endif
 
 bool python_pyobject_to_utf8(PyObject *obj, std::string& out, const char *context)
 {

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -71,6 +71,15 @@
 #include "primitives.h"
 namespace fs = std::filesystem;
 
+static std::string pythonShimExecutablePath()
+{
+  auto path = fs::path(PlatformUtils::applicationPath()) / PYTHON_EXECUTABLE_NAME;
+#if defined(_WIN32)
+  path += ".exe";
+#endif
+  return path.generic_string();
+}
+
 // #define HAVE_PYTHON_YIELD
 // CPython requires the init function for the `_openscad` extension module to
 // be named `PyInit__openscad` (double underscore). The reserved-identifier
@@ -1226,6 +1235,15 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     PyImport_AppendInittab("libfive", &PyInit_data);
     PyConfig config;
     PyConfig_InitPythonConfig(&config);
+
+#ifndef __EMSCRIPTEN__
+    {
+      const auto baseExecutable = pythonShimExecutablePath();
+      if (fs::exists(baseExecutable)) {
+        PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
+      }
+    }
+#endif
 
 #ifdef __EMSCRIPTEN__
 #ifdef WASM_NODE_BUILD

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -71,15 +71,6 @@
 #include "primitives.h"
 namespace fs = std::filesystem;
 
-static std::string pythonShimExecutablePath()
-{
-  auto path = fs::path(PlatformUtils::applicationPath()) / PYTHON_EXECUTABLE_NAME;
-#if defined(_WIN32)
-  path += ".exe";
-#endif
-  return path.generic_string();
-}
-
 // #define HAVE_PYTHON_YIELD
 // CPython requires the init function for the `_openscad` extension module to
 // be named `PyInit__openscad` (double underscore). The reserved-identifier
@@ -1235,12 +1226,19 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     PyImport_AppendInittab("libfive", &PyInit_data);
     PyConfig config;
     PyConfig_InitPythonConfig(&config);
+    PyStatus status;
 
 #ifndef __EMSCRIPTEN__
     {
       const auto baseExecutable = pythonShimExecutablePath();
       if (fs::exists(baseExecutable)) {
-        PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
+        status = PyConfig_SetBytesString(&config, &config.base_executable, baseExecutable.c_str());
+        if (PyStatus_Exception(status)) {
+          alreadyTried = true;
+          PyConfig_Clear(&config);
+          LOG(message_group::Error, "Failed to configure Python base executable.");
+          return;
+        }
       }
     }
 #endif
@@ -1356,7 +1354,7 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     }
 #endif
 
-    PyStatus status = Py_InitializeFromConfig(&config);
+    status = Py_InitializeFromConfig(&config);
     if (PyStatus_Exception(status)) {
       alreadyTried = true;
       LOG(message_group::Error, "Python %1$lu.%2$lu.%3$lu not found. Is it installed ?",

--- a/src/python/python_public.h
+++ b/src/python/python_public.h
@@ -63,4 +63,5 @@ int pythonRunArgs(int argc, char **argv);
 int pythonCreateVenv(const std::string& path);
 int pythonRunModule(const std::string& appPath, const std::string& module,
                     const std::vector<std::string>& args);
+std::string pythonShimExecutablePath();
 std::string venvBinDirFromSettings();

--- a/src/python/python_runtime.cc
+++ b/src/python/python_runtime.cc
@@ -1,0 +1,45 @@
+#include <Python.h>
+
+#ifdef _WIN32
+
+#include "python_runtime.h"
+
+#include <cstring>
+
+void python_configure_windows_sys_compat()
+{
+  PyObject *sys = PyImport_ImportModule("sys");
+  if (sys == nullptr) {
+    PyErr_Clear();
+    return;
+  }
+
+  PyObject *sysdict = PyModule_GetDict(sys);
+  PyObject *isMingw = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "_is_mingw");
+  if (isMingw == nullptr && PyErr_Occurred()) {
+    PyErr_Clear();
+  } else if (sysdict != nullptr && isMingw == nullptr) {
+    const char *compiler = Py_GetCompiler();
+    const bool runtimeIsMingw = compiler != nullptr && (strstr(compiler, "MINGW") != nullptr ||
+                                                        strstr(compiler, "GCC") != nullptr);
+    PyObject *value = runtimeIsMingw ? Py_True : Py_False;
+    if (PyDict_SetItemString(sysdict, "_is_mingw", value) != 0) {
+      PyErr_Clear();
+    }
+  }
+  PyObject *abiflags = sysdict == nullptr ? nullptr : PyDict_GetItemString(sysdict, "abiflags");
+  if (abiflags == nullptr && PyErr_Occurred()) {
+    PyErr_Clear();
+  } else if (sysdict != nullptr && abiflags == nullptr) {
+    PyObject *value = PyUnicode_FromString("");
+    if (value == nullptr) {
+      PyErr_Clear();
+    } else if (PyDict_SetItemString(sysdict, "abiflags", value) != 0) {
+      PyErr_Clear();
+    }
+    Py_XDECREF(value);
+  }
+  Py_DECREF(sys);
+}
+
+#endif

--- a/src/python/python_runtime.h
+++ b/src/python/python_runtime.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifdef _WIN32
+void python_configure_windows_sys_compat();
+#endif


### PR DESCRIPTION
## Summary
- Set CPython's base executable to the PythonSCAD Python shim during embedded Python startup and module execution.
- Prevent nested venv creation from inheriting the GUI binary as `sys._base_executable`, which caused `ensurepip` to run through PythonSCAD's option parser.

## Test plan
- Reproduced the failure with an existing venv whose `python` links to `pythonscad`; `python -m venv` failed during `ensurepip`.
- Verified the fixed build creates a new venv with `python -> pythonscad-python` and pip scripts installed.
- Verified File > Python > Create Virtual Environment succeeds in the GUI.
- Ran `cmake --build build -j6`.

Made with [Cursor](https://cursor.com)