### PR TITLE
build: refresh Windows wheel vcpkg baseline

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "customType": "regex",
       "description": "Update the vcpkg release tag used by Windows PyPI wheel builds.",
       "managerFilePatterns": [
-        "^scripts/cibuildwheel/install-deps-windows\\.ps1$"
+        "/^scripts\\/cibuildwheel\\/install-deps-windows\\.ps1$/"
       ],
       "matchStrings": [
         "\\$VcpkgVersion = \"(?<currentValue>\\d{4}\\.\\d{2}\\.\\d{2})\""

--- a/scripts/cibuildwheel/install-deps-windows.ps1
+++ b/scripts/cibuildwheel/install-deps-windows.ps1
@@ -65,7 +65,7 @@ if (-not $BisonExe -or -not $FlexExe) {
 }
 
 # Pin vcpkg to a release tag for reproducible builds (see vcpkg.json builtin-baseline).
-$VcpkgVersion = "2025.04.09"
+$VcpkgVersion = "2026.06.24"
 $VcpkgRoot = Join-Path $ProjectRoot ".wheel-vcpkg"
 $ManifestDir = Join-Path $ProjectRoot "scripts/cibuildwheel"
 $VcpkgManifest = Join-Path $ManifestDir "vcpkg.json"

--- a/scripts/cibuildwheel/vcpkg.json
+++ b/scripts/cibuildwheel/vcpkg.json
@@ -5,6 +5,7 @@
   "dependencies": [
     "boost-regex",
     "boost-program-options",
+    "boost-system",
     "boost-assign",
     "boost-lockfree",
     "eigen3",

--- a/scripts/cibuildwheel/vcpkg.json
+++ b/scripts/cibuildwheel/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pythonscad-pip",
   "version-string": "1.0.0",
-  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
+  "builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3",
   "dependencies": [
     "boost-regex",
     "boost-program-options",

--- a/setup.py
+++ b/setup.py
@@ -171,9 +171,9 @@ def get_link_libraries():
     libs = get_pkg_config_libraries()
 
     # Link concrete Boost libraries so auditwheel/delocate/delvewheel can
-    # bundle them. Current Homebrew Boost.System is header-only on macOS.
+    # bundle them. Current Boost.System is header-only on macOS and vcpkg/MSVC.
     boost_libs = ["boost_program_options"]
-    if not IS_DARWIN:
+    if not IS_DARWIN and not IS_WINDOWS:
         boost_libs.append("boost_system")
     # On Windows, Boost.Regex is selected via MSVC autolink; vcpkg's release
     # triplet does not provide a stable unversioned boost_regex.lib to name here.


### PR DESCRIPTION
## Summary
- Refresh the Windows PyPI wheel vcpkg pin from `2025.04.09` to `2026.06.24`.
- Sync `scripts/cibuildwheel/vcpkg.json` to the peeled `2026.06.24` baseline commit.
- Fix Renovate's custom regex manager file pattern so future `microsoft/vcpkg` release tags are detected.

## Why
The v1.1.1 PyPI release workflow failed while vcpkg built `gmp:x64-windows-release` because the old vcpkg pin still referenced stale MSYS2 package metadata for a removed `libtool` artifact.

Dependabot did not catch this because it only handles configured ecosystems in `.github/dependabot.yaml`; arbitrary PowerShell pins are outside its support. Renovate had a custom regex manager for this pin, but a local dry run showed it did not match the file until the file pattern was changed to Renovate's slash-delimited regex form.

## Verification
- `python3 -m json.tool scripts/cibuildwheel/vcpkg.json`
- `git ls-remote --tags https://github.com/microsoft/vcpkg.git "refs/tags/2026.06.24" "refs/tags/2026.06.24^{}"`
- `python3 scripts/cibuildwheel/update-vcpkg-baseline.py`
- `pre-commit run --files renovate.json scripts/cibuildwheel/install-deps-windows.ps1 scripts/cibuildwheel/vcpkg.json`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `LOG_LEVEL=debug npx --yes --package renovate renovate --platform=local --dry-run=lookup`


Made with [Cursor](https://cursor.com)