### PR TITLE
feat(osimport): add split_by_color option for multi-color SVG import

### DIFF
--- a/libraries/python/stubs/_openscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/_openscad-stubs/__init__.pyi
@@ -1,6 +1,6 @@
 """ PythonSCAD Stub File for use in editors like Visual Studio Code """
 from enum import Enum
-from typing import List, Mapping, Optional, Self, Sequence, Union, overload
+from typing import List, Literal, Mapping, Optional, Self, Sequence, Union, overload
 
 PyOpenSCADs = Union["PyOpenSCAD", list["PyOpenSCAD"]]
 """Type for functions that accept either a single OpenSCAD object or a list of objects."""
@@ -1371,27 +1371,63 @@ def machineconfig(
     """
     ...
 
+@overload
 def osimport(
     file: str,
-    layer: str,
-    convexity: int,
-    origin: List[float],
-    scale: float,
-    width: float,
-    height: float,
-    filename: str,
-    center: bool,
-    dpi: float,
-    stroke: bool,
-    id: int,
+    layer: Optional[str] = None,
+    convexity: int = 2,
+    origin: Optional[List[float]] = None,
+    scale: float = 1,
+    width: float = 1,
+    height: float = 1,
+    center: bool = False,
+    dpi: float = 72.0,
+    id: Optional[str] = None,
+    stroke: bool = False,
+    fn: Optional[float] = None,
+    fa: Optional[float] = None,
+    fs: Optional[float] = None,
+    split_by_color: Literal[False] = False,
 ) -> PyOpenSCAD:
     """Imports Object from disc
+
     Args:
         stroke: defaults to true which turnes open SVG pathes to polygons. if set to false,
                 SVG pathes are converted to polylines instead.
+        split_by_color: SVG only. When True, returns a dict of ``{hex_color: PyOpenSCAD}``
+                with one 2D object per distinct color found in the SVG, instead of a
+                single merged object. Useful for exporting each color as a separate
+                named/colored object (e.g. for multi-toolhead 3MF export via
+                ``export()``'s dict form). Raises ValueError for non-SVG files or if
+                the SVG has no colored shapes.
 
-
+    Example:
+        >>> parts = osimport("logo.svg", split_by_color=True)
+        >>> solids = {name: obj.linear_extrude(2) for name, obj in parts.items()}
+        >>> export(solids, "logo.3mf")
     """
+    ...
+
+@overload
+def osimport(
+    file: str,
+    layer: Optional[str] = None,
+    convexity: int = 2,
+    origin: Optional[List[float]] = None,
+    scale: float = 1,
+    width: float = 1,
+    height: float = 1,
+    center: bool = False,
+    dpi: float = 72.0,
+    id: Optional[str] = None,
+    stroke: bool = False,
+    fn: Optional[float] = None,
+    fa: Optional[float] = None,
+    fs: Optional[float] = None,
+    *,
+    split_by_color: Literal[True],
+) -> dict[str, PyOpenSCAD]:
+    """See the non-overloaded osimport() docstring."""
     ...
 
 def osuse(path: str) -> PyOpenSCAD:

--- a/libraries/python/stubs/_openscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/_openscad-stubs/__init__.pyi
@@ -1389,11 +1389,11 @@ def osimport(
     fs: Optional[float] = None,
     split_by_color: Literal[False] = False,
 ) -> PyOpenSCAD:
-    """Imports Object from disc
+    """Imports an object from disk.
 
     Args:
-        stroke: defaults to true which turnes open SVG pathes to polygons. if set to false,
-                SVG pathes are converted to polylines instead.
+        stroke: When True, turns open SVG paths into polygons. When False (the
+                default), SVG paths are converted to polylines instead.
         split_by_color: SVG only. When True, returns a dict of ``{hex_color: PyOpenSCAD}``
                 with one 2D object per distinct color found in the SVG, instead of a
                 single merged object. Useful for exporting each color as a separate

--- a/libraries/python/stubs/_openscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/_openscad-stubs/__init__.pyi
@@ -1435,7 +1435,7 @@ def osimport(
     file: str,
     layer: Optional[str],
     convexity: int,
-    origin: List[float],
+    origin: Optional[List[float]],
     scale: float,
     width: float,
     height: float,
@@ -1443,9 +1443,9 @@ def osimport(
     dpi: float,
     id: Optional[str],
     stroke: bool,
-    fn: float,
-    fa: float,
-    fs: float,
+    fn: Optional[float],
+    fa: Optional[float],
+    fs: Optional[float],
     split_by_color: Literal[True],
 ) -> dict[str, PyOpenSCAD]:
     """Positional form of the split-by-color overload."""

--- a/libraries/python/stubs/_openscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/_openscad-stubs/__init__.pyi
@@ -1430,6 +1430,27 @@ def osimport(
     """See the non-overloaded osimport() docstring."""
     ...
 
+@overload
+def osimport(
+    file: str,
+    layer: Optional[str],
+    convexity: int,
+    origin: List[float],
+    scale: float,
+    width: float,
+    height: float,
+    center: bool,
+    dpi: float,
+    id: Optional[str],
+    stroke: bool,
+    fn: float,
+    fa: float,
+    fs: float,
+    split_by_color: Literal[True],
+) -> dict[str, PyOpenSCAD]:
+    """Positional form of the split-by-color overload."""
+    ...
+
 def osuse(path: str) -> PyOpenSCAD:
     """Import an OpenSCAD library, exposing its modules and functions.
 

--- a/src/core/ColorUtil.cc
+++ b/src/core/ColorUtil.cc
@@ -5,6 +5,7 @@
 #include <boost/spirit/home/support/common_terminals.hpp>
 #include <cctype>
 #include <cmath>
+#include <cstdio>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -120,6 +121,15 @@ std::optional<Color4f> parse_color(const std::string& col)
   }
 
   return {};
+}
+
+std::string toHexString(const Color4f& col)
+{
+  int r = 0, g = 0, b = 0, a = 0;
+  col.getRgba(r, g, b, a);
+  char buf[10];
+  std::snprintf(buf, sizeof(buf), "#%02x%02x%02x%02x", r, g, b, a);
+  return std::string(buf);
 }
 
 Color4f getColor(const std::string& col, const Color4f& defaultcolor)

--- a/src/core/ColorUtil.h
+++ b/src/core/ColorUtil.h
@@ -18,6 +18,9 @@ inline Color4f CORNFIELD_FACE_COLOR{0xf9, 0xd7, 0x2c, 0xff};
 
 std::optional<Color4f> parse_color(const std::string& col);
 
+// Formats a color as a lowercase "#rrggbbaa" hex string (inverse of parse_color's hex path).
+std::string toHexString(const Color4f& col);
+
 Color4f getColor(const std::string& col, const Color4f& defaultcolor);
 
 Color4f getContrastColor(const Color4f& col);

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -235,7 +235,7 @@ std::unique_ptr<const Geometry> ImportNode::createGeometry() const
 #ifndef ENABLE_PIP
   case ImportType::SVG: {
     g = import_svg(this->discretizer, this->filename, this->id, this->layer, this->dpi, this->center,
-                   loc, this->stroke);
+                   loc, this->stroke, this->colorFilter);
     break;
   }
 #endif
