### PR TITLE
feat: add Test PyPI publishing step to workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -69,9 +69,9 @@ jobs:
             distance=$(git rev-list --count HEAD)
           fi
           sha=$(git rev-parse --short=10 HEAD)
-          dev_version="${base_version}.dev${distance}+g${sha}"
+          dev_version="${base_version}.dev${distance}"
           echo "PYTHONSCAD_VERSION_OVERRIDE=${dev_version}" >> "$GITHUB_ENV"
-          echo "Using dynamic package version: ${dev_version}"
+          echo "Using dynamic package version: ${dev_version} (sha ${sha})"
 
       - uses: actions/setup-python@v7
         with:
@@ -201,9 +201,9 @@ jobs:
             distance=$(git rev-list --count HEAD)
           fi
           sha=$(git rev-parse --short=10 HEAD)
-          dev_version="${base_version}.dev${distance}+g${sha}"
+          dev_version="${base_version}.dev${distance}"
           echo "PYTHONSCAD_VERSION_OVERRIDE=${dev_version}" >> "$GITHUB_ENV"
-          echo "Using dynamic package version: ${dev_version}"
+          echo "Using dynamic package version: ${dev_version} (sha ${sha})"
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,14 +1,18 @@
-# Builds binary wheels and a source distribution. Release-triggered runs publish
-# all artifacts to PyPI; manually dispatched runs only validate the build.
+# Builds binary wheels and a source distribution.
+# - Release-triggered runs publish to TestPyPI first, then PyPI.
+# - Manually dispatched runs on the release-please branch publish to TestPyPI
+#   using a unique PEP 440 dev version for iterative pre-release testing.
 #
 # Prerequisites (one-time setup):
-#   1. Create the "pythonscad" project on PyPI (https://pypi.org)
-#   2. Configure "trusted publishing" for this repository under:
-#      PyPI project settings -> Publishing -> Add a new publisher
+#   1. Create the "pythonscad" projects on PyPI and TestPyPI:
+#      - https://pypi.org/project/pythonscad/
+#      - https://test.pypi.org/project/pythonscad/
+#   2. Configure trusted publishing for this repository in both indexes:
+#      PyPI/TestPyPI project settings -> Publishing -> Add a new publisher
 #      - Owner: pythonscad
 #      - Repository: pythonscad
 #      - Workflow name: publish-to-pypi.yml
-#      - Environment name: pypi
+#      - Environment names: pypi (PyPI), testpypi (TestPyPI)
 name: Publish to PyPI
 
 on:
@@ -46,6 +50,28 @@ jobs:
         run: |
           git fetch --unshallow --tags || git fetch --tags
           git describe --tags --always --dirty
+
+      - name: Set dynamic version for manual TestPyPI runs
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/release-please--branches--master--components--pythonscad'
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_version="$(grep -Eo '^[0-9]+\.[0-9]+(\.[0-9]+)?' VERSION.txt | head -n1 || true)"
+          if [[ -z "${base_version}" ]]; then
+            echo "Unable to derive base version from VERSION.txt" >&2
+            exit 1
+          fi
+          if tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+            distance=$(git rev-list --count "${tag}..HEAD")
+          else
+            distance=$(git rev-list --count HEAD)
+          fi
+          sha=$(git rev-parse --short=10 HEAD)
+          dev_version="${base_version}.dev${distance}+g${sha}"
+          echo "PYTHONSCAD_VERSION_OVERRIDE=${dev_version}" >> "$GITHUB_ENV"
+          echo "Using dynamic package version: ${dev_version}"
 
       - uses: actions/setup-python@v7
         with:
@@ -157,6 +183,28 @@ jobs:
           git fetch --unshallow --tags || git fetch --tags
           git describe --tags --always --dirty
 
+      - name: Set dynamic version for manual TestPyPI runs
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/release-please--branches--master--components--pythonscad'
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_version="$(grep -Eo '^[0-9]+\.[0-9]+(\.[0-9]+)?' VERSION.txt | head -n1 || true)"
+          if [[ -z "${base_version}" ]]; then
+            echo "Unable to derive base version from VERSION.txt" >&2
+            exit 1
+          fi
+          if tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+            distance=$(git rev-list --count "${tag}..HEAD")
+          else
+            distance=$(git rev-list --count HEAD)
+          fi
+          sha=$(git rev-parse --short=10 HEAD)
+          dev_version="${base_version}.dev${distance}+g${sha}"
+          echo "PYTHONSCAD_VERSION_OVERRIDE=${dev_version}" >> "$GITHUB_ENV"
+          echo "Using dynamic package version: ${dev_version}"
+
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -199,6 +247,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
   publish-to-pypi:
     name: Publish to PyPI
     needs: [build-wheels, build-sdist, publish-to-test-pypi]

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -63,7 +63,7 @@ jobs:
             echo "Unable to derive base version from VERSION.txt" >&2
             exit 1
           fi
-          if tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+          if tag=$(git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null); then
             distance=$(git rev-list --count "${tag}..HEAD")
           else
             distance=$(git rev-list --count HEAD)
