### PR TITLE
fix(python): report invalid color names safely

### DIFF
--- a/src/python/py_ops.cc
+++ b/src/python/py_ops.cc
@@ -27,6 +27,7 @@
 #include "genlang/genlang.h"
 #include <Python.h>
 #include <algorithm>
+#include <string>
 #include "pyopenscad.h"
 #include <io/fileutils.h>
 #include <handle_dep.h>
@@ -244,15 +245,14 @@ PyObject *python_color_core(PyObject *obj, PyObject *color, double alpha)
   if (!python_vectorval(color, 3, 4, &col[0], &col[1], &col[2], &col[3])) {
     node->color.setRgba(float(col[0]), float(col[1]), float(col[2]), float(col[3]));
   } else if (PyUnicode_Check(color)) {
-    auto value = py_owned(PyUnicode_AsEncodedString(color, "utf-8", "~"));
-    if (value.get() == nullptr) return NULL;
-    char *colorname = PyBytes_AS_STRING(value.get());
+    std::string colorname;
+    if (!python_pyobject_to_utf8(color, colorname, "color() color")) return nullptr;
     const auto parsed_color = OpenSCAD::parse_color(colorname);
     if (parsed_color) {
       node->color = *parsed_color;
       if (1.0 != alpha) node->color.setAlpha(alpha);
     } else {
-      PyErr_SetString(PyExc_TypeError, "Cannot parse color");
+      PyErr_Format(PyExc_TypeError, "Unable to parse color %R", color);
       return NULL;
     }
   } else {
@@ -459,15 +459,14 @@ PyObject *python_repair_core(PyObject *obj, PyObject *color)
     if (!python_vectorval(color, 3, 4, &col[0], &col[1], &col[2], &col[3])) {
       node->color.setRgba(float(col[0]), float(col[1]), float(col[2]), float(col[3]));
     } else if (PyUnicode_Check(color)) {
-      auto value = py_owned(PyUnicode_AsEncodedString(color, "utf-8", "~"));
-      if (value.get() == nullptr) return nullptr;
-      const char *colorname = PyBytes_AS_STRING(value.get());
+      std::string colorname;
+      if (!python_pyobject_to_utf8(color, colorname, "repair() color")) return nullptr;
       const auto parsed_color = OpenSCAD::parse_color(colorname);
       if (parsed_color) {
         node->color = *parsed_color;
         node->color.setAlpha(1.0);
       } else {
-        PyErr_SetString(PyExc_TypeError, "Cannot parse color");
+        PyErr_Format(PyExc_TypeError, "Unable to parse color %R", color);
         return NULL;
       }
     } else {

--- a/tests/data/pythonscad-echo/color-invalid-name-message.py
+++ b/tests/data/pythonscad-echo/color-invalid-name-message.py
@@ -1,0 +1,18 @@
+"""Regression for invalid color-name exception messages."""
+from openscad import cube
+
+
+def expect_message(label, fn):
+    try:
+        fn()
+    except Exception as e:
+        print(f'{label}: {type(e).__name__}: {e}')
+    else:
+        print(f"{label}: NO EXCEPTION")
+
+
+c = cube(1)
+expect_message("color invalid name", lambda: c.color("notAName"))
+expect_message("color invalid nul name", lambda: c.color("Br\0on"))
+expect_message("repair invalid name", lambda: c.repair(color="notAName"))
+expect_message("repair invalid nul name", lambda: c.repair(color="Br\0on"))

--- a/tests/regression/pythonscadecho/color-invalid-name-message-expected.echo
+++ b/tests/regression/pythonscadecho/color-invalid-name-message-expected.echo
@@ -1,0 +1,5 @@
+color invalid name: TypeError: Unable to parse color 'notAName'
+color invalid nul name: TypeError: Unable to parse color 'Br\x00on'
+repair invalid name: TypeError: Unable to parse color 'notAName'
+repair invalid nul name: TypeError: Unable to parse color 'Br\x00on'
+


### PR DESCRIPTION
## Summary
- Preserve full Python color-name strings, including embedded NUL bytes, when parsing and reporting invalid colors.
- Match OpenSCAD-style invalid color diagnostics while escaping control characters in Python exception messages.
- Add an echo regression for invalid color names in `color()` and `repair(color=...)`.

## Test plan
- `pre-commit run --files src/python/py_ops.cc tests/data/pythonscad-echo/color-invalid-name-message.py tests/regression/pythonscadecho/color-invalid-name-message-expected.echo`
- `nice deguix cmake --build build -j6 && deguix ctest --test-dir build -R color-invalid-name-message --output-on-failure`


Made with [Cursor](https://cursor.com)