@@ -301,6 +301,10 @@ std::string ImportNode::toString() const
   stream << ", origin = [" << std::dec << this->origin_x << ", " << this->origin_y << "]";
   if (this->type == ImportType::SVG) {
     stream << ", dpi = " << this->dpi;
+    if (this->colorFilter) {
+      stream << ", colorFilter = [" << this->colorFilter->r() << ", " << this->colorFilter->g() << ", "
+             << this->colorFilter->b() << ", " << this->colorFilter->a() << "]";
+    }
   }
   stream << ", scale = " << this->scale << ", center = " << (this->center ? "true" : "false")
          << ", convexity = " << this->convexity << ", " << this->discretizer

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -300,7 +300,7 @@ std::string ImportNode::toString() const
   }
   stream << ", origin = [" << std::dec << this->origin_x << ", " << this->origin_y << "]";
   if (this->type == ImportType::SVG) {
-    stream << ", dpi = " << this->dpi;
+    stream << ", dpi = " << this->dpi << ", stroke = " << (this->stroke ? "true" : "false");
     if (this->colorFilter) {
       stream << ", colorFilter = [" << this->colorFilter->r() << ", " << this->colorFilter->g() << ", "
              << this->colorFilter->b() << ", " << this->colorFilter->a() << "]";

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -48,5 +48,8 @@ public:
   double origin_x, origin_y, scale;
   double width, height;
   bool stroke = false;
+  // SVG only: when set, restricts import to shapes resolving to this exact color.
+  // Used by osimport(..., split_by_color=True) to build one node per SVG color.
+  boost::optional<Color4f> colorFilter;
   std::unique_ptr<const class Geometry> createGeometry() const override;
 };

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -8,6 +8,7 @@
 #include "core/ModuleInstantiation.h"
 #include "core/Value.h"
 #include "core/node.h"
+#include "geometry/linalg.h"
 
 enum class ImportType {
   UNKNOWN,

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -3,9 +3,11 @@
 #include <boost/optional.hpp>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "core/AST.h"
 #include "core/CurveDiscretizer.h"
+#include "geometry/linalg.h"
 
 std::unique_ptr<class PolySet> import_stl(const std::string& filename, const Location& loc);
 std::unique_ptr<class PolySet> import_step(const std::string& filename, const Location& loc);
@@ -14,10 +16,18 @@ std::unique_ptr<class PolySet> import_off(const std::string& filename, const Loc
 std::unique_ptr<class PolySet> import_amf(const std::string&, const Location& loc);
 std::unique_ptr<class PolySet> import_3mf(const std::string&, const Location& loc);
 
-std::unique_ptr<class Polygon2d> import_svg(CurveDiscretizer discretizer, const std::string& filename,
+std::unique_ptr<class Polygon2d> import_svg(
+  CurveDiscretizer discretizer, const std::string& filename, const boost::optional<std::string>& id,
+  const boost::optional<std::string>& layer, const double dpi, const bool center, const Location& loc,
+  bool stroke, const boost::optional<Color4f>& colorFilter = boost::none);
+
+// Returns the distinct outline colors found in an SVG file, in first-appearance order,
+// resolved through the same fill/stroke -> Color4f logic used by import_svg().
+// Used to drive osimport(..., split_by_color=True).
+std::vector<Color4f> import_svg_list_colors(CurveDiscretizer discretizer, const std::string& filename,
                                             const boost::optional<std::string>& id,
-                                            const boost::optional<std::string>& layer, const double dpi,
-                                            const bool center, const Location& loc, bool stroke);
+                                            const boost::optional<std::string>& layer, bool stroke,
+                                            const Location& loc);
 #ifdef ENABLE_CDR
 std::unique_ptr<class Polygon2d> import_cdr(CurveDiscretizer discretizer, const std::string& filename,
                                             const Location& loc);

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -16,10 +16,11 @@ std::unique_ptr<class PolySet> import_off(const std::string& filename, const Loc
 std::unique_ptr<class PolySet> import_amf(const std::string&, const Location& loc);
 std::unique_ptr<class PolySet> import_3mf(const std::string&, const Location& loc);
 
-std::unique_ptr<class Polygon2d> import_svg(
-  CurveDiscretizer discretizer, const std::string& filename, const boost::optional<std::string>& id,
-  const boost::optional<std::string>& layer, const double dpi, const bool center, const Location& loc,
-  bool stroke, const boost::optional<Color4f>& colorFilter = boost::none);
+std::unique_ptr<class Polygon2d> import_svg(CurveDiscretizer discretizer, const std::string& filename,
+                                            const boost::optional<std::string>& id,
+                                            const boost::optional<std::string>& layer, const double dpi,
+                                            const bool center, const Location& loc, bool stroke,
+                                            const boost::optional<Color4f>& colorFilter = boost::none);
 
 // Returns the distinct outline colors found in an SVG file, in first-appearance order,
 // resolved through the same fill/stroke -> Color4f logic used by import_svg().

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -29,6 +29,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <algorithm>
 #include <exception>
 #include <memory>
 #include <string>
@@ -80,42 +81,91 @@ double calc_alignment(const libsvg::align_t alignment, double page_mm, double sc
   }
 }
 
+// Resolves an SVG fill/stroke color string the same way for every caller (regular
+// import, color enumeration, and color-filtered import), so that Color4f equality
+// comparisons between them (e.g. against ClipperUtils::cleanUnion's grouping) agree.
+Color4f resolve_outline_color(const std::string& color)
+{
+  if (color == "none") return Color4f(0, 0, 0, 0);  // transparent
+  auto x = OpenSCAD::parse_color(color);
+  if (x.has_value()) return *x;
+  return *OpenSCAD::parse_color("#f9d72c");
+}
+
+// Shared shape-selector construction for import_svg() and import_svg_list_colors(),
+// so both walk the exact same set of shapes for a given id/layer filter.
+void build_svg_selector(fnContext& scadContext, const boost::optional<std::string>& id,
+                        const boost::optional<std::string>& layer)
+{
+  if (id) {
+    scadContext.selector = [&scadContext, id, layer](const libsvg::shape *s) {
+      bool layer_match = true;
+      if (layer) {
+        layer_match = false;
+        for (const libsvg::shape *shape = s; shape->get_parent() != nullptr;
+             shape = shape->get_parent()) {
+          if (shape->has_layer() && shape->get_layer() == layer.get()) {
+            layer_match = true;
+            break;
+          }
+        }
+      }
+      return scadContext.match(layer_match && s->has_id() && s->get_id() == id.get());
+    };
+  } else if (layer) {
+    scadContext.selector = [&scadContext, layer](const libsvg::shape *s) {
+      return scadContext.match(s->has_layer() && s->get_layer() == layer.get());
+    };
+  } else {
+    // no selection means selecting the root
+    scadContext.selector = [&scadContext](const libsvg::shape *s) {
+      return scadContext.match(s->get_parent() == nullptr);
+    };
+  }
+}
+
 }  // namespace
+
+std::vector<Color4f> import_svg_list_colors(CurveDiscretizer discretizer, const std::string& filename,
+                                            const boost::optional<std::string>& id,
+                                            const boost::optional<std::string>& layer, bool stroke,
+                                            const Location& loc)
+{
+  std::vector<Color4f> colors;
+  try {
+    fnContext scadContext(
+      [&discretizer](double r, double angle) { return discretizer.getCircularSegmentCount(r, angle); },
+      discretizer.getPathSegmentCount(), stroke);
+    build_svg_selector(scadContext, id, layer);
+
+    const auto shapes = libsvg::libsvg_read_file(filename.c_str(), (void *)&scadContext);
+    for (const auto& shape_ptr : *shapes) {
+      if (shape_ptr->is_excluded()) continue;
+      const auto& s = *shape_ptr;
+      if (s.get_path_list().empty()) continue;
+      const Color4f color = resolve_outline_color(stroke ? s.get_stroke() : s.get_fill());
+      if (std::find(colors.begin(), colors.end(), color) == colors.end()) {
+        colors.push_back(color);
+      }
+    }
+    libsvg_free(shapes);
+  } catch (const std::exception& e) {
+    LOG(message_group::Error, "%1$s, import() at line %2$d", e.what(), loc.firstLine());
+  }
+  return colors;
+}
 
 std::unique_ptr<Polygon2d> import_svg(CurveDiscretizer discretizer, const std::string& filename,
                                       const boost::optional<std::string>& id,
                                       const boost::optional<std::string>& layer, const double dpi,
-                                      const bool center, const Location& loc, bool stroke)
+                                      const bool center, const Location& loc, bool stroke,
+                                      const boost::optional<Color4f>& colorFilter)
 {
   try {
     fnContext scadContext(
       [&discretizer](double r, double angle) { return discretizer.getCircularSegmentCount(r, angle); },
       discretizer.getPathSegmentCount(), stroke);
-    if (id) {
-      scadContext.selector = [&scadContext, id, layer](const libsvg::shape *s) {
-        bool layer_match = true;
-        if (layer) {
-          layer_match = false;
-          for (const libsvg::shape *shape = s; shape->get_parent() != nullptr;
-               shape = shape->get_parent()) {
-            if (shape->has_layer() && shape->get_layer() == layer.get()) {
-              layer_match = true;
-              break;
-            }
-          }
-        }
-        return scadContext.match(layer_match && s->has_id() && s->get_id() == id.get());
-      };
-    } else if (layer) {
-      scadContext.selector = [&scadContext, layer](const libsvg::shape *s) {
-        return scadContext.match(s->has_layer() && s->get_layer() == layer.get());
-      };
-    } else {
-      // no selection means selecting the root
-      scadContext.selector = [&scadContext](const libsvg::shape *s) {
-        return scadContext.match(s->get_parent() == nullptr);
-      };
-    }
+    build_svg_selector(scadContext, id, layer);
 
     std::string match_args;
     if (id) {
@@ -195,16 +245,11 @@ std::unique_ptr<Polygon2d> import_svg(CurveDiscretizer discretizer, const std::s
       if (!shape_ptr->is_excluded()) {
         Polygon2d poly;
         const auto& s = *shape_ptr;
+        const Color4f resolved_color = resolve_outline_color(stroke ? s.get_stroke() : s.get_fill());
+        if (colorFilter && resolved_color != *colorFilter) continue;
         for (const auto& p : s.get_path_list()) {
           Outline2d outline;
-          std::string color = stroke ? s.get_stroke() : s.get_fill();
-          if (color == "none") outline.color = Color4f(0, 0, 0, 0);  // transparent
-          else {
-            auto x = OpenSCAD::parse_color(color);
-            if (x.has_value()) {
-              outline.color = *x;
-            } else outline.color = *OpenSCAD::parse_color("#f9d72c");
-          }
+          outline.color = resolved_color;
           for (const auto& v : p) {
             const double x = scale.x() * (-viewbox.x() + v.x()) - cx;
             const double y = scale.y() * (-viewbox.y() - v.y()) + cy;

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -176,7 +176,8 @@ std::unique_ptr<Polygon2d> import_svg(CurveDiscretizer discretizer, const std::s
       match_args += "layer = \"" + layer.get() + "\"";
     }
 
-    const auto shapes = libsvg::libsvg_read_file(filename.c_str(), (void *)&scadContext);
+    const std::unique_ptr<libsvg::shapes_list_t, decltype(&libsvg::libsvg_free)> shapes(
+      libsvg::libsvg_read_file(filename.c_str(), (void *)&scadContext), &libsvg::libsvg_free);
     if (!match_args.empty() && !scadContext.has_matches()) {
       LOG(message_group::Warning, loc, "", "import() filter %2$s did not match anything", filename,
           match_args);
@@ -263,7 +264,6 @@ std::unique_ptr<Polygon2d> import_svg(CurveDiscretizer discretizer, const std::s
         if (!poly.isEmpty()) polygons.push_back(std::make_shared<const Polygon2d>(poly));
       }
     }
-    libsvg_free(shapes);
     std::reverse(polygons.begin(), polygons.end());
     auto result_cleaned = ClipperUtils::cleanUnion(polygons);
     return std::make_unique<Polygon2d>(result_cleaned);

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -138,7 +138,8 @@ std::vector<Color4f> import_svg_list_colors(CurveDiscretizer discretizer, const 
       discretizer.getPathSegmentCount(), stroke);
     build_svg_selector(scadContext, id, layer);
 
-    const auto shapes = libsvg::libsvg_read_file(filename.c_str(), (void *)&scadContext);
+    const std::unique_ptr<libsvg::shapes_list_t, decltype(&libsvg::libsvg_free)> shapes(
+      libsvg::libsvg_read_file(filename.c_str(), (void *)&scadContext), &libsvg::libsvg_free);
     for (const auto& shape_ptr : *shapes) {
       if (shape_ptr->is_excluded()) continue;
       const auto& s = *shape_ptr;
@@ -148,7 +149,6 @@ std::vector<Color4f> import_svg_list_colors(CurveDiscretizer discretizer, const 
         colors.push_back(color);
       }
     }
-    libsvg_free(shapes);
   } catch (const std::exception& e) {
     LOG(message_group::Error, "%1$s, import() at line %2$d", e.what(), loc.firstLine());
   }

--- a/src/libsvg/libsvg.cc
+++ b/src/libsvg/libsvg.cc
@@ -299,8 +299,14 @@ void dump(int idx, shape *s)
 
 shapes_list_t *libsvg_read_file(const char *filename, void *context)
 {
-  shape_list = new shapes_list_t();
-  streamFile(filename, context);
+  auto shapes = std::make_unique<shapes_list_t>();
+  shape_list = shapes.get();
+  try {
+    streamFile(filename, context);
+  } catch (...) {
+    shape_list = nullptr;
+    throw;
+  }
 
   // #ifdef DEBUG
   //	if (!shape_list->empty()) {
@@ -308,7 +314,8 @@ shapes_list_t *libsvg_read_file(const char *filename, void *context)
   //	}
   // #endif
 
-  return shape_list;
+  shape_list = nullptr;
+  return shapes.release();
 }
 
 void libsvg_free(shapes_list_t *shapes)

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -32,6 +32,9 @@
 #include "pyfunctions.h"
 #include "export.h"
 #include "ImportNode.h"
+#include <io/import.h>
+#include <ColorNode.h>
+#include <ColorUtil.h>
 #include <io/fileutils.h>
 #include <GeometryEvaluator.h>
 #include <platform/PlatformUtils.h>
@@ -483,10 +486,12 @@ PyObject *python_oo_export(PyObject *obj, PyObject *args, PyObject *kwargs)
 PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, ImportType type)
 {
   DECLARE_INSTANCE();
-  char *kwlist[] = {"file", "layer", "convexity", "origin", "scale", "width", "height", "center",
-                    "dpi",  "id",    "stroke",    "fn",     "fa",    "fs",    NULL};
+  char *kwlist[] = {"file",  "layer", "convexity", "origin", "scale", "width",
+                    "height", "center", "dpi",     "id",     "stroke", "fn",
+                    "fa",    "fs",    "split_by_color", NULL};
   double fn = NAN, fa = NAN, fs = NAN;
   PyObject *stroke = nullptr;
+  PyObject *split_by_color = nullptr;
 
   std::string filename;
   const char *v = NULL, *layer = NULL, *id = NULL;
@@ -494,9 +499,9 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
   int convexity = 2;
   double scale = 1.0, width = 1, height = 1, dpi = ImportNode::SVG_DEFAULT_DPI;
   PyObject *origin = NULL;
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|siO!dddOdsOddd", kwlist, &v, &layer, &convexity,
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|siO!dddOdsOdddO", kwlist, &v, &layer, &convexity,
                                    &PyList_Type, &origin, &scale, &width, &height, &center, &dpi, &id,
-                                   &stroke, &fn, &fa, &fs
+                                   &stroke, &fn, &fa, &fs, &split_by_color
 
                                    )) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing osimport(filename)");
@@ -541,41 +546,97 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     else if (ext == ".step") actualtype = ImportType::STEP;
   }
 
-  auto node = std::make_shared<ImportNode>(instance, actualtype, CreateCurveDiscretizer(kwargs));
-
-  node->filename = filename;
-
-  if (layer != NULL) node->layer = layer;
-  if (id != NULL) node->id = id;
-  node->convexity = convexity;
-  if (node->convexity <= 0) node->convexity = 1;
-
-  if (origin != NULL && PyList_Check(origin) && PyList_Size(origin) == 2) {
-    node->origin_x = PyFloat_AsDouble(PyList_GetItem(origin, 0));
-    node->origin_y = PyFloat_AsDouble(PyList_GetItem(origin, 1));
+  const bool splitByColor = (split_by_color == Py_True);
+  if (splitByColor && actualtype != ImportType::SVG) {
+    PyErr_SetString(PyExc_ValueError, "osimport(): split_by_color=True is only supported for SVG files");
+    return NULL;
   }
+#ifdef ENABLE_PIP
+  if (splitByColor) {
+    PyErr_SetString(PyExc_ValueError,
+                    "osimport(): split_by_color=True is not supported in this build");
+    return NULL;
+  }
+#endif
 
-  node->center = 0;
-  if (center == Py_True) node->center = 1;
-
-  node->stroke = false;
-  if (stroke == Py_True) node->stroke = true;
-
-  node->scale = scale;
-  if (node->scale <= 0) node->scale = 1;
-
-  node->dpi = ImportNode::SVG_DEFAULT_DPI;
-  double val = dpi;
-  if (val < 0.001) {
+  double dpiVal = dpi;
+  if (dpiVal < 0.001) {
     PyErr_SetString(PyExc_TypeError, "Invalid dpi value giving");
     return NULL;
-  } else {
-    node->dpi = val;
   }
 
-  node->width = width;
-  node->height = height;
-  return PyOpenSCADObjectFromNode(&PyOpenSCADType, node);
+  auto build_node = [&](const boost::optional<Color4f>& colorFilter) {
+    auto n = std::make_shared<ImportNode>(instance, actualtype, CreateCurveDiscretizer(kwargs));
+
+    n->filename = filename;
+
+    if (layer != NULL) n->layer = layer;
+    if (id != NULL) n->id = id;
+    n->convexity = convexity;
+    if (n->convexity <= 0) n->convexity = 1;
+
+    if (origin != NULL && PyList_Check(origin) && PyList_Size(origin) == 2) {
+      n->origin_x = PyFloat_AsDouble(PyList_GetItem(origin, 0));
+      n->origin_y = PyFloat_AsDouble(PyList_GetItem(origin, 1));
+    }
+
+    n->center = 0;
+    if (center == Py_True) n->center = 1;
+
+    n->stroke = false;
+    if (stroke == Py_True) n->stroke = true;
+
+    n->scale = scale;
+    if (n->scale <= 0) n->scale = 1;
+
+    n->dpi = dpiVal;
+
+    n->width = width;
+    n->height = height;
+
+    n->colorFilter = colorFilter;
+    return n;
+  };
+
+  if (!splitByColor) {
+    auto node = build_node(boost::none);
+    return PyOpenSCADObjectFromNode(&PyOpenSCADType, node);
+  }
+
+  const boost::optional<std::string> idOpt = id != NULL ? boost::optional<std::string>(id) : boost::none;
+  const boost::optional<std::string> layerOpt =
+    layer != NULL ? boost::optional<std::string>(layer) : boost::none;
+  const bool strokeBool = (stroke == Py_True);
+  const std::vector<Color4f> colors = import_svg_list_colors(
+    CreateCurveDiscretizer(kwargs), filename, idOpt, layerOpt, strokeBool, instance->location());
+  if (colors.empty()) {
+    PyErr_SetString(PyExc_ValueError,
+                    "osimport(): split_by_color=True but no colored shapes were found in the SVG");
+    return NULL;
+  }
+
+  PyObject *result = PyDict_New();
+  if (result == nullptr) return nullptr;
+  for (const auto& color : colors) {
+    auto importNode = build_node(color);
+    auto colorNode = std::make_shared<ColorNode>(instance);
+    colorNode->color = color;
+    colorNode->children.push_back(importNode);
+
+    PyObject *pyobj = PyOpenSCADObjectFromNode(&PyOpenSCADType, colorNode);
+    if (pyobj == nullptr) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+    const std::string hexKey = OpenSCAD::toHexString(color);
+    const int rc = PyDict_SetItemString(result, hexKey.c_str(), pyobj);
+    Py_DECREF(pyobj);
+    if (rc < 0) {
+      Py_DECREF(result);
+      return nullptr;
+    }
+  }
+  return result;
 }
 
 PyObject *python_import(PyObject *self, PyObject *args, PyObject *kwargs)

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -510,6 +510,14 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     PyErr_SetString(PyExc_TypeError, "osimport(): origin must be a two-element list or None");
     return nullptr;
   }
+  double originX = 0;
+  double originY = 0;
+  if (origin != nullptr && origin != Py_None) {
+    originX = PyFloat_AsDouble(PyList_GetItem(origin, 0));
+    if (PyErr_Occurred()) return nullptr;
+    originY = PyFloat_AsDouble(PyList_GetItem(origin, 1));
+    if (PyErr_Occurred()) return nullptr;
+  }
   if (v == NULL || v[0] == '\0') {
     PyErr_SetString(PyExc_ValueError, "osimport(): filename must not be empty");
     return NULL;
@@ -580,12 +588,8 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     n->convexity = convexity;
     if (n->convexity <= 0) n->convexity = 1;
 
-    n->origin_x = 0;
-    n->origin_y = 0;
-    if (origin != NULL && PyList_Check(origin) && PyList_Size(origin) == 2) {
-      n->origin_x = PyFloat_AsDouble(PyList_GetItem(origin, 0));
-      n->origin_y = PyFloat_AsDouble(PyList_GetItem(origin, 1));
-    }
+    n->origin_x = originX;
+    n->origin_y = originY;
 
     n->center = 0;
     if (center == Py_True) n->center = 1;

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -488,7 +488,7 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
   DECLARE_INSTANCE();
   char *kwlist[] = {"file", "layer", "convexity", "origin", "scale", "width", "height",         "center",
                     "dpi",  "id",    "stroke",    "fn",     "fa",    "fs",    "split_by_color", NULL};
-  double fn = NAN, fa = NAN, fs = NAN;
+  PyObject *fn = nullptr, *fa = nullptr, *fs = nullptr;
   PyObject *stroke = nullptr;
   PyObject *split_by_color = nullptr;
 
@@ -498,13 +498,17 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
   int convexity = 2;
   double scale = 1.0, width = 1, height = 1, dpi = ImportNode::SVG_DEFAULT_DPI;
   PyObject *origin = NULL;
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|ziO!dddOdzOdddO", kwlist, &v, &layer, &convexity,
-                                   &PyList_Type, &origin, &scale, &width, &height, &center, &dpi, &id,
-                                   &stroke, &fn, &fa, &fs, &split_by_color
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|ziOdddOdzOOOOO", kwlist, &v, &layer, &convexity,
+                                   &origin, &scale, &width, &height, &center, &dpi, &id, &stroke, &fn,
+                                   &fa, &fs, &split_by_color
 
                                    )) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing osimport(filename)");
     return NULL;
+  }
+  if (origin != nullptr && origin != Py_None && (!PyList_Check(origin) || PyList_Size(origin) != 2)) {
+    PyErr_SetString(PyExc_TypeError, "osimport(): origin must be a two-element list or None");
+    return nullptr;
   }
   if (v == NULL || v[0] == '\0') {
     PyErr_SetString(PyExc_ValueError, "osimport(): filename must not be empty");

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -573,6 +573,8 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     n->convexity = convexity;
     if (n->convexity <= 0) n->convexity = 1;
 
+    n->origin_x = 0;
+    n->origin_y = 0;
     if (origin != NULL && PyList_Check(origin) && PyList_Size(origin) == 2) {
       n->origin_x = PyFloat_AsDouble(PyList_GetItem(origin, 0));
       n->origin_y = PyFloat_AsDouble(PyList_GetItem(origin, 1));
@@ -609,7 +611,8 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     CreateCurveDiscretizer(kwargs), filename, idOpt, layerOpt, strokeBool, instance->location());
   if (colors.empty()) {
     PyErr_SetString(PyExc_ValueError,
-                    "osimport(): split_by_color=True but no colored shapes were found in the SVG");
+                    "osimport(): split_by_color=True found no colors matching the SVG selection; "
+                    "check id, layer, and stroke settings");
     return NULL;
   }
 

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -486,9 +486,8 @@ PyObject *python_oo_export(PyObject *obj, PyObject *args, PyObject *kwargs)
 PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, ImportType type)
 {
   DECLARE_INSTANCE();
-  char *kwlist[] = {"file",  "layer", "convexity", "origin", "scale", "width",
-                    "height", "center", "dpi",     "id",     "stroke", "fn",
-                    "fa",    "fs",    "split_by_color", NULL};
+  char *kwlist[] = {"file", "layer", "convexity", "origin", "scale", "width", "height",         "center",
+                    "dpi",  "id",    "stroke",    "fn",     "fa",    "fs",    "split_by_color", NULL};
   double fn = NAN, fa = NAN, fs = NAN;
   PyObject *stroke = nullptr;
   PyObject *split_by_color = nullptr;
@@ -553,15 +552,14 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
   }
 #ifdef ENABLE_PIP
   if (splitByColor) {
-    PyErr_SetString(PyExc_ValueError,
-                    "osimport(): split_by_color=True is not supported in this build");
+    PyErr_SetString(PyExc_ValueError, "osimport(): split_by_color=True is not supported in this build");
     return NULL;
   }
 #endif
 
   double dpiVal = dpi;
   if (dpiVal < 0.001) {
-    PyErr_SetString(PyExc_TypeError, "Invalid dpi value giving");
+    PyErr_SetString(PyExc_TypeError, "osimport(): dpi must be at least 0.001");
     return NULL;
   }
 

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -498,7 +498,7 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
   int convexity = 2;
   double scale = 1.0, width = 1, height = 1, dpi = ImportNode::SVG_DEFAULT_DPI;
   PyObject *origin = NULL;
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|siO!dddOdsOdddO", kwlist, &v, &layer, &convexity,
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|ziO!dddOdzOdddO", kwlist, &v, &layer, &convexity,
                                    &PyList_Type, &origin, &scale, &width, &height, &center, &dpi, &id,
                                    &stroke, &fn, &fa, &fs, &split_by_color
 
@@ -545,7 +545,9 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     else if (ext == ".step") actualtype = ImportType::STEP;
   }
 
