### PR TITLE
docs(release): fix mkdocs navigation

### DIFF
--- a/web/docs/releases/index.md
+++ b/web/docs/releases/index.md
@@ -2,7 +2,7 @@
 
 Read the announcement notes for recent PythonSCAD releases.
 
-- [PythonSCAD v1.1.1 "Prominentio"](PythonSCAD%20v1.1.1.md)
+- [PythonSCAD v1.1.2 "Prominentio"](PythonSCAD%20v1.1.2.md)
 - [PythonSCAD v1.0.0 "Impletio"](PythonSCAD%20v1.0.0.md)
 - [PythonSCAD v0.20.0](PythonSCAD%20v0.20.0.md)
 - [PythonSCAD v0.18.0](PythonSCAD%20v0.18.0.md)

--- a/web/mkdocs.yml
+++ b/web/mkdocs.yml
@@ -48,7 +48,7 @@ nav:
   - Downloads: downloads.md
   - Release Notes:
       - Overview: releases/index.md
-      - PythonSCAD v1.1.1: releases/PythonSCAD v1.1.1.md
+      - PythonSCAD v1.1.2: releases/PythonSCAD v1.1.2.md
       - PythonSCAD v1.0.0: releases/PythonSCAD v1.0.0.md
       - PythonSCAD v0.20.0: releases/PythonSCAD v0.20.0.md
       - PythonSCAD v0.18.0: releases/PythonSCAD v0.18.0.md


### PR DESCRIPTION
after rename of release notes from v1.1.1 to v1.1.2