### PR TITLE
ci: add release smoke workflow

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - name: Linux smoke tests

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,108 @@
+name: Release smoke tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      trigger_release_builds:
+        description: 'Trigger fresh release build workflows before smoke testing'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release-builds:
+    name: Prepare release build artifacts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Trigger and wait for release build workflows
+        if: ${{ inputs.trigger_release_builds }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/release-smoke/trigger-release-builds.sh \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF_NAME" \
+            --wait
+
+      - name: Use existing release build artifacts
+        if: ${{ !inputs.trigger_release_builds }}
+        run: |
+          echo "Using latest successful release build artifacts for $GITHUB_REF_NAME"
+
+  release-smoke:
+    name: ${{ matrix.name }}
+    needs: prepare-release-builds
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: Linux smoke tests
+            runner: ubuntu-24.04
+            timeout_minutes: 120
+          - name: macOS smoke tests
+            runner: macos-15-intel
+            timeout_minutes: 60
+          - name: Windows smoke tests
+            runner: windows-latest
+            timeout_minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Smoke test AppImages
+        if: runner.os == 'Linux'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/release-smoke/test-appimages.sh \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF_NAME"
+
+      - name: Smoke test Linux packages
+        if: runner.os == 'Linux'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/release-smoke/test-linux-packages.sh \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF_NAME"
+
+      - name: Smoke test macOS DMG
+        if: runner.os == 'macOS'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/release-smoke/test-macos.sh \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF_NAME"
+
+      - name: Smoke test Windows packages
+        if: runner.os == 'Windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          powershell -ExecutionPolicy Bypass -File scripts/release-smoke/test-windows.ps1 `
+            --repo "$env:GITHUB_REPOSITORY" `
+            --ref "$env:GITHUB_REF_NAME"

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -142,17 +142,17 @@ wait_for_workflows() {
   cancel_unfinished_workflows() {
     local failed_workflow=$1
 
-    for workflow in "${workflows[@]}"; do
-      if [[ "$workflow" == "$failed_workflow" || -n "${completed[$workflow]:-}" ]]; then
+    for cancel_workflow in "${workflows[@]}"; do
+      if [[ "$cancel_workflow" == "$failed_workflow" || -n "${completed[$cancel_workflow]:-}" ]]; then
         continue
       fi
 
-      local run_id=${run_ids[$workflow]:-}
+      local run_id=${run_ids[$cancel_workflow]:-}
       [[ -n "$run_id" ]] || continue
 
-      rs_warn "Cancelling unfinished run for $workflow: $run_id"
+      rs_warn "Cancelling unfinished run for $cancel_workflow: $run_id"
       gh run cancel "$run_id" --repo "$repo" ||
-        rs_warn "Could not cancel unfinished run for $workflow: $run_id"
+        rs_warn "Could not cancel unfinished run for $cancel_workflow: $run_id"
     done
   }
 

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -139,6 +139,23 @@ wait_for_workflows() {
 
   rs_log "Waiting for $remaining workflow runs; polling every 30 seconds"
 
+  cancel_unfinished_workflows() {
+    local failed_workflow=$1
+
+    for workflow in "${workflows[@]}"; do
+      if [[ "$workflow" == "$failed_workflow" || -n "${completed[$workflow]:-}" ]]; then
+        continue
+      fi
+
+      local run_id=${run_ids[$workflow]:-}
+      [[ -n "$run_id" ]] || continue
+
+      rs_warn "Cancelling unfinished run for $workflow: $run_id"
+      gh run cancel "$run_id" --repo "$repo" ||
+        rs_warn "Could not cancel unfinished run for $workflow: $run_id"
+    done
+  }
+
   while ((remaining > 0)); do
     for workflow in "${workflows[@]}"; do
       if [[ -n "${completed[$workflow]:-}" ]]; then
@@ -160,6 +177,7 @@ wait_for_workflows() {
         ((remaining -= 1))
         rs_log "Finished $workflow_name ($workflow): ${conclusion:-unknown} - $url"
         if [[ "$conclusion" != "success" ]]; then
+          cancel_unfinished_workflows "$workflow"
           rs_die "$workflow_name ($workflow) failed with conclusion: ${conclusion:-unknown}"
         fi
       fi

--- a/scripts/release-smoke/trigger-release-builds.sh
+++ b/scripts/release-smoke/trigger-release-builds.sh
@@ -136,9 +136,8 @@ wait_for_dispatched_run_id() {
 wait_for_workflows() {
   local -A completed=()
   local remaining=${#run_ids[@]}
-  local failures=0
 
-  rs_log "Waiting for $remaining workflow runs; polling once per minute"
+  rs_log "Waiting for $remaining workflow runs; polling every 30 seconds"
 
   while ((remaining > 0)); do
     for workflow in "${workflows[@]}"; do
@@ -161,20 +160,16 @@ wait_for_workflows() {
         ((remaining -= 1))
         rs_log "Finished $workflow_name ($workflow): ${conclusion:-unknown} - $url"
         if [[ "$conclusion" != "success" ]]; then
-          failures=1
+          rs_die "$workflow_name ($workflow) failed with conclusion: ${conclusion:-unknown}"
         fi
       fi
     done
 
     if ((remaining > 0)); then
       rs_log "$remaining workflow run(s) still running"
-      sleep 60
+      sleep 30
     fi
   done
-
-  if ((failures)); then
-    rs_die "one or more dispatched workflows failed"
-  fi
 
   rs_log "All dispatched workflows completed successfully"
 }


### PR DESCRIPTION
## Summary

- add a manual release smoke workflow with an optional `trigger_release_builds` boolean input
- run Linux, macOS, and Windows smoke tests in parallel after artifact preparation
- make `trigger-release-builds.sh --wait` fail as soon as any dispatched release build fails

## Verification

- `PRE_COMMIT_HOME=$(mktemp -d) pre-commit run`
- commit hooks (`pre-commit`, `commitlint`) passed during commit
