### PR TITLE
fix(release): keep Linux package smoke artifacts bind-mountable

### DIFF
--- a/scripts/release-smoke/test-linux-packages.sh
+++ b/scripts/release-smoke/test-linux-packages.sh
@@ -97,7 +97,12 @@ rs_require_command find
 rs_require_command python3
 rs_require_command realpath
 
-workdir=$(rs_make_workdir "$workdir_arg")
+if [[ -n "$workdir_arg" ]]; then
+  workdir=$(rs_make_workdir "$workdir_arg")
+else
+  mkdir -p "$PROJECT_ROOT/tmp"
+  workdir=$(mktemp -d "$PROJECT_ROOT/tmp/pythonscad-release-smoke.XXXXXX")
+fi
 trap 'rs_cleanup_workdir "$workdir" "$keep_workdir" "$?"' EXIT
 
 if [[ -z "$artifact_dir" ]]; then


### PR DESCRIPTION
## Summary
- Store default Linux package smoke artifacts under the repository-local `tmp/` directory instead of `/tmp`.
- Keeps downloaded `.deb` and `.rpm` files visible to Docker bind mounts when running the smoke tests from Cursor/sandboxed environments.

## Test plan
- `bash -n scripts/release-smoke/test-linux-packages.sh`
- `./scripts/release-smoke/test-linux-packages.sh` reproduced `/tmp/pythonscad-package.deb` being mounted as a directory before the fix.
- Post-fix rerun progressed past `apt-get install -y ./pythonscad-package.deb`; Docker saw the package bind target as a regular file with the expected size.

Made with [Cursor](https://cursor.com)