### PR TITLE
fix(pypi): restore PyPI wheel builds

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -100,7 +100,6 @@ jobs:
         shell: pwsh
         env:
           VCPKG_BINARY_SOURCES: ${{ github.event_name == 'workflow_dispatch' && format('clear;files,{0}/.wheel-vcpkg-cache,readwrite', github.workspace) || '' }}
-          PYTHONSCAD_WHEEL_DEBUG: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
         run: pwsh scripts/cibuildwheel/install-deps-windows.ps1
 
       - name: Prune Windows vcpkg cache
@@ -135,7 +134,6 @@ jobs:
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_BEFORE_ALL_WINDOWS: python -c "print('Windows wheel dependencies already installed by workflow')"
-          PYTHONSCAD_WHEEL_DEBUG: ${{ github.event_name == 'workflow_dispatch' && runner.os == 'Windows' && '1' || '' }}
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -100,7 +100,7 @@ jobs:
         shell: pwsh
         env:
           VCPKG_BINARY_SOURCES: ${{ github.event_name == 'workflow_dispatch' && format('clear;files,{0}/.wheel-vcpkg-cache,readwrite', github.workspace) || '' }}
-          PYTHONSCAD_WHEEL_DEBUG: "1"
+          PYTHONSCAD_WHEEL_DEBUG: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
         run: pwsh scripts/cibuildwheel/install-deps-windows.ps1
 
       - name: Prune Windows vcpkg cache
@@ -135,7 +135,7 @@ jobs:
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_BEFORE_ALL_WINDOWS: python -c "print('Windows wheel dependencies already installed by workflow')"
-          PYTHONSCAD_WHEEL_DEBUG: ${{ runner.os == 'Windows' && '1' || '' }}
+          PYTHONSCAD_WHEEL_DEBUG: ${{ github.event_name == 'workflow_dispatch' && runner.os == 'Windows' && '1' || '' }}
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -100,6 +100,7 @@ jobs:
         shell: pwsh
         env:
           VCPKG_BINARY_SOURCES: ${{ github.event_name == 'workflow_dispatch' && format('clear;files,{0}/.wheel-vcpkg-cache,readwrite', github.workspace) || '' }}
+          PYTHONSCAD_WHEEL_DEBUG: "1"
         run: pwsh scripts/cibuildwheel/install-deps-windows.ps1
 
       - name: Prune Windows vcpkg cache
@@ -134,6 +135,7 @@ jobs:
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_BEFORE_ALL_WINDOWS: python -c "print('Windows wheel dependencies already installed by workflow')"
+          PYTHONSCAD_WHEEL_DEBUG: ${{ runner.os == 'Windows' && '1' || '' }}
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -87,7 +87,10 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && runner.os == 'Windows'
         uses: actions/cache/restore@v4
         with:
+          # actions/cache versions include this path list; keep .wheel-vcpkg here
+          # so older wheel caches remain restorable across workflow changes.
           path: |
+            .wheel-vcpkg
             .wheel-vcpkg-cache
             ~/AppData/Local/vcpkg/archives
           key: pypi-windows-vcpkg-${{ hashFiles('scripts/cibuildwheel/vcpkg.json', 'scripts/cibuildwheel/install-deps-windows.ps1') }}
@@ -123,7 +126,9 @@ jobs:
           steps.windows-vcpkg-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
+          # Keep this in sync with the restore path list above.
           path: |
