### PR TITLE
ci: cleanup test build matrix

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -25,6 +25,9 @@ jobs:
           - os: ubuntu-22.04
             # libqscintilla2-qt6-dev not packaged
             qt: qt6
+          - os: ubuntu-24.04
+            # libqscintilla2-qt6-dev not packaged
+            qt: qt5
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
No longer test qt5 builds on Ubuntu 24.04 as we've switched to qt6 being the default.