@@ -195,7 +195,7 @@ jobs:
             echo "Unable to derive base version from VERSION.txt" >&2
             exit 1
           fi
-          if tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+          if tag=$(git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null); then
             distance=$(git rev-list --count "${tag}..HEAD")
           else
             distance=$(git rev-list --count HEAD)

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -176,10 +176,36 @@ jobs:
           name: pypi-sdist
           path: dist/*.tar.gz
 
-  publish:
-    name: Publish to PyPI
+  publish-to-test-pypi:
+    name: Publish to test PyPI
     needs: [build-wheels, build-sdist]
-    if: github.event_name == 'release'
+    if: >
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/release-please--branches--master--components--pythonscad')
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: pypi-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist, publish-to-test-pypi]
+    if: >
+      github.event_name == 'release' &&
+      github.event.action == 'published' &&
+      !github.event.release.prerelease
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -204,7 +204,7 @@ jobs:
     needs: [build-wheels, build-sdist, publish-to-test-pypi]
     if: >
       github.event_name == 'release' &&
-      github.event.action == 'published' &&
+      github.event.action == 'released' &&
       !github.event.release.prerelease
     runs-on: ubuntu-latest
     environment: pypi

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-import subprocess
 import os
 import re
 import shutil
+import subprocess
 import sys
 
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 IS_WINDOWS = sys.platform == "win32"
 IS_DARWIN = sys.platform == "darwin"
@@ -50,14 +50,14 @@ def get_version_parts():
     version = get_version()
     # Build metadata and pre-release/development suffixes are allowed for wheel
     # versions, but OPENSCAD_* macros still need numeric major/minor/patch.
-    match = re.match(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?(?:[.-].*)?(?:\+.*)?$", version)
+    match = re.match(r"^(([0-9]+)\.([0-9]+)(?:\.([0-9]+))?)(?:[.-].*)?(?:\+.*)?$", version)
     if not match:
         raise RuntimeError(f"Version string '{version}' doesn't match expected semantic version format")
 
-    major = str(int(match.group(1)))
-    minor = str(int(match.group(2)))
-    patch = str(int(match.group(3) or "0"))
-    shortversion = f"{major}.{minor}.{patch}"
+    major = str(int(match.group(2)))
+    minor = str(int(match.group(3)))
+    patch = str(int(match.group(4) or "0"))
+    shortversion = match.group(1)
     return version, shortversion, major, minor, patch
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ def apply_wheel_build_env():
 
 
 def get_version():
+    override = os.environ.get("PYTHONSCAD_VERSION_OVERRIDE", "").strip()
+    if override:
+        return override
     here = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(here, "VERSION.txt")) as f:
         return f.read().strip()
@@ -45,14 +48,17 @@ def get_version():
 
 def get_version_parts():
     version = get_version()
-    match = re.match(r"^(([0-9]+)\.([0-9]+)(?:\.([0-9]+))?)(?:-([^+]+))?(?:\+(.*))?$", version)
+    # Build metadata and pre-release/development suffixes are allowed for wheel
+    # versions, but OPENSCAD_* macros still need numeric major/minor/patch.
+    match = re.match(r"^([0-9]+)\.([0-9]+)(?:\.([0-9]+))?(?:[.-].*)?(?:\+.*)?$", version)
     if not match:
         raise RuntimeError(f"Version string '{version}' doesn't match expected semantic version format")
 
-    major = str(int(match.group(2)))
-    minor = str(int(match.group(3)))
-    patch = str(int(match.group(4) or "0"))
-    return version, match.group(1), major, minor, patch
+    major = str(int(match.group(1)))
+    minor = str(int(match.group(2)))
+    patch = str(int(match.group(3) or "0"))
+    shortversion = f"{major}.{minor}.{patch}"
+    return version, shortversion, major, minor, patch
 
 
 def pkg_config_cmd():


### PR DESCRIPTION
## Summary
This PR extends the PyPI publish workflow with a TestPyPI stage and release-please QA support.

## What changed
- Added `publish-to-test-pypi` job.
- Production `publish-to-pypi` now waits on TestPyPI publish and only runs for real `release` `released` events.
- Added `skip-existing: true` for TestPyPI uploads to keep reruns idempotent.
- Added branch-gated manual dispatch behavior for `release-please--branches--master--components--pythonscad`.
- For manual dispatches on that branch, builds use a unique PEP 440 dev version via `PYTHONSCAD_VERSION_OVERRIDE`:
  - Format: `<base>.dev<distance>`
  - Example: `1.1.2.dev77`
- Updated workflow header docs to describe both PyPI/TestPyPI trusted publishing setup and manual behavior.

## Why
This enables iterative pre-release validation on TestPyPI (publish/install/test/fix/repeat) without blocking final release publishing.

## Expected behavior
- `workflow_dispatch` on release-please branch: publish to TestPyPI only (unique dev version).
- `release` (`released`) event: publish to TestPyPI and then production PyPI.