-  const bool splitByColor = (split_by_color == Py_True);
+  const int splitByColorValue = split_by_color == nullptr ? 0 : PyObject_IsTrue(split_by_color);
+  if (splitByColorValue < 0) return nullptr;
+  const bool splitByColor = splitByColorValue != 0;
   if (splitByColor && actualtype != ImportType::SVG) {
     PyErr_SetString(PyExc_ValueError, "osimport(): split_by_color=True is only supported for SVG files");
     return NULL;
@@ -563,8 +565,9 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     return NULL;
   }
 
+  const auto discretizer = CreateCurveDiscretizer(kwargs);
   auto build_node = [&](const boost::optional<Color4f>& colorFilter) {
-    auto n = std::make_shared<ImportNode>(instance, actualtype, CreateCurveDiscretizer(kwargs));
+    auto n = std::make_shared<ImportNode>(instance, actualtype, discretizer);
 
     n->filename = filename;
 
@@ -607,8 +610,8 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
   const boost::optional<std::string> layerOpt =
     layer != NULL ? boost::optional<std::string>(layer) : boost::none;
   const bool strokeBool = (stroke == Py_True);
-  const std::vector<Color4f> colors = import_svg_list_colors(
-    CreateCurveDiscretizer(kwargs), filename, idOpt, layerOpt, strokeBool, instance->location());
+  const std::vector<Color4f> colors =
+    import_svg_list_colors(discretizer, filename, idOpt, layerOpt, strokeBool, instance->location());
   if (colors.empty()) {
     PyErr_SetString(PyExc_ValueError,
                     "osimport(): split_by_color=True found no colors matching the SVG selection; "

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -577,7 +577,19 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
     return NULL;
   }
 
-  const auto discretizer = CreateCurveDiscretizer(kwargs);
+  PyObjectUniquePtr discretizerKwargs(PyDict_New(), &PyObjectDeleter);
+  if (!discretizerKwargs) return nullptr;
+  auto addDiscretizerArg = [&](const char *name, PyObject *value) {
+    if (value == nullptr || value == Py_None) return true;
+    const double number = PyFloat_AsDouble(value);
+    if (PyErr_Occurred()) return false;
+    PyObjectUniquePtr normalized(PyFloat_FromDouble(number), &PyObjectDeleter);
+    return normalized && PyDict_SetItemString(discretizerKwargs.get(), name, normalized.get()) == 0;
+  };
+  if (!addDiscretizerArg("fn", fn) || !addDiscretizerArg("fa", fa) || !addDiscretizerArg("fs", fs)) {
+    return nullptr;
+  }
+  const auto discretizer = CreateCurveDiscretizer(discretizerKwargs.get());
   auto build_node = [&](const boost::optional<Color4f>& colorFilter) {
     auto n = std::make_shared<ImportNode>(instance, actualtype, discretizer);
 

--- a/tests/data/pythonscad-echo/svg-split-by-color.py
+++ b/tests/data/pythonscad-echo/svg-split-by-color.py
@@ -1,0 +1,33 @@
+"""Echo test for ``osimport(..., split_by_color=True)``.
+
+Exercises:
+  * split_by_color=True on a multi-color SVG returns a dict keyed by
+    hex color, one entry per distinct fill/stroke color
+  * default (no flag) and explicit split_by_color=False both keep
+    returning a single PyOpenSCAD object (backward compatibility)
+  * split_by_color=True on a non-SVG import raises ValueError
+"""
+
+from pythonscad import osimport
+
+SVG = "../svg/box-w-holes.svg"
+STL = "../scad/3D/features/import.stl"
+
+parts = osimport(SVG, split_by_color=True)
+print("type:", type(parts).__name__)
+print("keys:", sorted(parts.keys()))
+print("all values are PyOpenSCAD:", all(type(v).__name__ == "PyOpenSCAD" for v in parts.values()))
+
+default_result = osimport(SVG)
+print("default is dict:", isinstance(default_result, dict))
+print("default type:", type(default_result).__name__)
+
+explicit_false_result = osimport(SVG, split_by_color=False)
+print("explicit False is dict:", isinstance(explicit_false_result, dict))
+print("explicit False type:", type(explicit_false_result).__name__)
+
+try:
+    osimport(STL, split_by_color=True)
+    print("non-svg split_by_color: NO EXCEPTION (expected ValueError)")
+except ValueError as e:
+    print("non-svg split_by_color: ValueError")

--- a/tests/data/pythonscad-echo/svg-split-by-color.py
+++ b/tests/data/pythonscad-echo/svg-split-by-color.py
@@ -24,6 +24,12 @@ print("None selectors and truthy flag return dict:", isinstance(truthy_result, d
 positional_result = osimport(SVG, None, 2, None, 1, 1, 1, False, 72, None, False, None, None, None, True)
 print("fully positional flag returns dict:", isinstance(positional_result, dict))
 
+try:
+    osimport(SVG, origin=["invalid", 0])
+    print("invalid origin: NO EXCEPTION (expected TypeError)")
+except TypeError:
+    print("invalid origin: TypeError")
+
 default_result = osimport(SVG)
 print("default is dict:", isinstance(default_result, dict))
 print("default type:", type(default_result).__name__)

--- a/tests/data/pythonscad-echo/svg-split-by-color.py
+++ b/tests/data/pythonscad-echo/svg-split-by-color.py
@@ -21,6 +21,9 @@ print("all values are PyOpenSCAD:", all(type(v).__name__ == "PyOpenSCAD" for v i
 truthy_result = osimport(SVG, layer=None, id=None, split_by_color=1)
 print("None selectors and truthy flag return dict:", isinstance(truthy_result, dict))
 
+positional_result = osimport(SVG, None, 2, None, 1, 1, 1, False, 72, None, False, None, None, None, True)
+print("fully positional flag returns dict:", isinstance(positional_result, dict))
+
 default_result = osimport(SVG)
 print("default is dict:", isinstance(default_result, dict))
 print("default type:", type(default_result).__name__)

--- a/tests/data/pythonscad-echo/svg-split-by-color.py
+++ b/tests/data/pythonscad-echo/svg-split-by-color.py
@@ -2,7 +2,7 @@
 
 Exercises:
   * split_by_color=True on a multi-color SVG returns a dict keyed by
-    hex color, one entry per distinct fill/stroke color
+    hex color, one entry per distinct selected outline color
   * default (no flag) and explicit split_by_color=False both keep
     returning a single PyOpenSCAD object (backward compatibility)
   * split_by_color=True on a non-SVG import raises ValueError

--- a/tests/data/pythonscad-echo/svg-split-by-color.py
+++ b/tests/data/pythonscad-echo/svg-split-by-color.py
@@ -18,6 +18,9 @@ print("type:", type(parts).__name__)
 print("keys:", sorted(parts.keys()))
 print("all values are PyOpenSCAD:", all(type(v).__name__ == "PyOpenSCAD" for v in parts.values()))
 
+truthy_result = osimport(SVG, layer=None, id=None, split_by_color=1)
+print("None selectors and truthy flag return dict:", isinstance(truthy_result, dict))
+
 default_result = osimport(SVG)
 print("default is dict:", isinstance(default_result, dict))
 print("default type:", type(default_result).__name__)

--- a/tests/data/pythonscad-export-3mf/svg-split-by-color.py
+++ b/tests/data/pythonscad-export-3mf/svg-split-by-color.py
@@ -1,0 +1,16 @@
+"""Regression fixture for ``osimport(..., split_by_color=True)`` feeding
+directly into the dict form of ``export()``.
+
+Imports a two-color SVG with ``split_by_color=True`` (returning a dict
+keyed by hex color), extrudes each part, and exports the resulting dict
+straight to 3MF -- exercising the exact multi-toolhead workflow this
+feature exists for: one separately named/colored 3MF part per SVG
+color, with no manual splitting needed on the caller's side. The
+driver normalizes via ``post_process_3mf`` (XML extraction + UUID /
+timestamp / namespace scrub) before the text compare.
+"""
+from pythonscad import export, osimport
+
+parts = osimport("../svg/two-color.svg", split_by_color=True)
+solids = {name: obj.linear_extrude(2) for name, obj in parts.items()}
+export(solids, "svg-split-by-color.3mf")

--- a/tests/data/svg/two-color.svg
+++ b/tests/data/svg/two-color.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="20mm" height="10mm" viewBox="0 0 20 10" version="1.1">
+  <rect x="0" y="0" width="8" height="8" fill="#804000"/>
+  <rect x="12" y="0" width="8" height="8" fill="#004080"/>
+</svg>

--- a/tests/regression/pythonscad-export-3mf/svg-split-by-color/svg-split-by-color.3mf
+++ b/tests/regression/pythonscad-export-3mf/svg-split-by-color/svg-split-by-color.3mf
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" unit="millimeter" xml:lang="en-US" xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02" xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06" xmlns:b="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" xmlns:s="http://schemas.microsoft.com/3dmanufacturing/slice/2015/07">
+	<metadata name="Title">svg-split-by-color.3mf</metadata>
+	<metadata name="Application">OpenSCAD (https://www.openscad.org/)</metadata>
+	<metadata name="CreationDate">XXXX-XX-XXTXXXXXXXXZ</metadata>
+	<resources>
+		<basematerials id="1">
+			<base name="Default" displaycolor="#F9D72CFF" />
+			<base name="Color 1" displaycolor="#804000FF" />
+			<base name="Color 2" displaycolor="#004080FF" />
+		</basematerials>
+		<object id="2" name="#804000ff" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" pid="1" pindex="0">
+			<mesh>
+				<vertices>
+					<vertex x="0" y="2.000000" z="0" />
+					<vertex x="0" y="2.000000" z="2.000000" />
+					<vertex x="0" y="10.000000" z="0" />
+					<vertex x="0" y="10.000000" z="2.000000" />
+					<vertex x="8.000000" y="2.000000" z="0" />
+					<vertex x="8.000000" y="2.000000" z="2.000000" />
+					<vertex x="8.000000" y="10.000000" z="0" />
+					<vertex x="8.000000" y="10.000000" z="2.000000" />
+				</vertices>
+				<triangles>
+					<triangle v1="0" v2="1" v3="3" pid="1" p1="1" />
+					<triangle v1="0" v2="2" v3="4" pid="1" p1="1" />
+					<triangle v1="0" v2="3" v3="2" pid="1" p1="1" />
+					<triangle v1="0" v2="4" v3="1" pid="1" p1="1" />
+					<triangle v1="1" v2="4" v3="5" pid="1" p1="1" />
+					<triangle v1="1" v2="5" v3="3" pid="1" p1="1" />
+					<triangle v1="2" v2="3" v3="7" pid="1" p1="1" />
+					<triangle v1="2" v2="6" v3="4" pid="1" p1="1" />
+					<triangle v1="2" v2="7" v3="6" pid="1" p1="1" />
+					<triangle v1="3" v2="5" v3="7" pid="1" p1="1" />
+					<triangle v1="4" v2="6" v3="5" pid="1" p1="1" />
+					<triangle v1="5" v2="6" v3="7" pid="1" p1="1" />
+				</triangles>
+			</mesh>
+		</object>
+		<object id="3" name="#004080ff" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" pid="1" pindex="0">
+			<mesh>
+				<vertices>
+					<vertex x="12.000000" y="2.000000" z="0" />
+					<vertex x="12.000000" y="2.000000" z="2.000000" />
+					<vertex x="12.000000" y="10.000000" z="0" />
+					<vertex x="12.000000" y="10.000000" z="2.000000" />
+					<vertex x="20.000000" y="2.000000" z="0" />
+					<vertex x="20.000000" y="2.000000" z="2.000000" />
+					<vertex x="20.000000" y="10.000000" z="0" />
+					<vertex x="20.000000" y="10.000000" z="2.000000" />
+				</vertices>
+				<triangles>
+					<triangle v1="0" v2="1" v3="3" pid="1" p1="2" />
+					<triangle v1="0" v2="2" v3="4" pid="1" p1="2" />
+					<triangle v1="0" v2="3" v3="2" pid="1" p1="2" />
+					<triangle v1="0" v2="4" v3="1" pid="1" p1="2" />
+					<triangle v1="1" v2="4" v3="5" pid="1" p1="2" />
+					<triangle v1="1" v2="5" v3="3" pid="1" p1="2" />
+					<triangle v1="2" v2="3" v3="7" pid="1" p1="2" />
+					<triangle v1="2" v2="6" v3="4" pid="1" p1="2" />
+					<triangle v1="2" v2="7" v3="6" pid="1" p1="2" />
+					<triangle v1="3" v2="5" v3="7" pid="1" p1="2" />
+					<triangle v1="4" v2="6" v3="5" pid="1" p1="2" />
+					<triangle v1="5" v2="6" v3="7" pid="1" p1="2" />
+				</triangles>
+			</mesh>
+		</object>
+	</resources>
+	<build p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX">
+		<item objectid="2" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" />
+		<item objectid="3" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" />
+	</build>
+</model>

--- a/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
+++ b/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
@@ -1,0 +1,9 @@
+type: dict
+keys: ['#004080ff', '#804000ff']
+all values are PyOpenSCAD: True
+default is dict: False
+default type: PyOpenSCAD
+explicit False is dict: False
+explicit False type: PyOpenSCAD
+non-svg split_by_color: ValueError
+

--- a/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
+++ b/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
@@ -3,6 +3,7 @@ keys: ['#004080ff', '#804000ff']
 all values are PyOpenSCAD: True
 None selectors and truthy flag return dict: True
 fully positional flag returns dict: True
+invalid origin: TypeError
 default is dict: False
 default type: PyOpenSCAD
 explicit False is dict: False

--- a/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
+++ b/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
@@ -2,6 +2,7 @@ type: dict
 keys: ['#004080ff', '#804000ff']
 all values are PyOpenSCAD: True
 None selectors and truthy flag return dict: True
+fully positional flag returns dict: True
 default is dict: False
 default type: PyOpenSCAD
 explicit False is dict: False

--- a/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
+++ b/tests/regression/pythonscadecho/svg-split-by-color-expected.echo
@@ -1,6 +1,7 @@
 type: dict
 keys: ['#004080ff', '#804000ff']
 all values are PyOpenSCAD: True
+None selectors and truthy flag return dict: True
 default is dict: False
 default type: PyOpenSCAD
 explicit False is dict: False

--- a/web/docs/cheatsheet.md
+++ b/web/docs/cheatsheet.md
@@ -410,6 +410,10 @@
       <div>Import geometry from file (STL, OFF, AMF, 3MF, SVG, DXF)</div>
       <div><code>osimport("model.stl").show()</code></div>
 
+      <div class="func"><code><a href="../reference/io/#osimport">osimport</a>(file, split_by_color=True)</code></div>
+      <div>SVG only: return a dict of <code>{hex_color: 2D object}</code>, one entry per SVG color, for per-color/per-tool export</div>
+      <div><code>parts = osimport("logo.svg", split_by_color=True)<br>export({k: v.linear_extrude(2) for k, v in parts.items()}, "logo.3mf")</code></div>
+
       <div class="func"><code><a href="../reference/io/#osuse">osuse</a>(file)</code></div>
       <div>Use an OpenSCAD library file (like <code>use &lt;...&gt;</code>); call modules/functions on the returned handle</div>
       <div><code>lib = osuse("library.scad"); lib.my_module().show()</code></div>

--- a/web/docs/reference/io.md
+++ b/web/docs/reference/io.md
@@ -11,7 +11,7 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
     ```python
     osimport(file, layer="", convexity=2, origin=None, scale=None,
              width=0, height=0, center=False, dpi=96, id="", stroke=False,
-             fn=0, fa=0, fs=0)
+             fn=0, fa=0, fs=0, split_by_color=False)
     ```
 
 **Parameters:**
@@ -30,6 +30,7 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
 | `id` | string | `""` | Element ID (for SVG) |
 | `stroke` | bool | `False` | Include stroke paths (for SVG) |
 | `fn`, `fa`, `fs` | float | global | Curve discretization; defaults to the global `fn`/`fa`/`fs` values |
+| `split_by_color` | bool | `False` | SVG only: return a dict of `{hex_color: 2D object}` — one object per distinct SVG color — instead of a single merged object. Raises `ValueError` for non-SVG files or an SVG with no colored shapes. |
 
 **Supported formats:** STL, OFF, AMF, 3MF (3D); DXF, SVG (2D)
 
@@ -45,6 +46,25 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
 
     drawing = osimport("design.svg", dpi=96)
     drawing.linear_extrude(height=2).show()
+    ```
+
+**Multi-color SVG to multi-object 3MF (e.g. for multi-toolhead printing):**
+
+`split_by_color=True` returns one 2D object per SVG color, keyed by hex color
+string. Extrude each separately and pass the resulting dict to `export()` to
+produce a 3MF file with one separately named/colored object per SVG color —
+ready to assign to different tool heads in a slicer:
+
+=== "Python"
+
+    ```python
+    from pythonscad import *
+
+    parts = osimport("watermelon.svg", split_by_color=True)
+    # {"#4a7d2eff": <2D object>, "#c0392bff": <2D object>, ...}
+
+    solids = {name: obj.linear_extrude(2) for name, obj in parts.items()}
+    export(solids, "watermelon.3mf")
     ```
 
 **OpenSCAD reference:** [import](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Importing_Geometry#import)

--- a/web/docs/reference/io.md
+++ b/web/docs/reference/io.md
@@ -10,7 +10,7 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
 
     ```python
     osimport(file, layer="", convexity=2, origin=None, scale=None,
-             width=0, height=0, center=False, dpi=96, id="", stroke=False,
+             width=0, height=0, center=False, dpi=72, id="", stroke=False,
              fn=0, fa=0, fs=0, split_by_color=False)
     ```
 
@@ -26,11 +26,11 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
 | `width` | float | `0` | Width (for image-based imports) |
 | `height` | float | `0` | Height (for image-based imports) |
 | `center` | bool | `False` | Center the imported geometry |
-| `dpi` | float | `96` | DPI for SVG imports |
+| `dpi` | float | `72` | DPI for SVG imports |
 | `id` | string | `""` | Element ID (for SVG) |
 | `stroke` | bool | `False` | Include stroke paths (for SVG) |
 | `fn`, `fa`, `fs` | float | global | Curve discretization; defaults to the global `fn`/`fa`/`fs` values |
-| `split_by_color` | bool | `False` | SVG only: return a dict of `{hex_color: 2D object}` — one object per distinct SVG color — instead of a single merged object. Raises `ValueError` for non-SVG files or an SVG with no colored shapes. |
+| `split_by_color` | bool | `False` | SVG only: return `{hex_color: 2D object}` instead of one merged object; raises `ValueError` for unsupported input. |
 
 **Supported formats:** STL, OFF, AMF, 3MF (3D); DXF, SVG (2D)
 

--- a/web/docs/reference/io.md
+++ b/web/docs/reference/io.md
@@ -9,9 +9,9 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
 === "Python"
 
     ```python
-    osimport(file, layer="", convexity=2, origin=None, scale=None,
-             width=0, height=0, center=False, dpi=72, id="", stroke=False,
-             fn=0, fa=0, fs=0, split_by_color=False)
+    osimport(file, layer=None, convexity=2, origin=None, scale=1,
+             width=1, height=1, center=False, dpi=72, id=None, stroke=False,
+             fn=None, fa=None, fs=None, split_by_color=False)
     ```
 
 **Parameters:**
@@ -19,15 +19,15 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `file` | string | — | Path to the file to import |
-| `layer` | string | `""` | Layer name (for DXF files) |
+| `layer` | string | `None` | Layer name (for DXF files) |
 | `convexity` | int | `2` | Convexity hint |
 | `origin` | `[x, y]` | `None` | Origin offset (for DXF) |
-| `scale` | float | `None` | Scale factor (for DXF) |
-| `width` | float | `0` | Width (for image-based imports) |
-| `height` | float | `0` | Height (for image-based imports) |
+| `scale` | float | `1` | Scale factor (for DXF) |
+| `width` | float | `1` | Width (for image-based imports) |
+| `height` | float | `1` | Height (for image-based imports) |
 | `center` | bool | `False` | Center the imported geometry |
 | `dpi` | float | `72` | DPI for SVG imports |
-| `id` | string | `""` | Element ID (for SVG) |
+| `id` | string | `None` | Element ID (for SVG) |
 | `stroke` | bool | `False` | Include stroke paths (for SVG) |
 | `fn`, `fa`, `fs` | float | global | Curve discretization; defaults to the global `fn`/`fa`/`fs` values |
 | `split_by_color` | bool | `False` | SVG only: return `{hex_color: 2D object}` instead of one merged object; raises `ValueError` for unsupported input. |

--- a/web/docs/reference/io.md
+++ b/web/docs/reference/io.md
@@ -30,7 +30,7 @@ Import geometry from a file. This is the PythonSCAD equivalent of OpenSCAD's `im
 | `id` | string | `None` | Element ID (for SVG) |
 | `stroke` | bool | `False` | Include stroke paths (for SVG) |
 | `fn`, `fa`, `fs` | float | global | Curve discretization; defaults to the global `fn`/`fa`/`fs` values |
-| `split_by_color` | bool | `False` | SVG only: return `{hex_color: 2D object}` instead of one merged object; raises `ValueError` for unsupported input. |
+| `split_by_color` | bool | `False` | SVG only: return `{hex_color: 2D object}` instead of one merged object; raises `ValueError` for non-SVG input or when no colors match the SVG selection. |
 
 **Supported formats:** STL, OFF, AMF, 3MF (3D); DXF, SVG (2D)
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `split_by_color=True` flag to `osimport()` for SVG files, returning a `dict` of `{hex_color: 2D object}` (one object per distinct SVG color) instead of a single merged object.
- Each color is re-imported through a new `ImportNode.colorFilter` (mirroring the existing `id`/`layer` selector precedent) and wrapped in a `ColorNode`, so results compose directly with `export()`'s existing dict form to produce separately named/colored 3MF parts — e.g. for assigning colors to different tool heads on a multi-material/multi-toolhead 3D printer.
- Defaults to `False`; existing `osimport()` behavior and return type are fully unchanged when the flag is not used.
- No changes needed to `linear_extrude()` or the 3MF exporter — both already handle per-part color/naming correctly once given genuinely separate colored objects.

```python
from pythonscad import *

parts = osimport("logo.svg", split_by_color=True)
# {"#4a7d2eff": <2D object>, "#c0392bff": <2D object>, ...}

solids = {name: obj.linear_extrude(2) for name, obj in parts.items()}
export(solids, "logo.3mf")
```

## Changes
- `src/io/import_svg.cc` / `src/io/import.h`: factor out shared color-resolution/selector helpers; add `import_svg_list_colors()`; add optional `colorFilter` param to `import_svg()`.
- `src/core/ImportNode.h/.cc`: new `colorFilter` field, threaded through to `import_svg()`, reflected in `toString()` for correct geometry cache keys.
- `src/core/ColorUtil.h/.cc`: new `OpenSCAD::toHexString()` helper.
- `src/python/py_io.cc`: `split_by_color` kwarg on `osimport()`; builds one `ColorNode`-wrapped `ImportNode` per discovered color; raises `ValueError` for non-SVG imports or SVGs with no colored shapes.
- Python stubs, cheat sheet, and `web/docs/reference/io.md` updated with the new parameter and example.
- New tests: `tests/data/pythonscad-echo/svg-split-by-color.py` (dict shape / backward-compat / error path) and `tests/data/pythonscad-export-3mf/svg-split-by-color.py` (full import → extrude → 3MF export round trip), plus a new minimal two-color SVG fixture.

## Test plan
- [x] `ctest -R "svg|osimport|import"` — 229/229 passed (existing SVG import/export regressions unaffected)
- [x] `ctest -R "pythonscadecho|pythonscad-export-3mf|3mf"` — 95/95 passed
- [x] New echo test `pythonscadecho_svg-split-by-color` passes
- [x] New end-to-end test `pythonscad-export-3mf_svg-split-by-color` passes (multi-color SVG → per-color 3MF parts)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>