+            .wheel-vcpkg
             .wheel-vcpkg-cache
             ~/AppData/Local/vcpkg/archives
           key: ${{ steps.windows-vcpkg-cache.outputs.cache-primary-key }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -95,10 +95,12 @@ jobs:
           restore-keys: |
             pypi-windows-vcpkg-
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+      - name: Install Windows wheel dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
         env:
-          VCPKG_BINARY_SOURCES: ${{ github.event_name == 'workflow_dispatch' && runner.os == 'Windows' && format('clear;files,{0}/.wheel-vcpkg-cache,readwrite', github.workspace) || '' }}
+          VCPKG_BINARY_SOURCES: ${{ github.event_name == 'workflow_dispatch' && format('clear;files,{0}/.wheel-vcpkg-cache,readwrite', github.workspace) || '' }}
+        run: pwsh scripts/cibuildwheel/install-deps-windows.ps1
 
       - name: Prune Windows vcpkg cache
         if: always() && runner.os == 'Windows'
@@ -117,7 +119,6 @@ jobs:
 
       - name: Save Windows vcpkg cache
         if: >-
-          always() &&
           github.event_name == 'workflow_dispatch' &&
           runner.os == 'Windows' &&
           steps.windows-vcpkg-cache.outputs.cache-hit != 'true'
@@ -128,6 +129,11 @@ jobs:
             .wheel-vcpkg-cache
             ~/AppData/Local/vcpkg/archives
           key: ${{ steps.windows-vcpkg-cache.outputs.cache-primary-key }}
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        env:
+          CIBW_BEFORE_ALL_WINDOWS: python -c "print('Windows wheel dependencies already installed by workflow')"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -99,7 +99,7 @@ jobs:
         shell: pwsh
         env:
           VCPKG_BINARY_SOURCES: ${{ github.event_name == 'workflow_dispatch' && format('clear;files,{0}/.wheel-vcpkg-cache,readwrite', github.workspace) || '' }}
-        run: pwsh scripts/cibuildwheel/install-deps-windows.ps1
+        run: ./scripts/cibuildwheel/install-deps-windows.ps1
 
       - name: Prune Windows vcpkg cache
         if: always() && runner.os == 'Windows'

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -88,7 +88,6 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            .wheel-vcpkg
             .wheel-vcpkg-cache
             ~/AppData/Local/vcpkg/archives
           key: pypi-windows-vcpkg-${{ hashFiles('scripts/cibuildwheel/vcpkg.json', 'scripts/cibuildwheel/install-deps-windows.ps1') }}
@@ -125,7 +124,6 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: |
-            .wheel-vcpkg
             .wheel-vcpkg-cache
             ~/AppData/Local/vcpkg/archives
           key: ${{ steps.windows-vcpkg-cache.outputs.cache-primary-key }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,5 +1,5 @@
-# Builds binary wheels and a source distribution, then publishes all artifacts to PyPI.
-# Triggered when a GitHub Release is fully published (not prerelease).
+# Builds binary wheels and a source distribution. Release-triggered runs publish
+# all artifacts to PyPI; manually dispatched runs only validate the build.
 #
 # Prerequisites (one-time setup):
 #   1. Create the "pythonscad" project on PyPI (https://pypi.org)
@@ -67,8 +67,67 @@ jobs:
             echo "${GITHUB_WORKSPACE}/.venv/bin" >> "$GITHUB_PATH"
           fi
 
+      - name: Setup MSYS2 parser tools
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2
+        with:
+          msystem: MSYS
+          update: false
+          install: >-
+            flex
+            bison
+
+      - name: Add MSYS2 parser tools to PATH
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "C:/msys64/usr/bin" >> "$GITHUB_PATH"
+
+      - name: Restore Windows vcpkg cache
+        id: windows-vcpkg-cache
+        if: github.event_name == 'workflow_dispatch' && runner.os == 'Windows'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .wheel-vcpkg
+            .wheel-vcpkg-cache
+            ~/AppData/Local/vcpkg/archives
+          key: pypi-windows-vcpkg-${{ hashFiles('scripts/cibuildwheel/vcpkg.json', 'scripts/cibuildwheel/install-deps-windows.ps1') }}
+          restore-keys: |
+            pypi-windows-vcpkg-
+
       - name: Build wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        env:
+          VCPKG_BINARY_SOURCES: ${{ github.event_name == 'workflow_dispatch' && runner.os == 'Windows' && format('clear;files,{0}/.wheel-vcpkg-cache,readwrite', github.workspace) || '' }}
+
+      - name: Prune Windows vcpkg cache
+        if: always() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          foreach ($path in @(
+            ".wheel-vcpkg\buildtrees",
+            ".wheel-vcpkg\downloads",
+            ".wheel-vcpkg\packages"
+          )) {
+            if (Test-Path $path) {
+              Remove-Item -Recurse -Force $path
+            }
+          }
+
+      - name: Save Windows vcpkg cache
+        if: >-
+          always() &&
+          github.event_name == 'workflow_dispatch' &&
+          runner.os == 'Windows' &&
+          steps.windows-vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .wheel-vcpkg
+            .wheel-vcpkg-cache
+            ~/AppData/Local/vcpkg/archives
+          key: ${{ steps.windows-vcpkg-cache.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -111,6 +170,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [build-wheels, build-sdist]
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ dist/
 .uuid
 .autoenv.zsh
 
+# Python wheel build artifacts
+.venv-wheel/
+.wheel-vcpkg-fresh/
+.wheel-vcpkg-cache/
+scripts/cibuildwheel/vcpkg_installed/
+
 # Debian packaging build artifacts
 obj-x86_64-linux-gnu/
 deb-build.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,25 +167,25 @@ Both `--hook-type` flags are required to validate both code and commit messages.
 
 ### PR Iteration Workflow
 
-When iterating on a PR (force-pushing fixes in response to review feedback or
-CI failures), always cancel the currently-running workflows for that PR
-*before* pushing. The push itself triggers a fresh set of pipeline runs, so
-letting the old run finish only burns CI minutes / GitHub Actions concurrency
-slots without any benefit.
+The repository is configured to auto-cancel superseded workflow runs on push
+and to auto-trigger a fresh Copilot review on every push (including
+force-pushes). No manual `gh run cancel` or `gh copilot-review` re-request is
+needed in the normal case — just push.
 
-The cancel-then-push pattern, using `gh`:
+Copilot's review typically starts and finishes within 2-10 minutes, well
+inside the runtime of the CI matrix. The only fallback case: if every
+required check has gone green and no Copilot review has landed at all since
+the current HEAD was pushed, request one manually:
 
 ```bash
-# 1. Cancel any in-progress runs on this PR's branch
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-gh run list --branch "$BRANCH" --status in_progress --json databaseId \
-  --jq '.[].databaseId' | xargs -r -n1 gh run cancel
-gh run list --branch "$BRANCH" --status queued --json databaseId \
-  --jq '.[].databaseId' | xargs -r -n1 gh run cancel
-
-# 2. Now push
-git push --force-with-lease
+gh copilot-review "https://github.com/$OWNER/$REPO/pull/$PR" \
+  --wait --wait-timeout 15min --wait-interval 30sec
 ```
+
+This should be rare. A completed review with zero new comments (e.g.
+"Copilot reviewed 5 out of 6 changed files in this pull request and
+generated no new comments.") counts as a completed review — don't treat "no
+comments" as "no review happened."
 
 This applies whether the push is a force-push (amend) or a fast-forward (new
 commit). The new push will start fresh runs of every required check, so the

--- a/doc/pypi-wheels.md
+++ b/doc/pypi-wheels.md
@@ -11,8 +11,8 @@ pure-Python `openscad` / `pythonscad` overlay packages (see
 | ------------ | --------------------- | ------------- |
 | `manylinux_2_28_x86_64` | `ubuntu-24.04` | cp310–cp314 |
 | `manylinux_2_28_aarch64` | `ubuntu-24.04-arm` | cp310–cp314 |
-| `macosx_11_0_x86_64` | `macos-15-intel` | cp310–cp314 |
-| `macosx_11_0_arm64` | `macos-15` | cp310–cp314 |
+| `macosx_15_0_x86_64` | `macos-15-intel` | cp310–cp314 |
+| `macosx_15_0_arm64` | `macos-15` | cp310–cp314 |
 | `win_amd64` | `windows-2022` | cp310–cp314 |
 
 One manylinux wheel covers all glibc-based Linux distributions (Debian,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,10 @@ before-build = "bash -c 'echo \"cibuildwheel CXX=$CXX\"; \"$CXX\" --version'"
 environment = { CC = "/opt/rh/gcc-toolset-12/root/usr/bin/gcc", CXX = "/opt/rh/gcc-toolset-12/root/usr/bin/g++", CXXFLAGS = "-std=c++17", PYTHONSCAD_BUILD_PARALLEL = "6" }
 
 [tool.cibuildwheel.macos]
+# Homebrew bottles on the macos-15 runners currently require a macOS 15 target.
 environment = { MACOSX_DEPLOYMENT_TARGET = "15.0", PYTHONSCAD_BUILD_PARALLEL = "6" }
 before-all = "bash scripts/cibuildwheel/install-deps-macos.sh"
+repair-wheel-command = "DYLD_LIBRARY_PATH=\"$(brew --prefix)/lib\" delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]
 environment = { VCPKG_DEFAULT_TRIPLET = "x64-windows-release", PYTHONSCAD_BUILD_PARALLEL = "6" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ before-all = "bash scripts/cibuildwheel/install-deps-macos.sh"
 repair-wheel-command = "DYLD_LIBRARY_PATH=\"$(brew --prefix)/lib\" delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]
+# x64-windows-release is a vcpkg community triplet in the pinned vcpkg baseline.
 environment = { VCPKG_DEFAULT_TRIPLET = "x64-windows-release", PYTHONSCAD_BUILD_PARALLEL = "6" }
 before-all = "pwsh scripts/cibuildwheel/install-deps-windows.ps1"
 repair-wheel-command = "pwsh scripts/cibuildwheel/repair-wheel-windows.ps1 -Wheel {wheel} -DestDir {dest_dir}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ before-build = "bash -c 'echo \"cibuildwheel CXX=$CXX\"; \"$CXX\" --version'"
 environment = { CC = "/opt/rh/gcc-toolset-12/root/usr/bin/gcc", CXX = "/opt/rh/gcc-toolset-12/root/usr/bin/g++", CXXFLAGS = "-std=c++17", PYTHONSCAD_BUILD_PARALLEL = "6" }
 
 [tool.cibuildwheel.macos]
-environment = { MACOSX_DEPLOYMENT_TARGET = "11.0", PYTHONSCAD_BUILD_PARALLEL = "6" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "15.0", PYTHONSCAD_BUILD_PARALLEL = "6" }
 before-all = "bash scripts/cibuildwheel/install-deps-macos.sh"
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ Changelog = "https://github.com/pythonscad/pythonscad/blob/master/CHANGELOG.md"
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
-skip = ["*-musllinux*", "*-win32*", "*-win_arm64*", "cp*t-*", "pp*"]
+skip = ["*-musllinux*", "*-win32*", "*-win_arm64*", "cp*t-*"]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,25 +80,18 @@ skip = ["*-musllinux*", "*-win32*", "*-win_arm64*", "cp*t-*", "pp*"]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 build-frontend = "build"
-# cibuildwheel splits test-requires on ';', so PEP 508 markers must
-# use [[tool.cibuildwheel.overrides]] instead of inline markers here.
-test-requires = ["ipython>=9,<10"]
 test-command = "python {project}/scripts/smoke-test-pip.py"
-
-[[tool.cibuildwheel.overrides]]
-select = "cp310-*"
-test-requires = ["ipython>=8,<9"]
 
 [tool.cibuildwheel.linux]
 before-all = "bash scripts/cibuildwheel/install-deps-manylinux.sh"
 before-build = "bash -c 'echo \"cibuildwheel CXX=$CXX\"; \"$CXX\" --version'"
-environment = { CC = "/opt/rh/gcc-toolset-12/root/usr/bin/gcc", CXX = "/opt/rh/gcc-toolset-12/root/usr/bin/g++", CXXFLAGS = "-std=c++17" }
+environment = { CC = "/opt/rh/gcc-toolset-12/root/usr/bin/gcc", CXX = "/opt/rh/gcc-toolset-12/root/usr/bin/g++", CXXFLAGS = "-std=c++17", PYTHONSCAD_BUILD_PARALLEL = "6" }
 
 [tool.cibuildwheel.macos]
-environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0", PYTHONSCAD_BUILD_PARALLEL = "6" }
 before-all = "bash scripts/cibuildwheel/install-deps-macos.sh"
 
 [tool.cibuildwheel.windows]
-environment = { VCPKG_DEFAULT_TRIPLET = "x64-windows" }
+environment = { VCPKG_DEFAULT_TRIPLET = "x64-windows-release", PYTHONSCAD_BUILD_PARALLEL = "6" }
 before-all = "pwsh scripts/cibuildwheel/install-deps-windows.ps1"
 repair-wheel-command = "pwsh scripts/cibuildwheel/repair-wheel-windows.ps1 -Wheel {wheel} -DestDir {dest_dir}"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,40 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update the vcpkg release tag used by Windows PyPI wheel builds.",
+      "managerFilePatterns": [
+        "/^scripts/cibuildwheel/install-deps-windows\\.ps1$/"
+      ],
+      "matchStrings": [
+        "\\$VcpkgVersion = \"(?<currentValue>\\d{4}\\.\\d{2}\\.\\d{2})\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "microsoft/vcpkg",
+      "versioningTemplate": "loose"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "microsoft/vcpkg"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "python3 scripts/cibuildwheel/update-vcpkg-baseline.py"
+        ],
+        "fileFilters": [
+          "scripts/cibuildwheel/install-deps-windows.ps1",
+          "scripts/cibuildwheel/vcpkg.json"
+        ],
+        "executionMode": "update"
+      }
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "customType": "regex",
       "description": "Update the vcpkg release tag used by Windows PyPI wheel builds.",
       "managerFilePatterns": [
-        "/^scripts/cibuildwheel/install-deps-windows\\.ps1$/"
+        "^scripts/cibuildwheel/install-deps-windows\\.ps1$"
       ],
       "matchStrings": [
         "\\$VcpkgVersion = \"(?<currentValue>\\d{4}\\.\\d{2}\\.\\d{2})\""

--- a/scripts/cibuildwheel/install-deps-macos.sh
+++ b/scripts/cibuildwheel/install-deps-macos.sh
@@ -4,8 +4,32 @@
 set -euo pipefail
 
 echo "=== install-deps-macos.sh: installing pip wheel build deps ==="
+PROJECT_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
 
 # Homebrew is preinstalled on GitHub-hosted macOS runners.
 ./scripts/get-dependencies.py --yes --profile pythonscad-pip
+
+if ! pkg-config --exists lib3mf; then
+    echo "lib3mf unavailable from Homebrew; building lib3mf from source"
+    LIB3MF_VERSION=2.4.1
+    LIB3MF_SRC="/tmp/lib3mf-${LIB3MF_VERSION}"
+    BREW_PREFIX="$(brew --prefix)"
+    rm -rf "$LIB3MF_SRC"
+    curl -L "https://github.com/3MFConsortium/lib3mf/archive/v${LIB3MF_VERSION}.tar.gz" \
+        -o "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
+    tar -C /tmp -xzf "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
+    cd "$LIB3MF_SRC"
+    patch -p1 < "$PROJECT_ROOT/patches/lib3mf-macos.patch"
+    cmake -S . -B build \
+        -DLIB3MF_TESTS=OFF \
+        -DUSE_INCLUDED_ZLIB=OFF \
+        -DUSE_INCLUDED_LIBZIP=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$BREW_PREFIX" \
+        -DCMAKE_INSTALL_LIBDIR=lib
+    cmake --build build -j"$(sysctl -n hw.ncpu)"
+    cmake --install build
+    cd "$PROJECT_ROOT"
+fi
 
 echo "=== install-deps-macos.sh: done ==="

--- a/scripts/cibuildwheel/install-deps-macos.sh
+++ b/scripts/cibuildwheel/install-deps-macos.sh
@@ -29,6 +29,10 @@ if ! pkg-config --exists lib3mf; then
         -DCMAKE_INSTALL_LIBDIR=lib
     cmake --build build -j"$(sysctl -n hw.ncpu)"
     cmake --install build
+    mkdir -p "$BREW_PREFIX/lib/pkgconfig"
+    cp -a "$LIB3MF_SRC"/lib/lib3mf*.dylib "$BREW_PREFIX/lib/"
+    cp "$LIB3MF_SRC/lib/pkgconfig/lib3mf.pc" "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc"
+    sed -i.bak "s|^prefix=.*|prefix=$BREW_PREFIX|" "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc"
     cd "$PROJECT_ROOT"
 fi
 

--- a/scripts/cibuildwheel/install-deps-macos.sh
+++ b/scripts/cibuildwheel/install-deps-macos.sh
@@ -30,8 +30,16 @@ if ! pkg-config --exists lib3mf; then
     cmake --build build -j"$(sysctl -n hw.ncpu)"
     cmake --install build
     mkdir -p "$BREW_PREFIX/lib/pkgconfig"
-    cp -a "$LIB3MF_SRC"/lib/lib3mf*.dylib "$BREW_PREFIX/lib/"
-    cp "$LIB3MF_SRC/lib/pkgconfig/lib3mf.pc" "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc"
+    if ! compgen -G "$BREW_PREFIX/lib/lib3mf*.dylib" >/dev/null; then
+        echo "lib3mf install did not produce dylibs under $BREW_PREFIX/lib" >&2
+        exit 1
+    fi
+    if [[ -f "$LIB3MF_SRC/lib/pkgconfig/lib3mf.pc" ]]; then
+        cp "$LIB3MF_SRC/lib/pkgconfig/lib3mf.pc" "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc"
+    elif [[ ! -f "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc" ]]; then
+        echo "lib3mf install did not provide lib3mf.pc" >&2
+        exit 1
+    fi
     sed -i.bak "s|^prefix=.*|prefix=$BREW_PREFIX|" "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc"
     cd "$PROJECT_ROOT"
 fi

--- a/scripts/cibuildwheel/install-deps-macos.sh
+++ b/scripts/cibuildwheel/install-deps-macos.sh
@@ -15,7 +15,8 @@ if ! pkg-config --exists lib3mf; then
     LIB3MF_SRC="/tmp/lib3mf-${LIB3MF_VERSION}"
     BREW_PREFIX="$(brew --prefix)"
     rm -rf "$LIB3MF_SRC"
-    curl -L "https://github.com/3MFConsortium/lib3mf/archive/v${LIB3MF_VERSION}.tar.gz" \
+    curl --fail --show-error --retry 3 --retry-delay 5 -L \
+        "https://github.com/3MFConsortium/lib3mf/archive/v${LIB3MF_VERSION}.tar.gz" \
         -o "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
     tar -C /tmp -xzf "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
     cd "$LIB3MF_SRC"

--- a/scripts/cibuildwheel/install-deps-macos.sh
+++ b/scripts/cibuildwheel/install-deps-macos.sh
@@ -48,7 +48,7 @@ if ! pkg-config --exists lib3mf; then
         echo "lib3mf install did not provide lib3mf.pc" >&2
         exit 1
     fi
-    sed -i.bak "s|^prefix=.*|prefix=$BREW_PREFIX|" "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc"
+    sed -i '' "s|^prefix=.*|prefix=$BREW_PREFIX|" "$BREW_PREFIX/lib/pkgconfig/lib3mf.pc"
     cd "$PROJECT_ROOT"
 fi
 

--- a/scripts/cibuildwheel/install-deps-macos.sh
+++ b/scripts/cibuildwheel/install-deps-macos.sh
@@ -30,6 +30,14 @@ if ! pkg-config --exists lib3mf; then
     cmake --build build -j"$(sysctl -n hw.ncpu)"
     cmake --install build
     mkdir -p "$BREW_PREFIX/lib/pkgconfig"
+    shopt -s nullglob
+    lib3mf_dylibs=("$LIB3MF_SRC"/lib/lib3mf*.dylib)
+    shopt -u nullglob
+    if (( ${#lib3mf_dylibs[@]} == 0 )); then
+        echo "lib3mf build did not produce dylibs under $LIB3MF_SRC/lib" >&2
+        exit 1
+    fi
+    cp -a "${lib3mf_dylibs[@]}" "$BREW_PREFIX/lib/"
     if ! compgen -G "$BREW_PREFIX/lib/lib3mf*.dylib" >/dev/null; then
         echo "lib3mf install did not produce dylibs under $BREW_PREFIX/lib" >&2
         exit 1

--- a/scripts/cibuildwheel/install-deps-manylinux.sh
+++ b/scripts/cibuildwheel/install-deps-manylinux.sh
@@ -52,7 +52,8 @@ if ! $PKG_MGR install -y lib3mf-devel; then
     LIB3MF_VERSION=2.4.1
     LIB3MF_SRC="/tmp/lib3mf-${LIB3MF_VERSION}"
     rm -rf "$LIB3MF_SRC"
-    curl -L "https://github.com/3MFConsortium/lib3mf/archive/v${LIB3MF_VERSION}.tar.gz" \
+    curl --fail --show-error --retry 3 --retry-delay 5 -L \
+        "https://github.com/3MFConsortium/lib3mf/archive/v${LIB3MF_VERSION}.tar.gz" \
         -o "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
     tar -C /tmp -xzf "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
     cd "$LIB3MF_SRC"

--- a/scripts/cibuildwheel/install-deps-manylinux.sh
+++ b/scripts/cibuildwheel/install-deps-manylinux.sh
@@ -33,6 +33,7 @@ $PKG_MGR install -y \
     glib2-devel \
     gmp-devel \
     harfbuzz-devel \
+    lib3mf-devel \
     libxml2-devel \
     mpfr-devel \
     pkgconfig

--- a/scripts/cibuildwheel/install-deps-manylinux.sh
+++ b/scripts/cibuildwheel/install-deps-manylinux.sh
@@ -62,7 +62,8 @@ if ! $PKG_MGR install -y lib3mf-devel; then
         -DUSE_INCLUDED_ZLIB=OFF \
         -DUSE_INCLUDED_LIBZIP=OFF \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/local
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib64
     cmake --build build -j"$(nproc)"
     cmake --install build
     ldconfig

--- a/scripts/cibuildwheel/install-deps-manylinux.sh
+++ b/scripts/cibuildwheel/install-deps-manylinux.sh
@@ -23,6 +23,8 @@ $PKG_MGR install -y \
     boost-devel \
     cairo-devel \
     CGAL-devel \
+    cmake \
+    curl \
     double-conversion-devel \
     eigen3-devel \
     flex \
@@ -33,10 +35,34 @@ $PKG_MGR install -y \
     glib2-devel \
     gmp-devel \
     harfbuzz-devel \
-    lib3mf-devel \
+    libzip-devel \
     libxml2-devel \
+    make \
     mpfr-devel \
+    patch \
     pkgconfig
+
+if ! $PKG_MGR install -y lib3mf-devel; then
+    echo "lib3mf-devel unavailable from EL8 repos; building lib3mf from source"
+    LIB3MF_VERSION=2.4.1
+    LIB3MF_SRC="/tmp/lib3mf-${LIB3MF_VERSION}"
+    rm -rf "$LIB3MF_SRC"
+    curl -L "https://github.com/3MFConsortium/lib3mf/archive/v${LIB3MF_VERSION}.tar.gz" \
+        -o "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
+    tar -C /tmp -xzf "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
+    cd "$LIB3MF_SRC"
+    patch -p1 < /project/patches/lib3mf-macos.patch
+    cmake -S . -B build \
+        -DLIB3MF_TESTS=OFF \
+        -DUSE_INCLUDED_ZLIB=OFF \
+        -DUSE_INCLUDED_LIBZIP=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local
+    cmake --build build -j"$(nproc)"
+    cmake --install build
+    ldconfig
+    cd /project
+fi
 
 # libfive fails to compile with GCC 14's stricter C++ diagnostics; use GCC 12.
 $PKG_MGR install -y gcc-toolset-12

--- a/scripts/cibuildwheel/install-deps-manylinux.sh
+++ b/scripts/cibuildwheel/install-deps-manylinux.sh
@@ -56,6 +56,7 @@ if ! $PKG_MGR install -y lib3mf-devel; then
         -o "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
     tar -C /tmp -xzf "/tmp/lib3mf-${LIB3MF_VERSION}.tar.gz"
     cd "$LIB3MF_SRC"
+    # The patch removes non-portable compiler/linker assumptions and applies to manylinux too.
     patch -p1 < /project/patches/lib3mf-macos.patch
     cmake -S . -B build \
         -DLIB3MF_TESTS=OFF \

--- a/scripts/cibuildwheel/install-deps-manylinux.sh
+++ b/scripts/cibuildwheel/install-deps-manylinux.sh
@@ -42,6 +42,11 @@ $PKG_MGR install -y \
     patch \
     pkgconfig
 
+# cibuildwheel exports CC/CXX to gcc-toolset-12 before running before-all,
+# so install it before any source-built fallback dependencies invoke CMake.
+$PKG_MGR install -y gcc-toolset-12
+/opt/rh/gcc-toolset-12/root/usr/bin/g++ --version
+
 if ! $PKG_MGR install -y lib3mf-devel; then
     echo "lib3mf-devel unavailable from EL8 repos; building lib3mf from source"
     LIB3MF_VERSION=2.4.1
@@ -63,10 +68,6 @@ if ! $PKG_MGR install -y lib3mf-devel; then
     ldconfig
     cd /project
 fi
-
-# libfive fails to compile with GCC 14's stricter C++ diagnostics; use GCC 12.
-$PKG_MGR install -y gcc-toolset-12
-/opt/rh/gcc-toolset-12/root/usr/bin/g++ --version
 
 # libfive tree.cpp uses std::optional without including <optional>; EL8 libstdc++
 # does not pull it in transitively.

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -41,6 +41,40 @@ function Get-BoostRegexLibFiles {
     )
 }
 
+function Remove-VcpkgBinaryArchivesContainingPath {
+    param(
+        [string]$CacheRoot,
+        [string]$Needle
+    )
+    if (-not (Test-Path $CacheRoot)) {
+        return
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    Get-ChildItem -Path $CacheRoot -Recurse -File -Include "*.zip", "*.nupkg" -ErrorAction SilentlyContinue | ForEach-Object {
+        $Archive = $_
+        $Zip = $null
+        try {
+            $Zip = [IO.Compression.ZipFile]::OpenRead($Archive.FullName)
+            $ContainsNeedle = $Zip.Entries | Where-Object {
+                $_.FullName.Replace("\", "/").Contains($Needle)
+            } | Select-Object -First 1
+            if ($ContainsNeedle) {
+                Write-Host "Removing stale vcpkg binary archive $($Archive.FullName)"
+                $Zip.Dispose()
+                $Zip = $null
+                Remove-Item -Force $Archive.FullName
+            }
+        } catch {
+            Write-Host "Could not inspect vcpkg binary archive $($Archive.FullName): $_"
+        } finally {
+            if ($null -ne $Zip) {
+                $Zip.Dispose()
+            }
+        }
+    }
+}
+
 $ProjectRoot = if ($env:CIBW_PROJECT_DIR) {
     $env:CIBW_PROJECT_DIR
 } elseif ($env:GITHUB_WORKSPACE) {
@@ -145,7 +179,9 @@ try {
 $BoostRegexLibFiles = Get-BoostRegexLibFiles $Installed
 if ($BoostRegexLibFiles.Count -eq 0) {
     $InstallRoot = Join-Path $VcpkgRoot "installed"
-    Write-Host "boost-regex is marked installed but no Boost regex import library was found; removing stale vcpkg installed tree"
+    $BinaryCacheRoot = Join-Path $ProjectRoot ".wheel-vcpkg-cache"
+    Write-Host "boost-regex is marked installed but no Boost regex import library was found; removing stale vcpkg installed tree and cached boost-regex archive"
+    Remove-VcpkgBinaryArchivesContainingPath $BinaryCacheRoot "share/boost-regex/"
     if (Test-Path $InstallRoot) {
         Remove-Item -Recurse -Force $InstallRoot
     }

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -142,48 +142,49 @@ try {
     Pop-Location
 }
 
-$BoostRegexLibFiles = Get-BoostRegexLibFiles $Installed
-
 $PkgConfigDir = Join-Path $Installed "lib" "pkgconfig"
 $PkgConfExe = Join-Path $Installed "tools" "pkgconf" "pkgconf.exe"
 
 #region agent log
-$DebugPayload = [ordered]@{
-    sessionId = "ea88a1"
-    runId = if ($env:GITHUB_RUN_ID) { $env:GITHUB_RUN_ID } else { "local" }
-    hypothesisId = "A,B"
-    location = "scripts/cibuildwheel/install-deps-windows.ps1:vcpkg_snapshot"
-    message = "Snapshot Windows vcpkg library files after install"
-    data = [ordered]@{
-        installed = $Installed
-        libExists = Test-Path (Join-Path $Installed "lib")
-        manualLinkExists = Test-Path (Join-Path $Installed "lib" "manual-link")
-        boostRegexLibFiles = @(
-            Get-ChildItem -Path (Join-Path $Installed "lib") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
-                Select-Object -ExpandProperty Name
-        )
-        boostRegexManualLinkFiles = @(
-            Get-ChildItem -Path (Join-Path $Installed "lib" "manual-link") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
-                Select-Object -ExpandProperty Name
-        )
-        boostRegexPkgConfigFiles = @(
-            Get-ChildItem -Path $PkgConfigDir -Filter "*boost*regex*.pc" -ErrorAction SilentlyContinue |
-                Select-Object -ExpandProperty Name
-        )
-        boostRegexShareFiles = @(
-            Get-ChildItem -Path (Join-Path $Installed "share" "boost-regex") -Recurse -File -ErrorAction SilentlyContinue |
-                ForEach-Object { $_.FullName.Substring($Installed.Length + 1) }
-        )
-        boostRegexHeaderFiles = @(
-            Get-ChildItem -Path (Join-Path $Installed "include" "boost") -Filter "regex*" -ErrorAction SilentlyContinue |
-                Select-Object -ExpandProperty Name
-        )
+if ($env:PYTHONSCAD_WHEEL_DEBUG -eq "1") {
+    $DebugPayload = [ordered]@{
+        sessionId = "ea88a1"
+        runId = if ($env:GITHUB_RUN_ID) { $env:GITHUB_RUN_ID } else { "local" }
+        hypothesisId = "A,B"
+        location = "scripts/cibuildwheel/install-deps-windows.ps1:vcpkg_snapshot"
+        message = "Snapshot Windows vcpkg library files after install"
+        data = [ordered]@{
+            installed = $Installed
+            libExists = Test-Path (Join-Path $Installed "lib")
+            manualLinkExists = Test-Path (Join-Path $Installed "lib" "manual-link")
+            boostRegexLibFiles = @(
+                Get-ChildItem -Path (Join-Path $Installed "lib") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
+                    Select-Object -ExpandProperty Name
+            )
+            boostRegexManualLinkFiles = @(
+                Get-ChildItem -Path (Join-Path $Installed "lib" "manual-link") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
+                    Select-Object -ExpandProperty Name
+            )
+            boostRegexPkgConfigFiles = @(
+                Get-ChildItem -Path $PkgConfigDir -Filter "*boost*regex*.pc" -ErrorAction SilentlyContinue |
+                    Select-Object -ExpandProperty Name
+            )
+            boostRegexShareFiles = @(
+                Get-ChildItem -Path (Join-Path $Installed "share" "boost-regex") -Recurse -File -ErrorAction SilentlyContinue |
+                    ForEach-Object { $_.FullName.Substring($Installed.Length + 1) }
+            )
+            boostRegexHeaderFiles = @(
+                Get-ChildItem -Path (Join-Path $Installed "include" "boost") -Filter "regex*" -ErrorAction SilentlyContinue |
+                    Select-Object -ExpandProperty Name
+            )
+        }
+        timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
     }
-    timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+    $DebugJson = $DebugPayload | ConvertTo-Json -Depth 5 -Compress
+    $DebugRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+    Add-Content -Encoding utf8 -Path (Join-Path $DebugRoot "debug-ea88a1.log") -Value $DebugJson
+    Write-Host "AGENT_DEBUG $DebugJson"
 }
-$DebugJson = $DebugPayload | ConvertTo-Json -Depth 5 -Compress
-Add-Content -Encoding utf8 -Path (Join-Path $ProjectRoot "debug-ea88a1.log") -Value $DebugJson
-Write-Host "AGENT_DEBUG $DebugJson"
 #endregion
 
 # before-all runs in a separate process; persist env for setup.py and repair-wheel.

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -67,6 +67,8 @@ if (-not $BisonExe -or -not $FlexExe) {
 # Pin vcpkg to a release tag for reproducible builds (see vcpkg.json builtin-baseline).
 $VcpkgVersion = "2025.04.09"
 $VcpkgRoot = Join-Path $ProjectRoot ".wheel-vcpkg"
+$ManifestDir = Join-Path $ProjectRoot "scripts/cibuildwheel"
+$VcpkgManifest = Join-Path $ManifestDir "vcpkg.json"
 
 if (-not (Test-Path $VcpkgRoot)) {
     git clone --depth 1 --branch $VcpkgVersion `
@@ -84,13 +86,24 @@ if (-not (Test-Path $VcpkgRoot)) {
     }
 }
 
+$ManifestBaseline = ((Get-Content $VcpkgManifest -Raw) | ConvertFrom-Json)."builtin-baseline"
+Push-Location $VcpkgRoot
+try {
+    $CheckedOutCommit = (git rev-parse HEAD).Trim()
+    Assert-NativeCommandSucceeded "git rev-parse vcpkg HEAD"
+} finally {
+    Pop-Location
+}
+if ($ManifestBaseline -ne $CheckedOutCommit) {
+    throw "vcpkg tag $VcpkgVersion resolves to $CheckedOutCommit, but vcpkg.json builtin-baseline is $ManifestBaseline. Update both pins together."
+}
+
 $VcpkgExe = Join-Path $VcpkgRoot "vcpkg.exe"
 if (-not (Test-Path $VcpkgExe)) {
     & (Join-Path $VcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
     Assert-NativeCommandSucceeded "bootstrap vcpkg"
 }
 
-$ManifestDir = Join-Path $ProjectRoot "scripts/cibuildwheel"
 $Triplet = "x64-windows-release"
 $HostTriplet = "x64-windows-release"
 

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -31,16 +31,6 @@ function Remove-Msys2PathEntries {
     }) -join $Separator
 }
 
-function Get-BoostRegexLibFiles {
-    param([string]$Installed)
-    @(
-        Get-ChildItem -Path (Join-Path $Installed "lib") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
-            Select-Object -ExpandProperty FullName
-        Get-ChildItem -Path (Join-Path $Installed "lib" "manual-link") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
-            Select-Object -ExpandProperty FullName
-    )
-}
-
 $ProjectRoot = if ($env:CIBW_PROJECT_DIR) {
     $env:CIBW_PROJECT_DIR
 } elseif ($env:GITHUB_WORKSPACE) {
@@ -200,6 +190,7 @@ $EnvLines = @(
     "MSYS2_USR_BIN=$MsysUsrBin",
     "PYTHONSCAD_WHEEL_DEBUG=$env:PYTHONSCAD_WHEEL_DEBUG"
 )
-$EnvLines | Set-Content -Encoding utf8 $EnvFile
+$Utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllLines($EnvFile, $EnvLines, $Utf8NoBom)
 
 Write-Host "=== install-deps-windows.ps1: done (vcpkg root: $VcpkgRoot) ==="

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -41,40 +41,6 @@ function Get-BoostRegexLibFiles {
     )
 }
 
-function Remove-VcpkgBinaryArchivesContainingPath {
-    param(
-        [string]$CacheRoot,
-        [string]$Needle
-    )
-    if (-not (Test-Path $CacheRoot)) {
-        return
-    }
-
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    Get-ChildItem -Path $CacheRoot -Recurse -File -Include "*.zip", "*.nupkg" -ErrorAction SilentlyContinue | ForEach-Object {
-        $Archive = $_
-        $Zip = $null
-        try {
-            $Zip = [IO.Compression.ZipFile]::OpenRead($Archive.FullName)
-            $ContainsNeedle = $Zip.Entries | Where-Object {
-                $_.FullName.Replace("\", "/").Contains($Needle)
-            } | Select-Object -First 1
-            if ($ContainsNeedle) {
-                Write-Host "Removing stale vcpkg binary archive $($Archive.FullName)"
-                $Zip.Dispose()
-                $Zip = $null
-                Remove-Item -Force $Archive.FullName
-            }
-        } catch {
-            Write-Host "Could not inspect vcpkg binary archive $($Archive.FullName): $_"
-        } finally {
-            if ($null -ne $Zip) {
-                $Zip.Dispose()
-            }
-        }
-    }
-}
-
 $ProjectRoot = if ($env:CIBW_PROJECT_DIR) {
     $env:CIBW_PROJECT_DIR
 } elseif ($env:GITHUB_WORKSPACE) {
@@ -177,35 +143,6 @@ try {
 }
 
 $BoostRegexLibFiles = Get-BoostRegexLibFiles $Installed
-if ($BoostRegexLibFiles.Count -eq 0) {
-    $InstallRoot = Join-Path $VcpkgRoot "installed"
-    $BinaryCacheRoot = Join-Path $ProjectRoot ".wheel-vcpkg-cache"
-    Write-Host "boost-regex is marked installed but no Boost regex import library was found; removing stale vcpkg installed tree and cached boost-regex archive"
-    Remove-VcpkgBinaryArchivesContainingPath $BinaryCacheRoot "share/boost-regex/"
-    if (Test-Path $InstallRoot) {
-        Remove-Item -Recurse -Force $InstallRoot
-    }
-    Push-Location $ManifestDir
-    try {
-        $OriginalPath = $env:PATH
-        $env:PATH = Remove-Msys2PathEntries $env:PATH
-        & $VcpkgExe install `
-            --triplet $Triplet `
-            --host-triplet $HostTriplet `
-            --x-manifest-root $ManifestDir `
-            --x-install-root $InstallRoot
-        Assert-NativeCommandSucceeded "vcpkg reinstall after boost-regex repair"
-    } finally {
-        if ($null -ne $OriginalPath) {
-            $env:PATH = $OriginalPath
-        }
-        Pop-Location
-    }
-    $BoostRegexLibFiles = Get-BoostRegexLibFiles $Installed
-    if ($BoostRegexLibFiles.Count -eq 0) {
-        throw "vcpkg boost-regex repair completed, but no Boost regex import library exists under $Installed"
-    }
-}
 
 $PkgConfigDir = Join-Path $Installed "lib" "pkgconfig"
 $PkgConfExe = Join-Path $Installed "tools" "pkgconf" "pkgconf.exe"
@@ -231,6 +168,14 @@ $DebugPayload = [ordered]@{
         )
         boostRegexPkgConfigFiles = @(
             Get-ChildItem -Path $PkgConfigDir -Filter "*boost*regex*.pc" -ErrorAction SilentlyContinue |
+                Select-Object -ExpandProperty Name
+        )
+        boostRegexShareFiles = @(
+            Get-ChildItem -Path (Join-Path $Installed "share" "boost-regex") -Recurse -File -ErrorAction SilentlyContinue |
+                ForEach-Object { $_.FullName.Substring($Installed.Length + 1) }
+        )
+        boostRegexHeaderFiles = @(
+            Get-ChildItem -Path (Join-Path $Installed "include" "boost") -Filter "regex*" -ErrorAction SilentlyContinue |
                 Select-Object -ExpandProperty Name
         )
     }

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -68,17 +68,13 @@ $VcpkgVersion = "2025.04.09"
 $VcpkgRoot = Join-Path $ProjectRoot ".wheel-vcpkg"
 
 if (-not (Test-Path $VcpkgRoot)) {
-    git clone --branch $VcpkgVersion `
+    git clone --depth 1 --branch $VcpkgVersion `
         https://github.com/microsoft/vcpkg.git $VcpkgRoot
     Assert-NativeCommandSucceeded "git clone vcpkg"
 } else {
     Push-Location $VcpkgRoot
     try {
-        if (Test-Path ".git/shallow") {
-            git fetch --unshallow origin
-            Assert-NativeCommandSucceeded "git unshallow vcpkg"
-        }
-        git fetch origin "refs/tags/${VcpkgVersion}:refs/tags/${VcpkgVersion}"
+        git fetch --depth 1 origin "refs/tags/${VcpkgVersion}:refs/tags/${VcpkgVersion}"
         Assert-NativeCommandSucceeded "git fetch vcpkg tag"
         git checkout $VcpkgVersion
         Assert-NativeCommandSucceeded "git checkout vcpkg tag"

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -135,48 +135,6 @@ try {
 $PkgConfigDir = Join-Path $Installed "lib" "pkgconfig"
 $PkgConfExe = Join-Path $Installed "tools" "pkgconf" "pkgconf.exe"
 
-#region agent log
-if ($env:PYTHONSCAD_WHEEL_DEBUG -eq "1") {
-    $DebugPayload = [ordered]@{
-        sessionId = "ea88a1"
-        runId = if ($env:GITHUB_RUN_ID) { $env:GITHUB_RUN_ID } else { "local" }
-        hypothesisId = "A,B"
-        location = "scripts/cibuildwheel/install-deps-windows.ps1:vcpkg_snapshot"
-        message = "Snapshot Windows vcpkg library files after install"
-        data = [ordered]@{
-            installed = $Installed
-            libExists = Test-Path (Join-Path $Installed "lib")
-            manualLinkExists = Test-Path (Join-Path $Installed "lib" "manual-link")
-            boostRegexLibFiles = @(
-                Get-ChildItem -Path (Join-Path $Installed "lib") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
-                    Select-Object -ExpandProperty Name
-            )
-            boostRegexManualLinkFiles = @(
-                Get-ChildItem -Path (Join-Path $Installed "lib" "manual-link") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
-                    Select-Object -ExpandProperty Name
-            )
-            boostRegexPkgConfigFiles = @(
-                Get-ChildItem -Path $PkgConfigDir -Filter "*boost*regex*.pc" -ErrorAction SilentlyContinue |
-                    Select-Object -ExpandProperty Name
-            )
-            boostRegexShareFiles = @(
-                Get-ChildItem -Path (Join-Path $Installed "share" "boost-regex") -Recurse -File -ErrorAction SilentlyContinue |
-                    ForEach-Object { $_.FullName.Substring($Installed.Length + 1) }
-            )
-            boostRegexHeaderFiles = @(
-                Get-ChildItem -Path (Join-Path $Installed "include" "boost") -Filter "regex*" -ErrorAction SilentlyContinue |
-                    Select-Object -ExpandProperty Name
-            )
-        }
-        timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
-    }
-    $DebugJson = $DebugPayload | ConvertTo-Json -Depth 5 -Compress
-    $DebugRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
-    Add-Content -Encoding utf8 -Path (Join-Path $DebugRoot "debug-ea88a1.log") -Value $DebugJson
-    Write-Host "AGENT_DEBUG $DebugJson"
-}
-#endregion
-
 # before-all runs in a separate process; persist env for setup.py and repair-wheel.
 $EnvFile = Join-Path $ProjectRoot "scripts/cibuildwheel/wheel-build-env.env"
 $EnvLines = @(
@@ -187,8 +145,7 @@ $EnvLines = @(
     "PKG_CONFIG=$PkgConfExe",
     "BISON=$BisonExe",
     "FLEX=$FlexExe",
-    "MSYS2_USR_BIN=$MsysUsrBin",
-    "PYTHONSCAD_WHEEL_DEBUG=$env:PYTHONSCAD_WHEEL_DEBUG"
+    "MSYS2_USR_BIN=$MsysUsrBin"
 )
 $Utf8NoBom = New-Object System.Text.UTF8Encoding $false
 [System.IO.File]::WriteAllLines($EnvFile, $EnvLines, $Utf8NoBom)

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -111,6 +111,7 @@ if (-not (Test-Path $VcpkgExe)) {
     Assert-NativeCommandSucceeded "bootstrap vcpkg"
 }
 
+# Use vcpkg's pinned community release triplet; keep this in sync with pyproject.toml.
 $Triplet = "x64-windows-release"
 $HostTriplet = "x64-windows-release"
 $Installed = Join-Path $VcpkgRoot "installed" $Triplet

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -31,6 +31,16 @@ function Remove-Msys2PathEntries {
     }) -join $Separator
 }
 
+function Get-BoostRegexLibFiles {
+    param([string]$Installed)
+    @(
+        Get-ChildItem -Path (Join-Path $Installed "lib") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName
+        Get-ChildItem -Path (Join-Path $Installed "lib" "manual-link") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName
+    )
+}
+
 $ProjectRoot = if ($env:CIBW_PROJECT_DIR) {
     $env:CIBW_PROJECT_DIR
 } elseif ($env:GITHUB_WORKSPACE) {
@@ -113,6 +123,7 @@ if (-not (Test-Path $VcpkgExe)) {
 
 $Triplet = "x64-windows-release"
 $HostTriplet = "x64-windows-release"
+$Installed = Join-Path $VcpkgRoot "installed" $Triplet
 
 Push-Location $ManifestDir
 try {
@@ -131,7 +142,33 @@ try {
     Pop-Location
 }
 
-$Installed = Join-Path $VcpkgRoot "installed" $Triplet
+$BoostRegexLibFiles = Get-BoostRegexLibFiles $Installed
+if ($BoostRegexLibFiles.Count -eq 0) {
+    Write-Host "boost-regex is marked installed but no Boost regex import library was found; reinstalling boost-regex"
+    & $VcpkgExe remove "boost-regex:${Triplet}" --recurse
+    Assert-NativeCommandSucceeded "vcpkg remove boost-regex"
+    Push-Location $ManifestDir
+    try {
+        $OriginalPath = $env:PATH
+        $env:PATH = Remove-Msys2PathEntries $env:PATH
+        & $VcpkgExe install `
+            --triplet $Triplet `
+            --host-triplet $HostTriplet `
+            --x-manifest-root $ManifestDir `
+            --x-install-root (Join-Path $VcpkgRoot "installed")
+        Assert-NativeCommandSucceeded "vcpkg reinstall after boost-regex repair"
+    } finally {
+        if ($null -ne $OriginalPath) {
+            $env:PATH = $OriginalPath
+        }
+        Pop-Location
+    }
+    $BoostRegexLibFiles = Get-BoostRegexLibFiles $Installed
+    if ($BoostRegexLibFiles.Count -eq 0) {
+        throw "vcpkg boost-regex repair completed, but no Boost regex import library exists under $Installed"
+    }
+}
+
 $PkgConfigDir = Join-Path $Installed "lib" "pkgconfig"
 $PkgConfExe = Join-Path $Installed "tools" "pkgconf" "pkgconf.exe"
 

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -4,6 +4,32 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "=== install-deps-windows.ps1: bootstrapping vcpkg ==="
 
+function Assert-NativeCommandSucceeded {
+    param([string]$Description)
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Get-ExistingPath {
+    param([string[]]$Candidates)
+    foreach ($Candidate in $Candidates) {
+        if (Test-Path $Candidate) {
+            return $Candidate
+        }
+    }
+    return $null
+}
+
+function Remove-Msys2PathEntries {
+    param([string]$PathValue)
+    $MsysRoot = "C:\msys64\"
+    $Separator = [IO.Path]::PathSeparator
+    (($PathValue -split [Regex]::Escape($Separator)) | Where-Object {
+        $_ -and -not $_.StartsWith($MsysRoot, [StringComparison]::OrdinalIgnoreCase)
+    }) -join $Separator
+}
+
 $ProjectRoot = if ($env:CIBW_PROJECT_DIR) {
     $env:CIBW_PROJECT_DIR
 } elseif ($env:GITHUB_WORKSPACE) {
@@ -12,18 +38,50 @@ $ProjectRoot = if ($env:CIBW_PROJECT_DIR) {
     (Get-Location).Path
 }
 
+# Match the native MSVC workflow: vcpkg supplies libraries, MSYS2 supplies
+# parser generators. GitHub's Windows runners already include C:\msys64.
+$MsysUsrBin = Get-ExistingPath @("C:\msys64\usr\bin", "C:\msys64\ucrt64\bin")
+if (-not $MsysUsrBin) {
+    throw "MSYS2 was not found under C:\msys64; install MSYS2 or run msys2/setup-msys2 before cibuildwheel"
+}
+
+$Pacman = Join-Path $MsysUsrBin "pacman.exe"
+if (Test-Path $Pacman) {
+    & $Pacman -Sy --noconfirm flex bison
+    Assert-NativeCommandSucceeded "pacman install flex bison"
+}
+
+$BisonExe = Get-ExistingPath @(
+    (Join-Path $MsysUsrBin "bison.exe"),
+    (Join-Path $MsysUsrBin "win_bison.exe")
+)
+$FlexExe = Get-ExistingPath @(
+    (Join-Path $MsysUsrBin "flex.exe"),
+    (Join-Path $MsysUsrBin "win_flex.exe")
+)
+if (-not $BisonExe -or -not $FlexExe) {
+    throw "MSYS2 flex/bison tools were not found after install (bison: $BisonExe, flex: $FlexExe)"
+}
+
 # Pin vcpkg to a release tag for reproducible builds (see vcpkg.json builtin-baseline).
 $VcpkgVersion = "2025.04.09"
 $VcpkgRoot = Join-Path $ProjectRoot ".wheel-vcpkg"
 
 if (-not (Test-Path $VcpkgRoot)) {
-    git clone --depth 1 --branch $VcpkgVersion `
+    git clone --branch $VcpkgVersion `
         https://github.com/microsoft/vcpkg.git $VcpkgRoot
+    Assert-NativeCommandSucceeded "git clone vcpkg"
 } else {
     Push-Location $VcpkgRoot
     try {
-        git fetch --depth 1 origin "refs/tags/${VcpkgVersion}:refs/tags/${VcpkgVersion}"
+        if (Test-Path ".git/shallow") {
+            git fetch --unshallow origin
+            Assert-NativeCommandSucceeded "git unshallow vcpkg"
+        }
+        git fetch origin "refs/tags/${VcpkgVersion}:refs/tags/${VcpkgVersion}"
+        Assert-NativeCommandSucceeded "git fetch vcpkg tag"
         git checkout $VcpkgVersion
+        Assert-NativeCommandSucceeded "git checkout vcpkg tag"
     } finally {
         Pop-Location
     }
@@ -32,18 +90,27 @@ if (-not (Test-Path $VcpkgRoot)) {
 $VcpkgExe = Join-Path $VcpkgRoot "vcpkg.exe"
 if (-not (Test-Path $VcpkgExe)) {
     & (Join-Path $VcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
+    Assert-NativeCommandSucceeded "bootstrap vcpkg"
 }
 
 $ManifestDir = Join-Path $ProjectRoot "scripts/cibuildwheel"
-$Triplet = "x64-windows"
+$Triplet = "x64-windows-release"
+$HostTriplet = "x64-windows-release"
 
 Push-Location $ManifestDir
 try {
+    $OriginalPath = $env:PATH
+    $env:PATH = Remove-Msys2PathEntries $env:PATH
     & $VcpkgExe install `
         --triplet $Triplet `
+        --host-triplet $HostTriplet `
         --x-manifest-root $ManifestDir `
         --x-install-root (Join-Path $VcpkgRoot "installed")
+    Assert-NativeCommandSucceeded "vcpkg install"
 } finally {
+    if ($OriginalPath) {
+        $env:PATH = $OriginalPath
+    }
     Pop-Location
 }
 
@@ -51,20 +118,18 @@ $Installed = Join-Path $VcpkgRoot "installed" $Triplet
 $PkgConfigDir = Join-Path $Installed "lib" "pkgconfig"
 $PkgConfExe = Join-Path $Installed "tools" "pkgconf" "pkgconf.exe"
 
-# winflexbison installs win_bison.exe / win_flex.exe under tools/winflexbison/.
-$WinFlexDir = Join-Path $Installed "tools" "winflexbison"
-
 # before-all runs in a separate process; persist env for setup.py and repair-wheel.
 $EnvFile = Join-Path $ProjectRoot "scripts/cibuildwheel/wheel-build-env.env"
 $EnvLines = @(
     "VCPKG_ROOT=$VcpkgRoot",
     "VCPKG_DEFAULT_TRIPLET=$Triplet",
+    "VCPKG_DEFAULT_HOST_TRIPLET=$HostTriplet",
     "PKG_CONFIG_PATH=$PkgConfigDir",
-    "PKG_CONFIG=$PkgConfExe"
+    "PKG_CONFIG=$PkgConfExe",
+    "BISON=$BisonExe",
+    "FLEX=$FlexExe",
+    "MSYS2_USR_BIN=$MsysUsrBin"
 )
-if (Test-Path $WinFlexDir) {
-    $EnvLines += "WINFLEXBISON_DIR=$WinFlexDir"
-}
 $EnvLines | Set-Content -Encoding utf8 $EnvFile
 
 Write-Host "=== install-deps-windows.ps1: done (vcpkg root: $VcpkgRoot) ==="

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -26,7 +26,8 @@ function Remove-Msys2PathEntries {
     $MsysRoot = "C:\msys64\"
     $Separator = [IO.Path]::PathSeparator
     (($PathValue -split [Regex]::Escape($Separator)) | Where-Object {
-        $_ -and -not $_.StartsWith($MsysRoot, [StringComparison]::OrdinalIgnoreCase)
+        $Normalized = $_.Replace("/", "\")
+        $_ -and -not $Normalized.StartsWith($MsysRoot, [StringComparison]::OrdinalIgnoreCase)
     }) -join $Separator
 }
 

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -135,6 +135,37 @@ $Installed = Join-Path $VcpkgRoot "installed" $Triplet
 $PkgConfigDir = Join-Path $Installed "lib" "pkgconfig"
 $PkgConfExe = Join-Path $Installed "tools" "pkgconf" "pkgconf.exe"
 
+#region agent log
+$DebugPayload = [ordered]@{
+    sessionId = "ea88a1"
+    runId = if ($env:GITHUB_RUN_ID) { $env:GITHUB_RUN_ID } else { "local" }
+    hypothesisId = "A,B"
+    location = "scripts/cibuildwheel/install-deps-windows.ps1:vcpkg_snapshot"
+    message = "Snapshot Windows vcpkg library files after install"
+    data = [ordered]@{
+        installed = $Installed
+        libExists = Test-Path (Join-Path $Installed "lib")
+        manualLinkExists = Test-Path (Join-Path $Installed "lib" "manual-link")
+        boostRegexLibFiles = @(
+            Get-ChildItem -Path (Join-Path $Installed "lib") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
+                Select-Object -ExpandProperty Name
+        )
+        boostRegexManualLinkFiles = @(
+            Get-ChildItem -Path (Join-Path $Installed "lib" "manual-link") -Filter "*boost*regex*.lib" -ErrorAction SilentlyContinue |
+                Select-Object -ExpandProperty Name
+        )
+        boostRegexPkgConfigFiles = @(
+            Get-ChildItem -Path $PkgConfigDir -Filter "*boost*regex*.pc" -ErrorAction SilentlyContinue |
+                Select-Object -ExpandProperty Name
+        )
+    }
+    timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+}
+$DebugJson = $DebugPayload | ConvertTo-Json -Depth 5 -Compress
+Add-Content -Encoding utf8 -Path (Join-Path $ProjectRoot "debug-ea88a1.log") -Value $DebugJson
+Write-Host "AGENT_DEBUG $DebugJson"
+#endregion
+
 # before-all runs in a separate process; persist env for setup.py and repair-wheel.
 $EnvFile = Join-Path $ProjectRoot "scripts/cibuildwheel/wheel-build-env.env"
 $EnvLines = @(
@@ -145,7 +176,8 @@ $EnvLines = @(
     "PKG_CONFIG=$PkgConfExe",
     "BISON=$BisonExe",
     "FLEX=$FlexExe",
-    "MSYS2_USR_BIN=$MsysUsrBin"
+    "MSYS2_USR_BIN=$MsysUsrBin",
+    "PYTHONSCAD_WHEEL_DEBUG=$env:PYTHONSCAD_WHEEL_DEBUG"
 )
 $EnvLines | Set-Content -Encoding utf8 $EnvFile
 

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -144,9 +144,11 @@ try {
 
 $BoostRegexLibFiles = Get-BoostRegexLibFiles $Installed
 if ($BoostRegexLibFiles.Count -eq 0) {
-    Write-Host "boost-regex is marked installed but no Boost regex import library was found; reinstalling boost-regex"
-    & $VcpkgExe remove "boost-regex:${Triplet}" --recurse
-    Assert-NativeCommandSucceeded "vcpkg remove boost-regex"
+    $InstallRoot = Join-Path $VcpkgRoot "installed"
+    Write-Host "boost-regex is marked installed but no Boost regex import library was found; removing stale vcpkg installed tree"
+    if (Test-Path $InstallRoot) {
+        Remove-Item -Recurse -Force $InstallRoot
+    }
     Push-Location $ManifestDir
     try {
         $OriginalPath = $env:PATH
@@ -155,7 +157,7 @@ if ($BoostRegexLibFiles.Count -eq 0) {
             --triplet $Triplet `
             --host-triplet $HostTriplet `
             --x-manifest-root $ManifestDir `
-            --x-install-root (Join-Path $VcpkgRoot "installed")
+            --x-install-root $InstallRoot
         Assert-NativeCommandSucceeded "vcpkg reinstall after boost-regex repair"
     } finally {
         if ($null -ne $OriginalPath) {

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -105,7 +105,7 @@ try {
         --x-install-root (Join-Path $VcpkgRoot "installed")
     Assert-NativeCommandSucceeded "vcpkg install"
 } finally {
-    if ($OriginalPath) {
+    if ($null -ne $OriginalPath) {
         $env:PATH = $OriginalPath
     }
     Pop-Location

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -71,14 +71,21 @@ $ManifestDir = Join-Path $ProjectRoot "scripts/cibuildwheel"
 $VcpkgManifest = Join-Path $ManifestDir "vcpkg.json"
 
 if (-not (Test-Path $VcpkgRoot)) {
-    git clone --depth 1 --branch $VcpkgVersion `
+    # vcpkg versioned ports need historical tree objects; shallow clones fail during install.
+    git clone --branch $VcpkgVersion `
         https://github.com/microsoft/vcpkg.git $VcpkgRoot
     Assert-NativeCommandSucceeded "git clone vcpkg"
 } else {
     Push-Location $VcpkgRoot
     try {
-        git fetch --depth 1 origin "refs/tags/${VcpkgVersion}:refs/tags/${VcpkgVersion}"
+        git fetch origin "refs/tags/${VcpkgVersion}:refs/tags/${VcpkgVersion}"
         Assert-NativeCommandSucceeded "git fetch vcpkg tag"
+        $IsShallow = (git rev-parse --is-shallow-repository).Trim()
+        Assert-NativeCommandSucceeded "git check vcpkg shallow state"
+        if ($IsShallow -eq "true") {
+            git fetch --unshallow origin
+            Assert-NativeCommandSucceeded "git unshallow vcpkg"
+        }
         git checkout $VcpkgVersion
         Assert-NativeCommandSucceeded "git checkout vcpkg tag"
     } finally {

--- a/scripts/cibuildwheel/update-vcpkg-baseline.py
+++ b/scripts/cibuildwheel/update-vcpkg-baseline.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Sync the vcpkg manifest baseline with the pinned vcpkg release tag."""
+
+import json
+import pathlib
+import re
+import subprocess
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+INSTALL_DEPS = ROOT / "scripts" / "cibuildwheel" / "install-deps-windows.ps1"
+MANIFEST = ROOT / "scripts" / "cibuildwheel" / "vcpkg.json"
+VCPKG_REPO = "https://github.com/microsoft/vcpkg.git"
+
+
+def pinned_vcpkg_version():
+    match = re.search(r'^\$VcpkgVersion = "([^"]+)"$', INSTALL_DEPS.read_text(), re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not find $VcpkgVersion in {INSTALL_DEPS}")
+    return match.group(1)
+
+
+def tag_commit(version):
+    ref = f"refs/tags/{version}"
+    output = subprocess.check_output(
+        ["git", "ls-remote", "--tags", VCPKG_REPO, ref],
+        text=True,
+    ).strip()
+    if not output:
+        raise RuntimeError(f"Could not resolve vcpkg tag {version}")
+    return output.split()[0]
+
+
+def main():
+    version = pinned_vcpkg_version()
+    commit = tag_commit(version)
+    manifest = json.loads(MANIFEST.read_text())
+    manifest["builtin-baseline"] = commit
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"Updated {MANIFEST} builtin-baseline to {commit} for vcpkg {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cibuildwheel/update-vcpkg-baseline.py
+++ b/scripts/cibuildwheel/update-vcpkg-baseline.py
@@ -14,21 +14,25 @@ VCPKG_REPO = "https://github.com/microsoft/vcpkg.git"
 
 
 def pinned_vcpkg_version():
-    match = re.search(r'^\$VcpkgVersion = "([^"]+)"$', INSTALL_DEPS.read_text(), re.MULTILINE)
+    match = re.search(r'^\s*\$VcpkgVersion\s*=\s*"([^"]+)"\s*$', INSTALL_DEPS.read_text(), re.MULTILINE)
     if not match:
         raise RuntimeError(f"Could not find $VcpkgVersion in {INSTALL_DEPS}")
     return match.group(1)
 
 
 def tag_commit(version):
-    ref = f"refs/tags/{version}"
+    refs = [f"refs/tags/{version}", f"refs/tags/{version}^{{}}"]
     output = subprocess.check_output(
-        ["git", "ls-remote", "--tags", VCPKG_REPO, ref],
+        ["git", "ls-remote", "--tags", VCPKG_REPO, *refs],
         text=True,
     ).strip()
     if not output:
         raise RuntimeError(f"Could not resolve vcpkg tag {version}")
-    return output.split()[0]
+    resolved = {}
+    for line in output.splitlines():
+        commit, ref = line.split()
+        resolved[ref] = commit
+    return resolved.get(f"refs/tags/{version}^{{}}", resolved[f"refs/tags/{version}"])
 
 
 def main():

--- a/scripts/cibuildwheel/vcpkg.json
+++ b/scripts/cibuildwheel/vcpkg.json
@@ -1,19 +1,21 @@
 {
   "name": "pythonscad-pip",
   "version-string": "1.0.0",
-  "builtin-baseline": "2025.04.09",
+  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
   "dependencies": [
     "boost-regex",
     "boost-program-options",
+    "boost-assign",
+    "boost-lockfree",
     "eigen3",
     "cgal",
     "cairo",
     "harfbuzz",
     "fontconfig",
     "double-conversion",
+    "lib3mf",
     "libxml2",
     "glib",
-    "winflexbison",
     "pkgconf"
   ]
 }

--- a/scripts/deps/profiles/pythonscad-pip.json
+++ b/scripts/deps/profiles/pythonscad-pip.json
@@ -68,6 +68,7 @@
         "boost",
         "cgal",
         "cairo",
+        "cmake",
         "double-conversion",
         "eigen",
         "flex",
@@ -76,7 +77,7 @@
         "glib",
         "gmp",
         "harfbuzz",
-        "lib3mf",
+        "libzip",
         "libxml2",
         "mpfr",
         "pkg-config"

--- a/scripts/deps/profiles/pythonscad-pip.json
+++ b/scripts/deps/profiles/pythonscad-pip.json
@@ -21,6 +21,7 @@
         "libeigen3-dev",
         "libfontconfig-dev",
         "libfreetype-dev",
+        "lib3mf-dev",
         "libglib2.0-dev",
         "libgmp-dev",
         "libharfbuzz-dev",
@@ -52,6 +53,7 @@
         "glib2-devel",
         "gmp-devel",
         "harfbuzz-devel",
+        "lib3mf-devel",
         "libxml2-devel",
         "mpfr-devel",
         "pkgconfig"
@@ -74,6 +76,7 @@
         "glib",
         "gmp",
         "harfbuzz",
+        "lib3mf",
         "libxml2",
         "mpfr",
         "pkg-config"
@@ -97,6 +100,7 @@
         "glib2:p",
         "gmp:p",
         "harfbuzz:p",
+        "lib3mf:p",
         "libxml2:p",
         "mpfr:p",
         "pkgconf:p",

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,7 @@ def get_library_dirs():
     vcpkg_installed = get_vcpkg_installed_dir()
     if vcpkg_installed:
         dirs.append(os.path.join(vcpkg_installed, "lib"))
+        dirs.append(os.path.join(vcpkg_installed, "lib", "manual-link"))
     if IS_DARWIN:
         for prefix in ("/opt/homebrew", "/usr/local"):
             libdir = os.path.join(prefix, "lib")
@@ -282,9 +283,9 @@ def get_platform_sources():
     sources = ["src/platform/PlatformUtils.cc"]
     if IS_WINDOWS:
         sources.append("src/platform/PlatformUtils-win.cc")
-    elif IS_DARWIN:
-        sources.append("src/platform/PlatformUtils-mac.mm")
     else:
+        # The pip extension is headless, so POSIX paths are sufficient here;
+        # on macOS this avoids requiring Objective-C++ support from setuptools.
         sources.append("src/platform/PlatformUtils-posix.cc")
     return sources
 

--- a/setup.py
+++ b/setup.py
@@ -206,9 +206,11 @@ def get_link_libraries():
     """Return the full set of libraries to link the pip extension against."""
     libs = get_pkg_config_libraries()
 
-    # Match CMake (Boost::regex, Boost::program_options) so shared deps appear
-    # in DT_NEEDED and auditwheel/delocate/delvewheel can bundle them.
+    # Link concrete Boost libraries so auditwheel/delocate/delvewheel can
+    # bundle them. Current Homebrew Boost.System is header-only on macOS.
     boost_libs = ["boost_program_options"]
+    if not IS_DARWIN:
+        boost_libs.append("boost_system")
     if not IS_WINDOWS:
         boost_libs.insert(0, "boost_regex")
     for lib in boost_libs:
@@ -397,7 +399,10 @@ def get_platform_sources():
 def get_extra_link_args():
     """Return platform-specific linker flags."""
     if IS_DARWIN:
-        return ["-framework", "Foundation"]
+        args = ["-framework", "Foundation"]
+        for libdir in get_library_dirs():
+            args.append(f"-Wl,-rpath,{libdir}")
+        return args
     return []
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def apply_wheel_build_env():
         os.environ["PATH"] = winflex + os.pathsep + os.environ.get("PATH", "")
     msys2_usr_bin = os.environ.get("MSYS2_USR_BIN")
     if msys2_usr_bin and os.path.isdir(msys2_usr_bin):
-        os.environ["PATH"] = msys2_usr_bin + os.pathsep + os.environ.get("PATH", "")
+        os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + msys2_usr_bin
 
 def get_version():
     here = os.path.dirname(os.path.abspath(__file__))
@@ -255,6 +255,8 @@ def normalize_windows_link_libraries(libs, library_dirs):
 
         if not resolved and lib in system_libs:
             resolved = lib
+        if not resolved:
+            resolved = aliases.get(lib, lib)
 
         if resolved and resolved not in normalized:
             normalized.append(resolved)

--- a/setup.py
+++ b/setup.py
@@ -456,7 +456,12 @@ class BuildExtWithLexYacc(build_ext):
         super().finalize_options()
         build_parallel = os.environ.get("PYTHONSCAD_BUILD_PARALLEL")
         if build_parallel and not self.parallel:
-            self.parallel = int(build_parallel)
+            try:
+                self.parallel = int(build_parallel)
+            except ValueError as exc:
+                raise RuntimeError(
+                    "PYTHONSCAD_BUILD_PARALLEL must be an integer when set"
+                ) from exc
 
     def run(self):
         yacc_src = "src/core/parser.y"

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,10 @@ def get_link_libraries():
 
     # Match CMake (Boost::regex, Boost::program_options) so shared deps appear
     # in DT_NEEDED and auditwheel/delocate/delvewheel can bundle them.
-    for lib in ("boost_regex", "boost_program_options", "boost_system"):
+    boost_libs = ["boost_program_options", "boost_system"]
+    if not IS_WINDOWS:
+        boost_libs.insert(0, "boost_regex")
+    for lib in boost_libs:
         if lib not in libs:
             libs.append(lib)
     if IS_WINDOWS:

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ def apply_wheel_build_env():
                 os.environ[key] = value
     winflex = os.environ.get("WINFLEXBISON_DIR")
     if winflex and os.path.isdir(winflex):
-        os.environ["PATH"] = winflex + os.pathsep + os.environ.get("PATH", "")
+        path = os.environ.get("PATH", "")
+        os.environ["PATH"] = winflex + os.pathsep + path if path else winflex
     msys2_usr_bin = os.environ.get("MSYS2_USR_BIN")
     if msys2_usr_bin and os.path.isdir(msys2_usr_bin):
         path = os.environ.get("PATH", "")

--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,8 @@ def get_link_libraries():
     boost_libs = ["boost_program_options"]
     if not IS_DARWIN:
         boost_libs.append("boost_system")
+    # On Windows, Boost.Regex is selected via MSVC autolink; vcpkg's release
+    # triplet does not provide a stable unversioned boost_regex.lib to name here.
     if not IS_WINDOWS:
         boost_libs.insert(0, "boost_regex")
     for lib in boost_libs:

--- a/setup.py
+++ b/setup.py
@@ -580,6 +580,10 @@ class BuildExtWithLexYacc(build_ext):
                 ) from exc
 
     def build_extensions(self):
+        if IS_DARWIN and hasattr(self.compiler, "src_extensions"):
+            if ".mm" not in self.compiler.src_extensions:
+                self.compiler.src_extensions.append(".mm")
+
         if not IS_WINDOWS and hasattr(self.compiler, "_compile"):
             original_compile = self.compiler._compile
 

--- a/setup.py
+++ b/setup.py
@@ -279,8 +279,9 @@ def normalize_windows_link_libraries(libs, library_dirs):
 def get_extra_compile_args():
     """Return platform-specific compiler flags."""
     if IS_WINDOWS:
-        # Keep legacy Python C API keyword arrays and UTF-8 filesystem strings building under C++20.
-        return ["/bigobj", "/EHsc", "/std:c++20", "/Zc:strictStrings-", "/Zc:char8_t-"]
+        # Disable MSVC whole-program optimization; the wheel links the full
+        # extension for every Python ABI and /GL exhausts linker heap on CI.
+        return ["/bigobj", "/EHsc", "/std:c++20", "/Zc:strictStrings-", "/Zc:char8_t-", "/GL-"]
     args = ["-std=c++17"]
     if IS_DARWIN:
         args.append("-stdlib=libc++")

--- a/setup.py
+++ b/setup.py
@@ -559,6 +559,8 @@ def detect_libfive():
 class BuildExtWithLexYacc(build_ext):
     """Custom build_ext command to run lex/yacc before building extension modules."""
 
+    cxx_only_compile_args = {"-std=c++17", "-stdlib=libc++"}
+
     def finalize_options(self):
         super().finalize_options()
         build_parallel = os.environ.get("PYTHONSCAD_BUILD_PARALLEL")
@@ -569,6 +571,27 @@ class BuildExtWithLexYacc(build_ext):
                 raise RuntimeError(
                     "PYTHONSCAD_BUILD_PARALLEL must be an integer when set"
                 ) from exc
+
+    def build_extensions(self):
+        if not IS_WINDOWS and hasattr(self.compiler, "_compile"):
+            original_compile = self.compiler._compile
+
+            def compile_without_cxx_args_for_c_sources(obj, src, ext, cc_args, extra_postargs, pp_opts):
+                if src.endswith(".c") and extra_postargs:
+                    extra_postargs = [
+                        arg for arg in extra_postargs
+                        if arg not in self.cxx_only_compile_args
+                    ]
+                return original_compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+            self.compiler._compile = compile_without_cxx_args_for_c_sources
+            try:
+                super().build_extensions()
+            finally:
+                self.compiler._compile = original_compile
+            return
+
+        super().build_extensions()
 
     def run(self):
         yacc_src = "src/core/parser.y"

--- a/setup.py
+++ b/setup.py
@@ -246,9 +246,10 @@ def normalize_windows_link_libraries(libs, library_dirs):
                 break
 
             if lib.startswith("boost_"):
-                prefix = f"{lib}-".lower()
+                prefixes = (f"{lib}-".lower(), f"lib{lib}-".lower())
                 for name in os.listdir(libdir):
-                    if name.lower().startswith(prefix) and name.lower().endswith(".lib"):
+                    lowered = name.lower()
+                    if lowered.endswith(".lib") and lowered.startswith(prefixes):
                         resolved = os.path.splitext(name)[0]
                         break
             if resolved:

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,14 @@
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-import json
 import subprocess
 import os
 import re
 import shutil
 import sys
-import tempfile
-import time
 
 
 IS_WINDOWS = sys.platform == "win32"
 IS_DARWIN = sys.platform == "darwin"
-DEBUG_LOG_SESSION = "ea88a1"
-
-
-def agent_debug(hypothesis_id, location, message, data):
-    """Emit temporary CI diagnostics for Windows wheel dependency debugging."""
-    if os.environ.get("PYTHONSCAD_WHEEL_DEBUG") != "1":
-        return
-    payload = {
-        "sessionId": DEBUG_LOG_SESSION,
-        "runId": os.environ.get("GITHUB_RUN_ID", "local"),
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-        "timestamp": int(time.time() * 1000),
-    }
-    text = json.dumps(payload, sort_keys=True)
-    debug_dir = os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
-    debug_path = os.path.join(debug_dir, f"debug-{DEBUG_LOG_SESSION}.log")
-    try:
-        with open(debug_path, "a", encoding="utf-8") as log:
-            log.write(text + "\n")
-    except OSError:
-        pass
-    print(f"AGENT_DEBUG {text}", file=sys.stderr)
 
 
 def apply_wheel_build_env():
@@ -63,21 +35,7 @@ def apply_wheel_build_env():
     if msys2_usr_bin and os.path.isdir(msys2_usr_bin):
         path = os.environ.get("PATH", "")
         os.environ["PATH"] = path + os.pathsep + msys2_usr_bin if path else msys2_usr_bin
-    # region agent log
-    agent_debug(
-        "C",
-        "setup.py:apply_wheel_build_env",
-        "Loaded wheel build environment",
-        {
-            "env_file": env_file,
-            "env_file_exists": os.path.isfile(env_file),
-            "VCPKG_ROOT": os.environ.get("VCPKG_ROOT"),
-            "VCPKG_DEFAULT_TRIPLET": os.environ.get("VCPKG_DEFAULT_TRIPLET"),
-            "PKG_CONFIG": os.environ.get("PKG_CONFIG"),
-            "PKG_CONFIG_PATH": os.environ.get("PKG_CONFIG_PATH"),
-        },
-    )
-    # endregion
+
 
 def get_version():
     here = os.path.dirname(os.path.abspath(__file__))
@@ -288,29 +246,9 @@ def normalize_windows_link_libraries(libs, library_dirs):
         for libdir in library_dirs:
             if not os.path.isdir(libdir):
                 continue
-            boost_files = []
-            if lib.startswith("boost_"):
-                boost_files = [
-                    name
-                    for name in os.listdir(libdir)
-                    if "boost" in name.lower() and "regex" in name.lower()
-                ]
             for candidate in candidates:
                 if os.path.isfile(os.path.join(libdir, f"{candidate}.lib")):
                     resolved = candidate
-                    # region agent log
-                    agent_debug(
-                        "D",
-                        "setup.py:normalize_windows_link_libraries",
-                        "Resolved exact library candidate",
-                        {
-                            "lib": lib,
-                            "candidate": candidate,
-                            "libdir": libdir,
-                            "boost_regex_files": boost_files,
-                        },
-                    )
-                    # endregion
                     break
             if resolved:
                 break
@@ -321,20 +259,6 @@ def normalize_windows_link_libraries(libs, library_dirs):
                     lowered = name.lower()
                     if lowered.endswith(".lib") and lowered.startswith(prefixes):
                         resolved = os.path.splitext(name)[0]
-                        # region agent log
-                        agent_debug(
-                            "D",
-                            "setup.py:normalize_windows_link_libraries",
-                            "Resolved prefixed Boost library",
-                            {
-                                "lib": lib,
-                                "resolved": resolved,
-                                "libdir": libdir,
-                                "prefixes": prefixes,
-                                "boost_regex_files": boost_files,
-                            },
-                        )
-                        # endregion
                         break
             if resolved:
                 break
@@ -343,35 +267,6 @@ def normalize_windows_link_libraries(libs, library_dirs):
             resolved = lib
         if not resolved:
             resolved = aliases.get(lib, lib)
-            if lib.startswith("boost_"):
-                debug_dirs = []
-                for libdir in library_dirs:
-                    if os.path.isdir(libdir):
-                        debug_dirs.append(
-                            {
-                                "libdir": libdir,
-                                "boost_regex_files": [
-                                    name
-                                    for name in os.listdir(libdir)
-                                    if "boost" in name.lower() and "regex" in name.lower()
-                                ],
-                            }
-                        )
-                    else:
-                        debug_dirs.append({"libdir": libdir, "missing": True})
-                # region agent log
-                agent_debug(
-                    "A,B,D",
-                    "setup.py:normalize_windows_link_libraries",
-                    "Falling back to unresolved Boost library name",
-                    {
-                        "lib": lib,
-                        "resolved": resolved,
-                        "candidates": candidates,
-                        "library_dirs": debug_dirs,
-                    },
-                )
-                # endregion
 
         if resolved and resolved not in normalized:
             normalized.append(resolved)
@@ -939,19 +834,6 @@ def main():
     library_dirs = get_library_dirs()
     raw_link_libraries = get_link_libraries() + lib3mf_libs
     link_libraries = normalize_windows_link_libraries(raw_link_libraries, library_dirs)
-    # region agent log
-    agent_debug(
-        "A,B,C,D",
-        "setup.py:main",
-        "Prepared extension link inputs",
-        {
-            "library_dirs": library_dirs,
-            "raw_link_libraries": raw_link_libraries,
-            "link_libraries": link_libraries,
-            "vcpkg_installed": get_vcpkg_installed_dir(),
-        },
-    )
-    # endregion
 
     pythonscad_ext = Extension(
         "_openscad",

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,37 @@
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
+import json
 import subprocess
 import os
 import re
 import shutil
 import sys
+import time
 
 
 IS_WINDOWS = sys.platform == "win32"
 IS_DARWIN = sys.platform == "darwin"
+DEBUG_LOG_SESSION = "ea88a1"
+
+
+def agent_debug(hypothesis_id, location, message, data):
+    """Emit temporary CI diagnostics for Windows wheel dependency debugging."""
+    if os.environ.get("PYTHONSCAD_WHEEL_DEBUG") != "1":
+        return
+    payload = {
+        "sessionId": DEBUG_LOG_SESSION,
+        "runId": os.environ.get("GITHUB_RUN_ID", "local"),
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": int(time.time() * 1000),
+    }
+    text = json.dumps(payload, sort_keys=True)
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "debug-ea88a1.log"), "a", encoding="utf-8") as log:
+        log.write(text + "\n")
+    print(f"AGENT_DEBUG {text}", file=sys.stderr)
 
 
 def apply_wheel_build_env():
@@ -34,6 +57,21 @@ def apply_wheel_build_env():
     if msys2_usr_bin and os.path.isdir(msys2_usr_bin):
         path = os.environ.get("PATH", "")
         os.environ["PATH"] = path + os.pathsep + msys2_usr_bin if path else msys2_usr_bin
+    # region agent log
+    agent_debug(
+        "C",
+        "setup.py:apply_wheel_build_env",
+        "Loaded wheel build environment",
+        {
+            "env_file": env_file,
+            "env_file_exists": os.path.isfile(env_file),
+            "VCPKG_ROOT": os.environ.get("VCPKG_ROOT"),
+            "VCPKG_DEFAULT_TRIPLET": os.environ.get("VCPKG_DEFAULT_TRIPLET"),
+            "PKG_CONFIG": os.environ.get("PKG_CONFIG"),
+            "PKG_CONFIG_PATH": os.environ.get("PKG_CONFIG_PATH"),
+        },
+    )
+    # endregion
 
 def get_version():
     here = os.path.dirname(os.path.abspath(__file__))
@@ -239,9 +277,29 @@ def normalize_windows_link_libraries(libs, library_dirs):
         for libdir in library_dirs:
             if not os.path.isdir(libdir):
                 continue
+            boost_files = []
+            if lib.startswith("boost_"):
+                boost_files = [
+                    name
+                    for name in os.listdir(libdir)
+                    if "boost" in name.lower() and "regex" in name.lower()
+                ]
             for candidate in candidates:
                 if os.path.isfile(os.path.join(libdir, f"{candidate}.lib")):
                     resolved = candidate
+                    # region agent log
+                    agent_debug(
+                        "D",
+                        "setup.py:normalize_windows_link_libraries",
+                        "Resolved exact library candidate",
+                        {
+                            "lib": lib,
+                            "candidate": candidate,
+                            "libdir": libdir,
+                            "boost_regex_files": boost_files,
+                        },
+                    )
+                    # endregion
                     break
             if resolved:
                 break
@@ -252,6 +310,20 @@ def normalize_windows_link_libraries(libs, library_dirs):
                     lowered = name.lower()
                     if lowered.endswith(".lib") and lowered.startswith(prefixes):
                         resolved = os.path.splitext(name)[0]
+                        # region agent log
+                        agent_debug(
+                            "D",
+                            "setup.py:normalize_windows_link_libraries",
+                            "Resolved prefixed Boost library",
+                            {
+                                "lib": lib,
+                                "resolved": resolved,
+                                "libdir": libdir,
+                                "prefixes": prefixes,
+                                "boost_regex_files": boost_files,
+                            },
+                        )
+                        # endregion
                         break
             if resolved:
                 break
@@ -260,6 +332,35 @@ def normalize_windows_link_libraries(libs, library_dirs):
             resolved = lib
         if not resolved:
             resolved = aliases.get(lib, lib)
+            if lib.startswith("boost_"):
+                debug_dirs = []
+                for libdir in library_dirs:
+                    if os.path.isdir(libdir):
+                        debug_dirs.append(
+                            {
+                                "libdir": libdir,
+                                "boost_regex_files": [
+                                    name
+                                    for name in os.listdir(libdir)
+                                    if "boost" in name.lower() and "regex" in name.lower()
+                                ],
+                            }
+                        )
+                    else:
+                        debug_dirs.append({"libdir": libdir, "missing": True})
+                # region agent log
+                agent_debug(
+                    "A,B,D",
+                    "setup.py:normalize_windows_link_libraries",
+                    "Falling back to unresolved Boost library name",
+                    {
+                        "lib": lib,
+                        "resolved": resolved,
+                        "candidates": candidates,
+                        "library_dirs": debug_dirs,
+                    },
+                )
+                # endregion
 
         if resolved and resolved not in normalized:
             normalized.append(resolved)
@@ -800,6 +901,19 @@ def main():
     library_dirs = get_library_dirs()
     raw_link_libraries = get_link_libraries() + lib3mf_libs
     link_libraries = normalize_windows_link_libraries(raw_link_libraries, library_dirs)
+    # region agent log
+    agent_debug(
+        "A,B,C,D",
+        "setup.py:main",
+        "Prepared extension link inputs",
+        {
+            "library_dirs": library_dirs,
+            "raw_link_libraries": raw_link_libraries,
+            "link_libraries": link_libraries,
+            "vcpkg_installed": get_vcpkg_installed_dir(),
+        },
+    )
+    # endregion
 
     pythonscad_ext = Extension(
         "_openscad",

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import sys
+import tempfile
 import time
 
 
@@ -28,9 +29,13 @@ def agent_debug(hypothesis_id, location, message, data):
         "timestamp": int(time.time() * 1000),
     }
     text = json.dumps(payload, sort_keys=True)
-    here = os.path.dirname(os.path.abspath(__file__))
-    with open(os.path.join(here, "debug-ea88a1.log"), "a", encoding="utf-8") as log:
-        log.write(text + "\n")
+    debug_dir = os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()
+    debug_path = os.path.join(debug_dir, f"debug-{DEBUG_LOG_SESSION}.log")
+    try:
+        with open(debug_path, "a", encoding="utf-8") as log:
+            log.write(text + "\n")
+    except OSError:
+        pass
     print(f"AGENT_DEBUG {text}", file=sys.stderr)
 
 
@@ -389,9 +394,9 @@ def get_platform_sources():
     sources = ["src/platform/PlatformUtils.cc"]
     if IS_WINDOWS:
         sources.append("src/platform/PlatformUtils-win.cc")
+    elif IS_DARWIN:
+        sources.append("src/platform/PlatformUtils-mac.mm")
     else:
-        # The pip extension is headless, so POSIX paths are sufficient here;
-        # on macOS this avoids requiring Objective-C++ support from setuptools.
         sources.append("src/platform/PlatformUtils-posix.cc")
     return sources
 
@@ -399,10 +404,7 @@ def get_platform_sources():
 def get_extra_link_args():
     """Return platform-specific linker flags."""
     if IS_DARWIN:
-        args = ["-framework", "Foundation"]
-        for libdir in get_library_dirs():
-            args.append(f"-Wl,-rpath,{libdir}")
-        return args
+        return ["-framework", "Foundation"]
     return []
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ def apply_wheel_build_env():
     winflex = os.environ.get("WINFLEXBISON_DIR")
     if winflex and os.path.isdir(winflex):
         os.environ["PATH"] = winflex + os.pathsep + os.environ.get("PATH", "")
-
+    msys2_usr_bin = os.environ.get("MSYS2_USR_BIN")
+    if msys2_usr_bin and os.path.isdir(msys2_usr_bin):
+        os.environ["PATH"] = msys2_usr_bin + os.pathsep + os.environ.get("PATH", "")
 
 def get_version():
     here = os.path.dirname(os.path.abspath(__file__))
@@ -170,6 +172,10 @@ def get_link_libraries():
     for lib in ("boost_regex", "boost_program_options", "boost_system"):
         if lib not in libs:
             libs.append(lib)
+    if IS_WINDOWS:
+        for lib in ("libpng16", "shell32"):
+            if lib not in libs:
+                libs.append(lib)
 
     cgal_raw = pkg_config_flags(["CGAL"], "--libs-only-l")
     if cgal_raw:
@@ -209,10 +215,58 @@ def get_library_dirs():
     return dirs
 
 
+def normalize_windows_link_libraries(libs, library_dirs):
+    """Translate pkg-config library names to MSVC/vcpkg import library names."""
+    if not IS_WINDOWS:
+        return libs
+
+    system_libs = {"advapi32", "bcrypt", "kernel32", "shell32", "user32", "winmm", "ws2_32"}
+    aliases = {
+        "3mf": "lib3mf",
+        "xml2": "libxml2",
+        "z": "zlib",
+    }
+
+    normalized = []
+    for lib in libs:
+        candidates = [aliases.get(lib, lib)]
+        if lib.startswith("boost_"):
+            candidates.append(lib)
+
+        resolved = None
+        for libdir in library_dirs:
+            if not os.path.isdir(libdir):
+                continue
+            for candidate in candidates:
+                if os.path.isfile(os.path.join(libdir, f"{candidate}.lib")):
+                    resolved = candidate
+                    break
+            if resolved:
+                break
+
+            if lib.startswith("boost_"):
+                prefix = f"{lib}-".lower()
+                for name in os.listdir(libdir):
+                    if name.lower().startswith(prefix) and name.lower().endswith(".lib"):
+                        resolved = os.path.splitext(name)[0]
+                        break
+            if resolved:
+                break
+
+        if not resolved and lib in system_libs:
+            resolved = lib
+
+        if resolved and resolved not in normalized:
+            normalized.append(resolved)
+
+    return normalized
+
+
 def get_extra_compile_args():
     """Return platform-specific compiler flags."""
     if IS_WINDOWS:
-        return ["/bigobj", "/EHsc", "/std:c++17"]
+        # Keep legacy Python C API keyword arrays and UTF-8 filesystem strings building under C++20.
+        return ["/bigobj", "/EHsc", "/std:c++20", "/Zc:strictStrings-", "/Zc:char8_t-"]
     args = ["-std=c++17"]
     if IS_DARWIN:
         args.append("-stdlib=libc++")
@@ -244,6 +298,8 @@ def get_extra_defines():
     if IS_WINDOWS:
         defines.extend([
             ("NOMINMAX", None),
+            ("NOGDI", None),
+            ("WIN32_LEAN_AND_MEAN", None),
             ("_USE_MATH_DEFINES", None),
             ("CGAL_DISABLE_ROUNDING_MATH_CHECK", None),
         ])
@@ -265,9 +321,19 @@ def detect_lib3mf():
 
         major = int(ver.split(".")[0])
         if major >= 2:
+            for base in list(inc_dirs):
+                cpp_bindings_dir = os.path.join(base, "Bindings", "Cpp")
+                if (cpp_bindings_dir not in inc_dirs and
+                        os.path.isfile(os.path.join(cpp_bindings_dir, "lib3mf_implicit.hpp"))):
+                    inc_dirs.append(cpp_bindings_dir)
             sources = ["src/io/export_3mf_v2.cc", "src/io/import_3mf_v2.cc"]
             print(f"lib3mf: found v{ver} (v2 API)")
         else:
+            for base in list(inc_dirs):
+                legacy_dir = os.path.join(base, "lib3mf")
+                if (legacy_dir not in inc_dirs and
+                        os.path.isfile(os.path.join(legacy_dir, "Model", "COM", "NMR_DLLInterfaces.h"))):
+                    inc_dirs.append(legacy_dir)
             sources = ["src/io/export_3mf_v1.cc", "src/io/import_3mf_v1.cc"]
             print(f"lib3mf: found v{ver} (v1 API)")
 
@@ -384,6 +450,12 @@ def detect_libfive():
 class BuildExtWithLexYacc(build_ext):
     """Custom build_ext command to run lex/yacc before building extension modules."""
 
+    def finalize_options(self):
+        super().finalize_options()
+        build_parallel = os.environ.get("PYTHONSCAD_BUILD_PARALLEL")
+        if build_parallel and not self.parallel:
+            self.parallel = int(build_parallel)
+
     def run(self):
         yacc_src = "src/core/parser.y"
         lex_src = "src/core/lexer.l"
@@ -399,8 +471,20 @@ class BuildExtWithLexYacc(build_ext):
             target_time = min(os.path.getmtime(t) for t in targets)
             return src_time > target_time
 
-        bison_cmd = "win_bison" if IS_WINDOWS else "bison"
-        flex_cmd = "win_flex" if IS_WINDOWS else "flex"
+        def resolve_tool(env_var, candidates):
+            env_value = os.environ.get(env_var)
+            if env_value:
+                if os.path.isfile(env_value) or shutil.which(env_value):
+                    return env_value
+                raise RuntimeError(f"{env_var} points to missing executable: {env_value}")
+            for candidate in candidates:
+                resolved = shutil.which(candidate)
+                if resolved:
+                    return resolved
+            raise RuntimeError(f"Could not find any of: {', '.join(candidates)}")
+
+        bison_cmd = resolve_tool("BISON", ["win_bison", "bison"] if IS_WINDOWS else ["bison"])
+        flex_cmd = resolve_tool("FLEX", ["win_flex", "flex"] if IS_WINDOWS else ["flex"])
 
         if needs_rebuild(yacc_src, [yacc_out, yacc_hdr]):
             print(f"Generating Yacc: {yacc_src}")
@@ -443,6 +527,7 @@ def main():
               "src/python/pyconversion.cc",
               "src/python/pydata.cc",
               "src/python/pyopenscad.cc",
+              "src/python/python_runtime.cc",
               "src/python/pymod.cc",
               "src/python/pip_fixer.cc"
             ]
@@ -702,12 +787,16 @@ def main():
         ("STACKSIZE", "524288"),
     ] + lib3mf_defines + libfive_defines + get_extra_defines()
 
+    library_dirs = get_library_dirs()
+    raw_link_libraries = get_link_libraries() + lib3mf_libs
+    link_libraries = normalize_windows_link_libraries(raw_link_libraries, library_dirs)
+
     pythonscad_ext = Extension(
         "_openscad",
         sources=all_sources,
         include_dirs=project_include_dirs,
-        library_dirs=get_library_dirs(),
-        libraries=get_link_libraries() + lib3mf_libs,
+        library_dirs=library_dirs,
+        libraries=link_libraries,
         define_macros=all_defines,
         extra_compile_args=get_extra_compile_args(),
         extra_link_args=get_extra_link_args(),

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ def get_link_libraries():
 
     # Match CMake (Boost::regex, Boost::program_options) so shared deps appear
     # in DT_NEEDED and auditwheel/delocate/delvewheel can bundle them.
-    boost_libs = ["boost_program_options", "boost_system"]
+    boost_libs = ["boost_program_options"]
     if not IS_WINDOWS:
         boost_libs.insert(0, "boost_regex")
     for lib in boost_libs:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ def apply_wheel_build_env():
         os.environ["PATH"] = winflex + os.pathsep + os.environ.get("PATH", "")
     msys2_usr_bin = os.environ.get("MSYS2_USR_BIN")
     if msys2_usr_bin and os.path.isdir(msys2_usr_bin):
-        os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + msys2_usr_bin
+        path = os.environ.get("PATH", "")
+        os.environ["PATH"] = path + os.pathsep + msys2_usr_bin if path else msys2_usr_bin
 
 def get_version():
     here = os.path.dirname(os.path.abspath(__file__))

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -46,6 +46,8 @@ namespace fs = std::filesystem;
 #ifdef _MSC_VER
 #include <io.h>
 #define isatty _isatty
+#elif defined(__MINGW32__)
+#include <unistd.h>
 #endif
 std::string stringcontents;
 int lexerget_lineno(void);

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -27,6 +27,7 @@
 %option prefix="lexer"
 %option nounput
 %option noinput
+%option nounistd
 
 %{
 

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -46,7 +46,7 @@ namespace fs = std::filesystem;
 #ifdef _MSC_VER
 #include <io.h>
 #define isatty _isatty
-#elif defined(__MINGW32__)
+#else
 #include <unistd.h>
 #endif
 std::string stringcontents;

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -800,7 +800,7 @@ std::string PolygonNode::toString() const
 VectorOfVector2d PolygonNode::createGeometry_sub(const std::vector<Vector3d>& points,
                                                  const std::vector<size_t>& path) const
 {
-  std::vector<Vector2d> result;
+  VectorOfVector2d result;
   int n = path.size();
   for (int i = 0; i < n; i++) {
     const auto& ptprev = points[path[(i + n - 1) % n]];

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -2425,7 +2425,7 @@ void calculate_path_dirs(Vector3d prevpt, Vector3d curpt, Vector3d nextpt, Vecto
 }
 
 std::vector<Vector3d> calculate_path_profile(Vector3d *vec_x, Vector3d *vec_y, Vector3d curpt,
-                                             const std::vector<Vector2d>& profile)
+                                             const VectorOfVector2d& profile)
 {
   std::vector<Vector3d> result;
   for (unsigned int i = 0; i < profile.size(); i++) {
@@ -2611,7 +2611,7 @@ static std::unique_ptr<Geometry> extrudePath(const PathExtrudeNode& node, const 
           }
         }
         for (auto& p3d : ps_face->indices) {
-          std::vector<Vector2d> p2d;
+          VectorOfVector2d p2d;
           for (unsigned int i = 0; i < p3d.size(); i++) {
             Vector3d pt = ps_face->vertices[p3d[i]];
             p2d.push_back(Vector2d(pt[0], pt[1]));
@@ -3198,7 +3198,7 @@ static std::unique_ptr<PolySet> wrapObject(const WrapNode& node, const PolySet *
   }
   // now build scale form xmin to xmax
   std::vector<double> xscale;
-  std::vector<Vector2d> polygon;
+  VectorOfVector2d polygon;
   int polygonlen;
   if (node.shape != nullptr) {
     Tree tree(node.shape, "");

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -244,12 +244,12 @@ void PolySetBuilder::addCurve(std::shared_ptr<Curve> new_curve)
     for (auto& curve : curves) {
       auto arc_curve = std::dynamic_pointer_cast<ArcCurve>(curve);
       if (arc_curve != nullptr) {
-        if (*arc_curve == *arc_new_curve) return;  // duplicate
+        if (arc_curve->operator==(*arc_new_curve)) return;  // duplicate
       }
     }
   }
   for (auto& curve : curves)
-    if (*curve == *new_curve) return;  // duplicate
+    if (curve->operator==(*new_curve)) return;  // duplicate
   curves.push_back(new_curve);
 }
 
@@ -260,12 +260,12 @@ void PolySetBuilder::addSurface(std::shared_ptr<Surface> new_surface)
     for (auto& surface : surfaces) {
       auto cyl_surface = std::dynamic_pointer_cast<CylinderSurface>(surface);
       if (cyl_surface != nullptr) {
-        if (*cyl_surface == *cyl_new_surface) return;  // duplicate
+        if (cyl_surface->operator==(*cyl_new_surface)) return;  // duplicate
       }
     }
   }
   for (auto& surface : surfaces)
-    if (*surface == *new_surface) return;  // duplicate
+    if (surface->operator==(*new_surface)) return;  // duplicate
   surfaces.push_back(new_surface);
 }
 

--- a/src/geometry/rotate_extrude.cc
+++ b/src/geometry/rotate_extrude.cc
@@ -180,7 +180,7 @@ std::unique_ptr<PolySet> rotatePolygonSub(const RotateExtrudeNode& node, const P
 
     for (const auto& outline : poly.outlines()) {
       const double angle = node.start + j * node.angle / fragments;  // start on the X axis
-      std::vector<Vector2d> vertices2d;
+      VectorOfVector2d vertices2d;
       double cur_twist = 0;
 #ifdef ENABLE_PYTHON
       if (node.profile_func != NULL) {

--- a/src/io/export_foldable.h
+++ b/src/io/export_foldable.h
@@ -39,7 +39,7 @@ struct plateS {
   VectorOfVector2d pt;     // actual points
   VectorOfVector2d pt_l1;  // leap starts
   VectorOfVector2d pt_l2;  // leap ends
-  VectorOfVector2d bnd;    // Complete boundary representing points and leps
+  VectorOfVector2d bnd;    // Complete boundary representing points and leaps
   int done;
 };
 

--- a/src/io/export_foldable.h
+++ b/src/io/export_foldable.h
@@ -1,4 +1,13 @@
 
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "geometry/linalg.h"
+
+class PolySet;
+
 struct lineS {
   Vector2d p1;
   Vector2d p2;
@@ -27,10 +36,10 @@ struct plotSettingsS {
 };
 
 struct plateS {
-  std::vector<Vector2d> pt;     // actual points
-  std::vector<Vector2d> pt_l1;  // leap starts
-  std::vector<Vector2d> pt_l2;  // leap ends
-  std::vector<Vector2d> bnd;    // Complete boundary representing points and leps
+  VectorOfVector2d pt;     // actual points
+  VectorOfVector2d pt_l1;  // leap starts
+  VectorOfVector2d pt_l2;  // leap ends
+  VectorOfVector2d bnd;    // Complete boundary representing points and leps
   int done;
 };
 

--- a/src/python/py_math.cc
+++ b/src/python/py_math.cc
@@ -374,27 +374,31 @@ void PyOpenSCADVectorIter_dealloc(PyOpenSCADVectorIter *self)
 }
 
 // Iterator Type Definition
-PyTypeObject PyOpenSCADVectorIterType = {
-  PyVarObject_HEAD_INIT(nullptr, 0).tp_name = "PyOpenSCADVectorType.Iterator",
-  .tp_basicsize = sizeof(PyOpenSCADVectorIter),
-  .tp_dealloc = (destructor)PyOpenSCADVectorIter_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_iter = PyOpenSCADVectorType_iter,
-  .tp_iternext = PyOpenSCADVectorType_iternext,  // <-- __next__ Implementierung
-};
+PyTypeObject PyOpenSCADVectorIterType = [] {
+  PyTypeObject type = {PyVarObject_HEAD_INIT(nullptr, 0)};
+  type.tp_name = "PyOpenSCADVectorType.Iterator";
+  type.tp_basicsize = sizeof(PyOpenSCADVectorIter);
+  type.tp_dealloc = (destructor)PyOpenSCADVectorIter_dealloc;
+  type.tp_flags = Py_TPFLAGS_DEFAULT;
+  type.tp_iter = PyOpenSCADVectorType_iter;
+  type.tp_iternext = PyOpenSCADVectorType_iternext;  // <-- __next__ Implementierung
+  return type;
+}();
 
 PyMappingMethods PyOpenSCADVectorMapping = {0, PyOpenSCADVector__getitem__, PyOpenSCADVector__setitem__};
 
-PyTypeObject PyOpenSCADVectorType = {
-  PyVarObject_HEAD_INIT(NULL, 0).tp_name = "PyOpenSCADVector",
-  .tp_basicsize = sizeof(PyOpenSCADVectorObject),
-  .tp_itemsize = 0,
-  .tp_repr = (reprfunc)PyOpenSCADVector_repr,
-  .tp_as_number = &PyOpenSCADVector_number_methods,
-  .tp_as_mapping = &PyOpenSCADVectorMapping,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_iter = PyOpenSCADVectorType_iter,
-  .tp_methods = PyOpenSCADVectorMethods,
-  .tp_init = (initproc)python_vector,
-  .tp_new = PyOpenSCADVector_new,
-};
+PyTypeObject PyOpenSCADVectorType = [] {
+  PyTypeObject type = {PyVarObject_HEAD_INIT(NULL, 0)};
+  type.tp_name = "PyOpenSCADVector";
+  type.tp_basicsize = sizeof(PyOpenSCADVectorObject);
+  type.tp_itemsize = 0;
+  type.tp_repr = (reprfunc)PyOpenSCADVector_repr;
+  type.tp_as_number = &PyOpenSCADVector_number_methods;
+  type.tp_as_mapping = &PyOpenSCADVectorMapping;
+  type.tp_flags = Py_TPFLAGS_DEFAULT;
+  type.tp_iter = PyOpenSCADVectorType_iter;
+  type.tp_methods = PyOpenSCADVectorMethods;
+  type.tp_init = (initproc)python_vector;
+  type.tp_new = PyOpenSCADVector_new;
+  return type;
+}();

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -2217,6 +2217,9 @@ static void run_basic_python_repl(void)
 {
   pymain_run_interactive_hook();
   PyCompilerFlags cf = {};
+#if PY_VERSION_HEX >= 0x030B0000
+  cf.cf_feature_version = PY_MINOR_VERSION;
+#endif
   PyRun_AnyFileFlags(stdin, "<stdin>", &cf);
 }
 

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1820,14 +1820,17 @@ static PyGetSetDef PyOpenSCADItemRef_getset[] = {
    NULL},
   {NULL}};
 
-static PyTypeObject PyOpenSCADItemRefType = {
-  PyVarObject_HEAD_INIT(NULL, 0).tp_name = "pyopenscad.ChildRef",
-  .tp_basicsize = sizeof(PyOpenSCADItemRef),
-  .tp_dealloc = (destructor)PyOpenSCADItemRef_dealloc,
-  .tp_getattro = PyOpenSCADItemRef_getattro,
-  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-  .tp_getset = PyOpenSCADItemRef_getset,
-  .tp_new = PyType_GenericNew};
+static PyTypeObject PyOpenSCADItemRefType = [] {
+  PyTypeObject type = {PyVarObject_HEAD_INIT(NULL, 0)};
+  type.tp_name = "pyopenscad.ChildRef";
+  type.tp_basicsize = sizeof(PyOpenSCADItemRef);
+  type.tp_dealloc = (destructor)PyOpenSCADItemRef_dealloc;
+  type.tp_getattro = PyOpenSCADItemRef_getattro;
+  type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+  type.tp_getset = PyOpenSCADItemRef_getset;
+  type.tp_new = PyType_GenericNew;
+  return type;
+}();
 
 // ---------------------
 // PyOpenSCADObjectIter
@@ -1886,14 +1889,16 @@ void PyOpenSCADObjectIter_dealloc(PyOpenSCADObjectIter *self)
 }
 
 // Iterator Type Definition
-PyTypeObject PyOpenSCADObjectIterType = {
-  PyVarObject_HEAD_INIT(nullptr, 0).tp_name = "PyOpenSCADType.Iterator",
-  .tp_basicsize = sizeof(PyOpenSCADObjectIter),
-  .tp_dealloc = (destructor)PyOpenSCADObjectIter_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_iter = PyOpenSCADType_iter,
-  .tp_iternext = PyOpenSCADType_iternext,  // <-- __next__ Implementierung
-};
+PyTypeObject PyOpenSCADObjectIterType = [] {
+  PyTypeObject type = {PyVarObject_HEAD_INIT(nullptr, 0)};
+  type.tp_name = "PyOpenSCADType.Iterator";
+  type.tp_basicsize = sizeof(PyOpenSCADObjectIter);
+  type.tp_dealloc = (destructor)PyOpenSCADObjectIter_dealloc;
+  type.tp_flags = Py_TPFLAGS_DEFAULT;
+  type.tp_iter = PyOpenSCADType_iter;
+  type.tp_iternext = PyOpenSCADType_iternext;  // <-- __next__ Implementierung
+  return type;
+}();
 
 // ---------------------------
 // PythonSCAD Sequence methods
@@ -2211,7 +2216,7 @@ static void windows_reattach_console_for_repl(void)
 static void run_basic_python_repl(void)
 {
   pymain_run_interactive_hook();
-  PyCompilerFlags cf = _PyCompilerFlags_INIT;
+  PyCompilerFlags cf = {};
   PyRun_AnyFileFlags(stdin, "<stdin>", &cf);
 }
 

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -2216,11 +2216,7 @@ static void windows_reattach_console_for_repl(void)
 static void run_basic_python_repl(void)
 {
   pymain_run_interactive_hook();
-  PyCompilerFlags cf = {};
-#if PY_VERSION_HEX >= 0x030B0000
-  cf.cf_feature_version = PY_MINOR_VERSION;
-#endif
-  PyRun_AnyFileFlags(stdin, "<stdin>", &cf);
+  PyRun_AnyFileFlags(stdin, "<stdin>", nullptr);
 }
 
 // Open the basic embedded CPython REPL on stdin. Reachable explicitly


### PR DESCRIPTION
## Summary
- Restore the PyPI wheel workflow across Windows, macOS, and Linux by fixing platform-specific source selection, linker inputs, dependency bootstrap, and repair steps.
- Keep Windows wheel dependency setup reproducible with the pinned vcpkg release/baseline, release triplet, MSYS2 parser tools, and targeted binary caches.
- Remove temporary wheel debug diagnostics after the matrix went green, and add Renovate coverage so the vcpkg release/baseline pins do not go stale.

## Test plan
- Manual `publish-to-pypi.yml` workflow built all platforms successfully.
- `pre-commit run --files setup.py scripts/cibuildwheel/install-deps-windows.ps1 .github/workflows/publish-to-pypi.yml pyproject.toml doc/pypi-wheels.md`
- `python3 scripts/cibuildwheel/update-vcpkg-baseline.py`

## Review follow-up
- Resolved stale and current Copilot review threads with either code changes or rationale.
- Documented current macOS `macosx_15_0_*` wheel tags and Windows vcpkg triplet assumptions.