### PR TITLE
fix(wasm): keep playground responsive during evaluation

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -130,8 +130,10 @@ jobs:
               echo 'PASS'
             "
 
-      - name: Test notebook geometry protocol
-        run: node --test wasm-test/notebook-geometry.test.mjs
+      - name: Test notebook worker protocol
+        run: |
+          node --test wasm-test/notebook-geometry.test.mjs
+          node --test wasm-test/notebook-protocol.test.mjs
 
       - name: Build WASM web variant
         run: |
@@ -160,6 +162,9 @@ jobs:
              wasm-test/test.html \
              wasm-test/notebook.html \
              wasm-test/notebook-geometry.mjs \
+             wasm-test/notebook-protocol.mjs \
+             wasm-test/notebook-kernel.mjs \
+             wasm-test/notebook-worker.mjs \
              dist-wasm/
           cp wasm-test/vendor/three.module.min.js \
              wasm-test/vendor/three.core.min.js \
@@ -268,6 +273,9 @@ jobs:
              wasm-bundle/pythonscad.wasm \
              wasm-bundle/pythonscad.data \
              wasm-bundle/notebook-geometry.mjs \
+             wasm-bundle/notebook-protocol.mjs \
+             wasm-bundle/notebook-kernel.mjs \
+             wasm-bundle/notebook-worker.mjs \
              playground/
           cp wasm-bundle/vendor/three.module.min.js \
              wasm-bundle/vendor/three.core.min.js \

--- a/wasm-test/notebook-kernel.mjs
+++ b/wasm-test/notebook-kernel.mjs
@@ -1,0 +1,151 @@
+/**
+ * Main-thread client for the notebook Python kernel worker.
+ */
+import {MSG, resolveWorkerResponse,} from './notebook-protocol.mjs';
+
+export class NotebookKernel
+{
+  constructor(options = {})
+  {
+    this.workerUrl = options.workerUrl ?? './notebook-worker.mjs';
+    this.onDebug = options.onDebug ?? (() => {});
+    this.worker = null;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.ready = false;
+    this.busy = false;
+    this.queue = [];
+    this.cachedBuffers = null;
+  }
+
+  _debug(msg, type) { this.onDebug(msg, type); }
+
+  _attachWorker(worker)
+  {
+    this.worker = worker;
+    worker.onmessage = (event) => this._onMessage(event.data);
+    worker.onerror = (event) => this._onWorkerError(event);
+    worker.onmessageerror = (event) => {
+      this._debug('Worker message error: ' + event, 'error');
+    };
+  }
+
+  _onWorkerError(event)
+  {
+    const message = event.message || 'Worker script error';
+    this._debug('Worker error: ' + message, 'error');
+    this._failAllPending(new Error(message), true);
+    this.ready = false;
+  }
+
+  _failAllPending(error, crashed = false)
+  {
+    error.crashed = crashed;
+    for (const [, entry] of this.pending) entry.reject(error);
+    this.pending.clear();
+    this.busy = false;
+    this.queue = [];
+  }
+
+  _onMessage(data)
+  {
+    if (!data || typeof data.id !== 'number') return;
+    resolveWorkerResponse(this.pending, data);
+  }
+
+  _request(type, payload, transfer)
+  {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      this.pending.set(id, {resolve, reject});
+      try {
+        this.worker.postMessage({type, id, ...payload}, transfer || []);
+      } catch (e) {
+        this.pending.delete(id);
+        reject(e);
+      }
+    });
+  }
+
+  _enqueue(op)
+  {
+    return new Promise((resolve, reject) => {
+      this.queue.push({op, resolve, reject});
+      this._pumpQueue();
+    });
+  }
+
+  _pumpQueue()
+  {
+    if (this.busy || this.queue.length === 0) return;
+    const job = this.queue.shift();
+    this.busy = true;
+    job.op().then(job.resolve, job.reject).finally(() => {
+      this.busy = false;
+      this._pumpQueue();
+    });
+  }
+
+  async spawn(wasmBinary, dataBinary)
+  {
+    this.terminate();
+    if (wasmBinary && dataBinary) {
+      // Keep copies for respawn: transferred buffers are neutered on the main thread.
+      this.cachedBuffers = {
+        wasmBinary: wasmBinary.slice(0),
+        dataBinary: dataBinary.slice(0),
+      };
+    }
+    const worker = new Worker(this.workerUrl, {type: 'module'});
+    this._attachWorker(worker);
+
+    const transfer = [];
+    const payload = {};
+    if (wasmBinary) {
+      payload.wasmBinary = wasmBinary;
+      transfer.push(wasmBinary);
+    }
+    if (dataBinary) {
+      payload.dataBinary = dataBinary;
+      transfer.push(dataBinary);
+    }
+
+    const result = await this._enqueue(() => this._request(MSG.INIT, payload, transfer));
+    this.ready = Boolean(result.ready);
+    if (!this.ready) throw new Error('Worker failed to initialize kernel');
+    return result;
+  }
+
+  async respawnAfterCrash()
+  {
+    if (!this.cachedBuffers) throw new Error('No cached WASM buffers for respawn');
+    this._debug('Respawning worker after crash…', 'info');
+    return this.spawn(this.cachedBuffers.wasmBinary, this.cachedBuffers.dataBinary);
+  }
+
+  terminate()
+  {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this._failAllPending(new Error('Worker terminated'), false);
+    this.ready = false;
+  }
+
+  evaluate(code)
+  {
+    if (!this.ready || !this.worker) {
+      return Promise.reject(new Error('Kernel not ready'));
+    }
+    return this._enqueue(() => this._request(MSG.EVALUATE, {code: String(code ?? '')}));
+  }
+
+  exportModel(format)
+  {
+    if (!this.ready || !this.worker) {
+      return Promise.reject(new Error('Kernel not ready'));
+    }
+    return this._enqueue(() => this._request(MSG.EXPORT, {format: String(format || 'stl')}));
+  }
+}

--- a/wasm-test/notebook-kernel.mjs
+++ b/wasm-test/notebook-kernel.mjs
@@ -43,8 +43,9 @@ export class NotebookKernel
     error.crashed = crashed;
     for (const [, entry] of this.pending) entry.reject(error);
     this.pending.clear();
-    this.busy = false;
+    for (const job of this.queue) job.reject(error);
     this.queue = [];
+    this.busy = false;
   }
 
   _onMessage(data)

--- a/wasm-test/notebook-protocol.mjs
+++ b/wasm-test/notebook-protocol.mjs
@@ -109,7 +109,6 @@ export function wrapNotebookExec(code)
 export function buildExportScript(format, path = '/tmp/download.' + format)
 {
   const safePath = String(path);
-  const safeFormat = String(format);
   return [
     'if _last_shown_obj is None:',
     '    print("NO_MODEL_SHOWN_YET")',

--- a/wasm-test/notebook-protocol.mjs
+++ b/wasm-test/notebook-protocol.mjs
@@ -1,0 +1,159 @@
+/** Shared notebook kernel protocol helpers (main thread + worker). */
+
+export const MSG = {
+  INIT: 'init',
+  EVALUATE: 'evaluate',
+  EXPORT: 'export',
+  RESULT: 'result',
+  EXPORT_RESULT: 'export-result',
+  ERROR: 'error',
+};
+
+export const REPL_PRELUDE = [
+  'import ast as _ast',
+  'import json as _json',
+  'import pythonscad as _pyscad',
+  'import openscad as _oscad',
+  'from pythonscad import *',
+  '_orig_show = _pyscad.show',
+  '_last_shown_obj = None',
+  'def _emit_geometry(obj):',
+  '    global _last_shown_obj',
+  '    _last_shown_obj = obj',
+  '    try:',
+  '        result = obj.mesh()',
+  '        if len(result) > 0 and len(result[0]) > 0 and len(result[0][0]) == 2:',
+  '            outlines_list = [[[float(p[0]), float(p[1])] for p in outline] for outline in result]',
+  '            print(\'@@MIME_START@@\' + _json.dumps({\'type\': \'2d\', \'outlines\': outlines_list}) + \'@@MIME_END@@\')',
+  '        else:',
+  '            verts, faces, colors, color_indices = obj.mesh(color=True)',
+  '            verts_list  = [[float(c) for c in v] for v in verts]',
+  '            faces_list  = [[int(i) for i in f] for f in faces]',
+  '            colors_list = [[float(x) for x in col] for col in colors]',
+  '            cidx_list   = [int(i) for i in color_indices]',
+  '            print(\'@@MIME_START@@\' + _json.dumps({',
+  '                \'type\': \'3d\',',
+  '                \'vertices\': verts_list,',
+  '                \'faces\': faces_list,',
+  '                \'colors\': colors_list,',
+  '                \'color_indices\': cidx_list',
+  '            }) + \'@@MIME_END@@\')',
+  '    except Exception as _e:',
+  '        print(\'GEOMETRY_ERROR: \' + repr(_e))',
+  'def show(obj, *a, **kw):',
+  '    r = _orig_show(obj, *a, **kw)',
+  '    _emit_geometry(obj)',
+  '    return r',
+  'def _notebook_show(obj, *a, **kw):',
+  '    r = obj.show(*a, **kw)',
+  '    if isinstance(obj, _probe_base_class):',
+  '        _emit_geometry(obj)',
+  '    return r',
+  'class _NotebookShowTransformer(_ast.NodeTransformer):',
+  '    def visit_Call(self, node):',
+  '        node = self.generic_visit(node)',
+  '        if isinstance(node.func, _ast.Attribute) and node.func.attr == \'show\':',
+  '            return _ast.copy_location(_ast.Call(',
+  '                func=_ast.Name(id=\'_notebook_show\', ctx=_ast.Load()),',
+  '                args=[node.func.value, *node.args],',
+  '                keywords=node.keywords), node)',
+  '        return node',
+  'def _notebook_exec(source):',
+  '    tree = _ast.parse(source, filename=\'<notebook>\', mode=\'exec\')',
+  '    tree = _NotebookShowTransformer().visit(tree)',
+  '    _ast.fix_missing_locations(tree)',
+  '    exec(compile(tree, \'<notebook>\', \'exec\'), globals(), globals())',
+  '_pyscad.show = show',
+  '_oscad.show = show',
+  '_probe_base_class = type(cube(1))',
+  'print(\'PRELUDE_LOADED_OK\')',
+].join('\n');
+
+const RESERVED_LAST_LINE = new Set([
+  'pass',
+  'break',
+  'continue',
+  'return',
+  'else',
+  'elif',
+  'try',
+  'except',
+  'finally',
+]);
+
+/** Jupyter-style: bare identifier on the last non-empty line becomes show(...). */
+export function autoShowLastLine(code)
+{
+  const lines = String(code ?? '').split('\n');
+  let lastIdx = lines.length - 1;
+  while (lastIdx >= 0 && lines[lastIdx].trim() === '') lastIdx--;
+  if (lastIdx < 0) return String(code ?? '');
+
+  const originalLine = lines[lastIdx];
+  const indent = originalLine.match(/^(\s*)/)[1];
+  const lastLine = originalLine.trim();
+  const isBareIdentifier = /^[A-Za-z_][A-Za-z0-9_]*$/.test(lastLine);
+  if (isBareIdentifier && !RESERVED_LAST_LINE.has(lastLine)) {
+    lines[lastIdx] = indent + 'show(' + lastLine + ')';
+    return lines.join('\n');
+  }
+  return lines.join('\n');
+}
+
+export function wrapNotebookExec(code)
+{
+  const finalCode = autoShowLastLine(code);
+  return '_notebook_exec(' + JSON.stringify(finalCode) + ')';
+}
+
+export function buildExportScript(format, path = '/tmp/download.' + format)
+{
+  const safePath = String(path);
+  const safeFormat = String(format);
+  return [
+    'if _last_shown_obj is None:',
+    '    print("NO_MODEL_SHOWN_YET")',
+    'else:',
+    '    export(_last_shown_obj, ' + JSON.stringify(safePath) + ')',
+    '    print("EXPORT_OK")',
+  ].join('\n');
+}
+
+export function combinePythonOutput(stdoutLines, stderrLines, returnValue)
+{
+  const fromBuffers = (stdoutLines || []).join('\n');
+  const fromStderr = (stderrLines || []).join('\n');
+  return [fromBuffers, String(returnValue ?? '').trim(), fromStderr]
+    .filter(s => s && s.trim())
+    .join('\n');
+}
+
+export function exportPathForFormat(format)
+{
+  return '/tmp/download.' + String(format || 'stl');
+}
+
+/** Classify a worker->main response for a pending request id. */
+export function resolveWorkerResponse(pending, data)
+{
+  const entry = pending.get(data.id);
+  if (!entry) return false;
+
+  pending.delete(data.id);
+  if (data.type === MSG.ERROR) {
+    const err = new Error(data.message || 'Worker error');
+    err.crashed = Boolean(data.crashed);
+    entry.reject(err);
+    return true;
+  }
+  if (data.type === MSG.EXPORT_RESULT) {
+    entry.resolve(data);
+    return true;
+  }
+  if (data.type === MSG.RESULT) {
+    entry.resolve(data);
+    return true;
+  }
+  entry.reject(new Error('Unexpected worker message type: ' + data.type));
+  return true;
+}

--- a/wasm-test/notebook-protocol.test.mjs
+++ b/wasm-test/notebook-protocol.test.mjs
@@ -121,3 +121,19 @@ test('NotebookKernel serializes requests against a mock worker', async () => {
   await Promise.all([p1, p2]);
   assert.equal(serial, '1:OUT:first2:OUT:second');
 });
+
+test('NotebookKernel rejects in-flight and queued requests on termination', async () => {
+  const kernel = new NotebookKernel({workerUrl: 'unused'});
+  kernel._attachWorker({
+    postMessage: () => {},
+    terminate: () => {},
+  });
+  kernel.ready = true;
+
+  const inFlight = kernel.evaluate('first');
+  const queued = kernel.evaluate('second');
+  kernel.terminate();
+
+  await assert.rejects(inFlight, /Worker terminated/);
+  await assert.rejects(queued, /Worker terminated/);
+});

--- a/wasm-test/notebook-protocol.test.mjs
+++ b/wasm-test/notebook-protocol.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {MSG, REPL_PRELUDE, autoShowLastLine, buildExportScript, combinePythonOutput, exportPathForFormat, resolveWorkerResponse, wrapNotebookExec,} from './notebook-protocol.mjs';
+import {NotebookKernel} from './notebook-kernel.mjs';
+
+test('REPL prelude includes notebook hooks', () => {
+  assert.match(REPL_PRELUDE, /PRELUDE_LOADED_OK/);
+  assert.match(REPL_PRELUDE, /_notebook_exec/);
+});
+
+test('autoShowLastLine wraps bare identifiers', () => {
+  assert.equal(autoShowLastLine('mymodel\n'), 'show(mymodel)\n');
+  assert.equal(autoShowLastLine('pass\n'), 'pass\n');
+  assert.equal(autoShowLastLine('  x\n'), '  show(x)\n');
+  assert.equal(autoShowLastLine('return x\n'), 'return x\n');
+});
+
+test('wrapNotebookExec and combinePythonOutput', () => {
+  assert.equal(wrapNotebookExec('mymodel'), '_notebook_exec(' + JSON.stringify('show(mymodel)') + ')');
+  assert.equal(combinePythonOutput(['line1', 'line2'], ['warn'], 'ret'), 'line1\nline2\nret\nwarn');
+});
+
+test('export helpers', () => {
+  assert.equal(buildExportScript('stl'), [
+    'if _last_shown_obj is None:',
+    '    print("NO_MODEL_SHOWN_YET")',
+    'else:',
+    '    export(_last_shown_obj, "/tmp/download.stl")',
+    '    print("EXPORT_OK")',
+  ].join('\n'));
+  assert.equal(exportPathForFormat('3mf'), '/tmp/download.3mf');
+});
+
+test('resolveWorkerResponse handles result and error', () => {
+  {
+    const pending = new Map([[
+      7, {
+        resolve: (v) => {
+          resolved = v;
+        },
+        reject: () => {},
+      }
+    ]]);
+    let resolved;
+    assert.equal(resolveWorkerResponse(pending, {type: MSG.RESULT, id: 7, output: 'ok'}), true);
+    assert.deepEqual(resolved, {type: MSG.RESULT, id: 7, output: 'ok'});
+    assert.equal(pending.size, 0);
+  } {const pending = new Map([[
+       9, {
+         resolve: () => {},
+         reject: (e) => {
+           rejected = e;
+         },
+       }
+     ]]);
+     let rejected; assert.equal(
+       resolveWorkerResponse(pending, {type: MSG.ERROR, id: 9, message: 'boom', crashed: true}), true);
+     assert.equal(rejected.message, 'boom'); assert.equal(rejected.crashed, true);}
+});
+
+class MockWorker
+{
+  constructor()
+  {
+    this.onmessage = null;
+    this.postMessage = (msg) => {
+      queueMicrotask(() => this._handle(msg));
+    };
+  }
+
+  _reply(data)
+  {
+    if (typeof this.onmessage === 'function') this.onmessage({data});
+  }
+
+  _handle(msg)
+  {
+    if (msg.type === MSG.INIT) {
+      this._reply({type: MSG.RESULT, id: msg.id, ready: true});
+      return;
+    }
+    if (msg.type === MSG.EVALUATE) {
+      this._reply({
+        type: MSG.RESULT,
+        id: msg.id,
+        output: 'OUT:' + msg.code.slice(0, 8),
+      });
+      return;
+    }
+    if (msg.type === MSG.EXPORT) {
+      this._reply({type: MSG.EXPORT_RESULT, id: msg.id, status: 'ok', format: msg.format});
+    }
+  }
+
+  terminate() {}
+}
+
+test('NotebookKernel serializes requests against a mock worker', async () => {
+  const kernel = new NotebookKernel({workerUrl: 'unused'});
+  const worker = new MockWorker();
+  kernel._attachWorker(worker);
+
+  const initResult = await kernel._enqueue(() => kernel._request(MSG.INIT, {}));
+  kernel.ready = Boolean(initResult.ready);
+  assert.equal(kernel.ready, true);
+
+  const evalResult = await kernel.evaluate('show(cube(1))');
+  assert.equal(evalResult.output, 'OUT:show(cub');
+
+  const exportResult = await kernel.exportModel('stl');
+  assert.equal(exportResult.status, 'ok');
+
+  let serial = '';
+  const p1 = kernel.evaluate('first').then(r => {
+    serial += '1:' + r.output;
+  });
+  const p2 = kernel.evaluate('second').then(r => {
+    serial += '2:' + r.output;
+  });
+  await Promise.all([p1, p2]);
+  assert.equal(serial, '1:OUT:first2:OUT:second');
+});

--- a/wasm-test/notebook-worker.mjs
+++ b/wasm-test/notebook-worker.mjs
@@ -1,0 +1,179 @@
+/**
+ * PythonSCAD notebook kernel worker: owns Emscripten module and Python REPL.
+ */
+import factory from './pythonscad.js';
+import {MSG, REPL_PRELUDE, buildExportScript, combinePythonOutput, exportPathForFormat, wrapNotebookExec,} from './notebook-protocol.mjs';
+
+let mod = null;
+let evalPython = null;
+let pythonInited = false;
+let jobChain = Promise.resolve();
+
+function errMsg(e)
+{
+  if (e == null) return 'unknown error';
+  if (typeof e === 'string') return e;
+  if (e instanceof Error) return e.message || String(e);
+  try {
+    return String(e.message ?? e);
+  } catch (_) {
+    return String(e);
+  }
+}
+
+function enqueueJob(fn)
+{
+  const run = jobChain.then(fn, fn);
+  jobChain = run.catch(() => {});
+  return run;
+}
+
+function reply(data, transfer)
+{
+  self.postMessage(data, transfer || []);
+}
+
+function replyError(id, e, crashed = false)
+{
+  reply({type: MSG.ERROR, id, message: errMsg(e), crashed});
+}
+
+function makeEvalContext()
+{
+  const stdoutBuf = [];
+  const stderrBuf = [];
+  return {
+    stdoutBuf,
+    stderrBuf,
+    clear() {
+      stdoutBuf.length = 0;
+      stderrBuf.length = 0;
+    },
+    evaluate(source) {
+      this.clear();
+      const returnValue = evalPython.evaluate(source, false);
+      return combinePythonOutput(stdoutBuf, stderrBuf, returnValue);
+    },
+  };
+}
+
+let evalCtx = null;
+
+async function initKernel(wasmBinary, dataBinary)
+{
+  mod = null;
+  evalPython = null;
+  pythonInited = false;
+  evalCtx = null;
+
+  const factoryOpts = {
+    noInitialRun: true,
+    print: (t) => {
+      if (evalCtx) evalCtx.stdoutBuf.push(t);
+    },
+    printErr: (t) => {
+      if (evalCtx) evalCtx.stderrBuf.push(t);
+    },
+  };
+  if (wasmBinary) factoryOpts.wasmBinary = wasmBinary;
+  if (dataBinary) factoryOpts.getPreloadedPackage = () => dataBinary;
+
+  mod = await factory(factoryOpts);
+  evalPython = {
+    init: mod.cwrap('EmsInitPython', null, []),
+    evaluate: mod.cwrap('EmsEvaluatePython', 'string', ['string', 'number']),
+    finish: mod.cwrap('EmsFinishPython', null, []),
+  };
+
+  evalPython.init();
+  pythonInited = true;
+  evalCtx = makeEvalContext();
+
+  evalCtx.evaluate(REPL_PRELUDE);
+  evalCtx.clear();
+}
+
+async function handleInit(msg)
+{
+  try {
+    await initKernel(msg.wasmBinary, msg.dataBinary);
+    reply({type: MSG.RESULT, id: msg.id, ready: true});
+  } catch (e) {
+    replyError(msg.id, e, false);
+  }
+}
+
+async function handleEvaluate(msg)
+{
+  if (!pythonInited || !evalCtx) {
+    replyError(msg.id, 'Kernel not initialized');
+    return;
+  }
+  try {
+    const output = evalCtx.evaluate(wrapNotebookExec(msg.code));
+    reply({type: MSG.RESULT, id: msg.id, output});
+  } catch (e) {
+    replyError(msg.id, e, true);
+  }
+}
+
+async function handleExport(msg)
+{
+  if (!pythonInited || !evalCtx || !mod) {
+    replyError(msg.id, 'Kernel not initialized');
+    return;
+  }
+
+  const format = String(msg.format || 'stl');
+  const path = exportPathForFormat(format);
+
+  try {
+    try {
+      mod.FS.mkdir('/tmp');
+    } catch (_) { /* exists */
+    }
+    try {
+      mod.FS.unlink(path);
+    } catch (_) { /* absent */
+    }
+
+    const output = evalCtx.evaluate(buildExportScript(format, path));
+    if (output.includes('NO_MODEL_SHOWN_YET')) {
+      reply({type: MSG.EXPORT_RESULT, id: msg.id, status: 'no-model'});
+      return;
+    }
+
+    const fileBytes = mod.FS.readFile(path);
+    const buffer =
+      fileBytes.buffer.slice(fileBytes.byteOffset, fileBytes.byteOffset + fileBytes.byteLength);
+    reply(
+      {
+        type: MSG.EXPORT_RESULT,
+        id: msg.id,
+        status: 'ok',
+        format,
+        byteLength: buffer.byteLength,
+        fileBytes: buffer,
+      },
+      [buffer]);
+  } catch (e) {
+    replyError(msg.id, e, true);
+  }
+}
+
+self.onmessage = (event) => {
+  const msg = event.data;
+  if (!msg || typeof msg.type !== 'string') return;
+
+  if (msg.type === MSG.INIT) {
+    enqueueJob(() => handleInit(msg));
+    return;
+  }
+  if (msg.type === MSG.EVALUATE) {
+    enqueueJob(() => handleEvaluate(msg));
+    return;
+  }
+  if (msg.type === MSG.EXPORT) {
+    enqueueJob(() => handleExport(msg));
+  }
+};

--- a/wasm-test/notebook.html
+++ b/wasm-test/notebook.html
@@ -345,12 +345,13 @@
   <span class="sep">│</span>
   <span id="cell-count">0 cells</span>
   <span class="sep">│</span>
-  <span>PythonSCAD/WASM (EmsEvaluatePython)</span>
+  <span>PythonSCAD/WASM worker kernel</span>
 </div>
 
 <script type="module">
 import * as THREE from './vendor/three.module.min.js';
 import { extractGeometryPayloads, mergeGeometries } from './notebook-geometry.mjs';
+import { NotebookKernel } from './notebook-kernel.mjs';
 
 const _dbgPanel = document.createElement('div');
 _dbgPanel.id = 'dbg';
@@ -380,83 +381,31 @@ function dbg(msg, type) {
   body.scrollTop = body.scrollHeight;
 }
 
-let mod          = null;
-let evalPython    = null;
-let pythonInited  = false;
-let wasmReady     = false;
-const stdoutBuf  = [];
-const stderrBuf  = [];
-
-const REPL_PRELUDE = [
-  "import ast as _ast",
-  "import json as _json",
-  "import pythonscad as _pyscad",
-  "import openscad as _oscad",
-  "from pythonscad import *",
-  "_orig_show = _pyscad.show",
-  "_last_shown_obj = None",
-  "def _emit_geometry(obj):",
-  "    global _last_shown_obj",
-  "    _last_shown_obj = obj",
-  "    try:",
-  "        result = obj.mesh()",
-  "        if len(result) > 0 and len(result[0]) > 0 and len(result[0][0]) == 2:",
-  "            # 2D object: result is a list of outlines, each a list of [x,y] points",
-  "            outlines_list = [[[float(p[0]), float(p[1])] for p in outline] for outline in result]",
-  "            print('@@MIME_START@@' + _json.dumps({'type': '2d', 'outlines': outlines_list}) + '@@MIME_END@@')",
-  "        else:",
-  "            verts, faces, colors, color_indices = obj.mesh(color=True)",
-  "            verts_list  = [[float(c) for c in v] for v in verts]",
-  "            faces_list  = [[int(i) for i in f] for f in faces]",
-  "            colors_list = [[float(x) for x in col] for col in colors]",
-  "            cidx_list   = [int(i) for i in color_indices]",
-  "            print('@@MIME_START@@' + _json.dumps({",
-  "                'type': '3d',",
-  "                'vertices': verts_list,",
-  "                'faces': faces_list,",
-  "                'colors': colors_list,",
-  "                'color_indices': cidx_list",
-  "            }) + '@@MIME_END@@')",
-  "    except Exception as _e:",
-  "        print('GEOMETRY_ERROR: ' + repr(_e))",
-  "def show(obj, *a, **kw):",
-  "    r = _orig_show(obj, *a, **kw)",
-  "    _emit_geometry(obj)",
-  "    return r",
-  "def _notebook_show(obj, *a, **kw):",
-  "    r = obj.show(*a, **kw)",
-  "    if isinstance(obj, _probe_base_class):",
-  "        _emit_geometry(obj)",
-  "    return r",
-  "class _NotebookShowTransformer(_ast.NodeTransformer):",
-  "    def visit_Call(self, node):",
-  "        node = self.generic_visit(node)",
-  "        if isinstance(node.func, _ast.Attribute) and node.func.attr == 'show':",
-  "            return _ast.copy_location(_ast.Call(",
-  "                func=_ast.Name(id='_notebook_show', ctx=_ast.Load()),",
-  "                args=[node.func.value, *node.args],",
-  "                keywords=node.keywords), node)",
-  "        return node",
-  "def _notebook_exec(source):",
-  "    tree = _ast.parse(source, filename='<notebook>', mode='exec')",
-  "    tree = _NotebookShowTransformer().visit(tree)",
-  "    _ast.fix_missing_locations(tree)",
-  "    exec(compile(tree, '<notebook>', 'exec'), globals(), globals())",
-  "# Re-export the instrumented show onto the modules so a user cell that runs",
-  "# 'from pythonscad import *' (or 'from openscad import *') re-binds THIS show",
-  "# instead of clobbering it with the original (which emits no notebook geometry).",
-  "_pyscad.show = show",
-  "_oscad.show = show",
-  "_probe_base_class = type(cube(1))",
-  "print('PRELUDE_LOADED_OK')",
-].join('\n');
+let kernel      = null;
+let wasmReady   = false;
+let kernelBusy  = false;
 
 async function reloadWasmAfterCrash() {
-  dbg('Reloading WASM module after crash…', 'info');
-  mod = null;
-  evalPython = null;
-  pythonInited = false;
-  await initWasm();
+  dbg('Reloading WASM worker after crash…', 'info');
+  wasmReady = false;
+  setControlsEnabled(false);
+  try {
+    if (kernel && kernel.cachedBuffers) {
+      await kernel.respawnAfterCrash();
+    } else {
+      await initWasm();
+      return;
+    }
+    wasmReady = true;
+    setBadge('ready', 'PySCAD/WASM');
+    setStatus('Kernel ready');
+    setControlsEnabled(true);
+  } catch (e) {
+    const msg = errMsg(e);
+    setBadge('error', 'Reload failed');
+    setStatus('Reload error: ' + msg);
+    dbg('reloadWasmAfterCrash ERROR: ' + msg, 'error');
+  }
 }
 
 function fmtBytes(n) {
@@ -551,17 +500,11 @@ function finishLoadProgress() {
 async function initWasm() {
   setBadge('busy', 'Loading…');
   setStatus('Loading PythonSCAD/WASM…');
+  setControlsEnabled(false);
   try {
-    const factoryOpts = {
-      noInitialRun: true,
-      print:    (t) => { stdoutBuf.push(t); dbg('stdout: ' + t); },
-      printErr: (t) => { stderrBuf.push(t); dbg('stderr: ' + t, 'error'); },
-    };
+    let wasmBuf = null;
+    let dataBuf = null;
 
-    // Pre-download the two large assets ourselves so we can show real
-    // progress. pythonscad.wasm (engine + CPython) and pythonscad.data
-    // (stdlib + libraries) are ~18 MB each and are the long pole on slow
-    // links. If anything here fails we fall back to Emscripten's own loader.
     try {
       const prog = { wasm: { loaded: 0, total: 0 }, data: { loaded: 0, total: 0 } };
       const report = () => {
@@ -575,40 +518,35 @@ async function initWasm() {
         }
       };
       setLoadProgress(null, 'Downloading…');
-      const [wasmBuf, dataBuf] = await Promise.all([
+      [wasmBuf, dataBuf] = await Promise.all([
         fetchWithProgress('./pythonscad.wasm', (l, t) => { prog.wasm = { loaded: l, total: t }; report(); }),
         fetchWithProgress('./pythonscad.data', (l, t) => { prog.data = { loaded: l, total: t }; report(); }),
       ]);
-      factoryOpts.wasmBinary = wasmBuf;
-      factoryOpts.getPreloadedPackage = () => dataBuf;
       setLoadProgress(100, 'Initialising kernel…');
     } catch (preErr) {
       dbg('asset prefetch failed, using default loader: ' + errMsg(preErr), 'error');
       setLoadProgress(null, 'Initialising kernel…');
     }
 
-    const { default: factory } = await import('./pythonscad.js');
-    mod = await factory(factoryOpts);
+    if (!kernel) {
+      kernel = new NotebookKernel({
+        onDebug: (msg, type) => dbg(msg, type),
+      });
+    }
 
-    evalPython = {
-      init:     mod.cwrap('EmsInitPython',     null,     []),
-      evaluate: mod.cwrap('EmsEvaluatePython', 'string', ['string', 'number']),
-      finish:   mod.cwrap('EmsFinishPython',   null,     []),
-    };
-
-    evalPython.init();
-    pythonInited = true;
-    dbg('EmsInitPython() done', 'info');
-
-    const preludeResult = evalPython.evaluate(REPL_PRELUDE, false);
-    dbg('prelude result: ' + JSON.stringify(preludeResult), 'info');
-    stdoutBuf.length = 0; stderrBuf.length = 0;  // discard prelude's own output
+    if (wasmBuf && dataBuf) {
+      await kernel.spawn(wasmBuf, dataBuf);
+    } else {
+      // Fallback: worker fetches assets via Emscripten's default loader.
+      await kernel.spawn(null, null);
+    }
 
     wasmReady = true;
     setBadge('ready', 'PySCAD/WASM');
     setStatus('Kernel ready');
     finishLoadProgress();
-    enableUI();
+    setControlsEnabled(true);
+    dbg('Notebook worker kernel ready', 'info');
   } catch(e) {
     const msg = errMsg(e);
     setBadge('error', 'Load failed');
@@ -619,45 +557,6 @@ async function initWasm() {
     dbg('initWasm ERROR: ' + msg, 'error');
     console.error(e);
   }
-}
-
-function autoShowLastLine(code) {
-  const lines = code.split('\n');
-  let lastIdx = lines.length - 1;
-  while (lastIdx >= 0 && lines[lastIdx].trim() === '') lastIdx--;
-  if (lastIdx < 0) return code;
-
-  const originalLine = lines[lastIdx];
-  const indent = originalLine.match(/^(\s*)/)[1];
-  const lastLine = originalLine.trim();
-  const isBareIdentifier = /^[A-Za-z_][A-Za-z0-9_]*$/.test(lastLine);
-  const RESERVED = new Set(['pass','break','continue','return','else','elif','try','except','finally']);
-  if (isBareIdentifier && !RESERVED.has(lastLine)) {
-    lines[lastIdx] = indent + 'show(' + lastLine + ')';
-    return lines.join('\n');
-  }
-
-  return lines.join('\n');
-}
-
-function renderPython(code) {
-  stdoutBuf.length = 0;
-  stderrBuf.length = 0;
-  const finalCode = autoShowLastLine(code);
-  dbg('evaluate() <- ' + JSON.stringify(finalCode.slice(0,120)), 'info');
-  const returnValue = evalPython.evaluate('_notebook_exec(' + JSON.stringify(finalCode) + ')', false);
-  dbg('evaluate() return value -> ' + JSON.stringify(String(returnValue).slice(0,300)), 'info');
-  dbg('stdoutBuf after call -> ' + JSON.stringify(stdoutBuf), 'info');
-  dbg('stderrBuf after call -> ' + JSON.stringify(stderrBuf), 'info');
-  // Combine print()/stderr captured via callbacks with whatever
-  // evaluate() returns directly (some builds return '', others echo it back).
-  const fromBuffers = stdoutBuf.join('\n');
-  const fromStderr   = stderrBuf.join('\n');
-  const combined = [fromBuffers, String(returnValue || '').trim(), fromStderr]
-    .filter(s => s && s.trim())
-    .join('\n');
-  dbg('renderPython combined -> ' + JSON.stringify(combined.slice(0,200)), 'info');
-  return combined;
 }
 
 function extractGeometry(output) {
@@ -1039,7 +938,7 @@ function outputRowHTML(c) {
     '</div>');
 }
 
-function runCell(id) {
+function runCell(id, opts = {}) {
   const cell = cells.find(c => c.id === id);
   if (!cell) return Promise.resolve();
   const ta = document.getElementById('ed-' + id);
@@ -1047,6 +946,7 @@ function runCell(id) {
 
   if (cell.type === 'markdown') { runMarkdown(cell); return Promise.resolve(); }
   if (!wasmReady) { alert('Kernel not ready yet.'); return Promise.resolve(); }
+  if (kernelBusy && !opts.batch) return Promise.resolve();
 
   const outRow = document.getElementById('outrow-' + id);
   const outCtr = document.getElementById('outctr-' + id);
@@ -1061,79 +961,83 @@ function runCell(id) {
   bodyEl.innerHTML = '<div class="output-body"><div class="output-log">⏳ Evaluating…</div></div>';
   ctrEl.textContent = '[*]';
   timEl.textContent = '';
+  if (!opts.batch) setKernelBusy(true);
   setBadge('busy', 'Running…');
   setStatus('Running cell ' + id + '…');
 
   const t0 = Date.now();
 
-  return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => {
-    let rawOutput;
-    let crashed = false;
-    try {
-      rawOutput = renderPython(cell.code);
-    } catch(e) {
-      crashed = true;
-      const msg = errMsg(e);
-      rawOutput = 'ERROR: ' + msg;
-      dbg('runCell ' + id + ' CRASHED: ' + msg, 'error');
-      // A WASM-level crash (e.g. "memory access out of bounds") corrupts
-      // the entire WASM heap — re-calling EmsInitPython on the same module
-      // instance won't help. Reload the whole module from scratch.
+  return kernel.evaluate(cell.code).then(result => {
+    const rawOutput = result.output || '';
+    finishRunCell(id, cell, rawOutput, false, t0);
+  }).catch(e => {
+    const crashed = Boolean(e && e.crashed);
+    const rawOutput = 'ERROR: ' + errMsg(e);
+    dbg('runCell ' + id + (crashed ? ' CRASHED: ' : ' error: ') + errMsg(e), 'error');
+    finishRunCell(id, cell, rawOutput, crashed, t0);
+    if (crashed) {
       wasmReady = false;
       setBadge('error', 'Kernel crashed — reloading…');
       reloadWasmAfterCrash();
     }
+  }).finally(() => {
+    if (!opts.batch) setKernelBusy(false);
+  });
+}
 
-    const elapsed = ((Date.now() - t0) / 1000).toFixed(2);
-    timEl.textContent = elapsed + 's';
-    // Restore the cell's own stable execution number (assigned at creation)
-    ctrEl.textContent = '[' + cell.executionCount + ']';
-    outCtr.textContent = '[' + cell.executionCount + ']';
-    if (!crashed) setBadge('ready', 'PySCAD/WASM');
+function finishRunCell(id, cell, rawOutput, crashed, t0) {
+  const outCtr = document.getElementById('outctr-' + id);
+  const lblEl  = document.getElementById('lbl-' + id);
+  const bodyEl = document.getElementById('body-' + id);
+  const ctrEl  = document.getElementById('ctr-' + id);
+  const timEl  = document.getElementById('tim-' + id);
 
-    const r = extractGeometry(rawOutput);
-    const geometry = r.geometry, text = r.text;
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(2);
+  timEl.textContent = elapsed + 's';
+  ctrEl.textContent = '[' + cell.executionCount + ']';
+  outCtr.textContent = '[' + cell.executionCount + ']';
+  if (!crashed && wasmReady) setBadge('ready', 'PySCAD/WASM');
 
-    dbg('runCell ' + id + ' -> geometry=' + (geometry ? 'yes' : 'no') + ' text=' + JSON.stringify(text), 'info');
+  const r = extractGeometry(rawOutput);
+  const geometry = r.geometry, text = r.text;
 
-    if (crashed) {
-      lblEl.textContent = 'error';
-      bodyEl.innerHTML = '<div class="output-body"><div class="output-log error">' + escHTML(text) + '</div></div>';
-      setStatus('Error in cell ' + id);
-    } else if (geometry) {
-      lblEl.textContent = '3D model';
-      bodyEl.innerHTML = '';
-      if (text) {
-        const d = document.createElement('div');
-        d.className = 'output-body';
-        d.innerHTML = '<div class="output-log warn">' + escHTML(text) + '</div>';
-        bodyEl.appendChild(d);
-      }
-      const wrap = document.createElement('div');
-      wrap.className = 'stl-viewer-wrap';
-      const canvas = document.createElement('canvas');
-      wrap.appendChild(canvas);
-      const bar = document.createElement('div');
-      bar.className = 'stl-bar';
-      bar.innerHTML = '<span class="stl-info">' + geometry.faces.length + ' faces &middot; ' + elapsed + 's</span>';
-      wrap.appendChild(bar);
-      bodyEl.appendChild(wrap);
-      initViewerGeometry(canvas, geometry);
-      setStatus('Render complete (' + elapsed + 's)');
-    } else if (text) {
-      // Heuristic: PythonSCAD error/traceback text usually contains these markers
-      const looksLikeError = /Traceback|Error:|SyntaxError|NameError|TypeError|ValueError/.test(text);
-      lblEl.textContent = looksLikeError ? 'error' : 'output';
-      bodyEl.innerHTML = '<div class="output-body"><div class="output-log' +
-        (looksLikeError ? ' error' : '') + '">' + escHTML(text) + '</div></div>';
-      setStatus('Done (' + elapsed + 's)');
-    } else {
-      lblEl.textContent = 'done';
-      bodyEl.innerHTML = '<div class="output-body"><div class="output-log" style="opacity:0.5">(no output)</div></div>';
-      setStatus('Done (' + elapsed + 's)');
+  dbg('runCell ' + id + ' -> geometry=' + (geometry ? 'yes' : 'no') + ' text=' + JSON.stringify(String(text).slice(0, 120)), 'info');
+
+  if (crashed) {
+    lblEl.textContent = 'error';
+    bodyEl.innerHTML = '<div class="output-body"><div class="output-log error">' + escHTML(text) + '</div></div>';
+    setStatus('Error in cell ' + id);
+  } else if (geometry) {
+    lblEl.textContent = '3D model';
+    bodyEl.innerHTML = '';
+    if (text) {
+      const d = document.createElement('div');
+      d.className = 'output-body';
+      d.innerHTML = '<div class="output-log warn">' + escHTML(text) + '</div>';
+      bodyEl.appendChild(d);
     }
-    resolve();
-  })));
+    const wrap = document.createElement('div');
+    wrap.className = 'stl-viewer-wrap';
+    const canvas = document.createElement('canvas');
+    wrap.appendChild(canvas);
+    const bar = document.createElement('div');
+    bar.className = 'stl-bar';
+    bar.innerHTML = '<span class="stl-info">' + geometry.faces.length + ' faces &middot; ' + elapsed + 's</span>';
+    wrap.appendChild(bar);
+    bodyEl.appendChild(wrap);
+    initViewerGeometry(canvas, geometry);
+    setStatus('Render complete (' + elapsed + 's)');
+  } else if (text) {
+    const looksLikeError = /Traceback|Error:|SyntaxError|NameError|TypeError|ValueError/.test(text);
+    lblEl.textContent = looksLikeError ? 'error' : 'output';
+    bodyEl.innerHTML = '<div class="output-body"><div class="output-log' +
+      (looksLikeError ? ' error' : '') + '">' + escHTML(text) + '</div></div>';
+    setStatus('Done (' + elapsed + 's)');
+  } else {
+    lblEl.textContent = 'done';
+    bodyEl.innerHTML = '<div class="output-body"><div class="output-log" style="opacity:0.5">(no output)</div></div>';
+    setStatus('Done (' + elapsed + 's)');
+  }
 }
 
 function runMarkdown(cell) {
@@ -1144,7 +1048,13 @@ function runMarkdown(cell) {
 }
 
 async function runAllCells() {
-  for (const c of cells) await runCell(c.id);
+  if (kernelBusy || !wasmReady) return;
+  setKernelBusy(true);
+  try {
+    for (const c of cells) await runCell(c.id, { batch: true });
+  } finally {
+    setKernelBusy(false);
+  }
 }
 
 function clearAllOutputs() {
@@ -1591,62 +1501,45 @@ window.loadNotebookFromFile = function(input) {
   input.value = '';  // allow re-selecting the same file later
 };
 
-window.downloadLastModel = function(format) {
+window.downloadLastModel = async function(format) {
   format = format || 'stl';
-  if (!wasmReady) { alert('Kernel not ready yet.'); return; }
-  const path = '/tmp/download.' + format;
+  if (!wasmReady || kernelBusy) {
+    alert(kernelBusy ? 'Kernel is busy — wait for the current cell to finish.' : 'Kernel not ready yet.');
+    return;
+  }
+  setKernelBusy(true);
+  setBadge('busy', 'Exporting…');
   try {
-    mod.FS.mkdir('/tmp');
-  } catch(_) { /* already exists — fine */ }
-  try {
-    mod.FS.unlink(path);
-  } catch(_) { /* file may not exist yet — fine */ }
-
-  stdoutBuf.length = 0;
-  stderrBuf.length = 0;
-  const exportCode =
-    'if _last_shown_obj is None:\n' +
-    '    print("NO_MODEL_SHOWN_YET")\n' +
-    'else:\n' +
-    '    export(_last_shown_obj, "' + path + '")\n' +
-    '    print("EXPORT_OK")\n';
-
-  let ret;
-  try {
-    ret = evalPython.evaluate(exportCode, false);
-  } catch(e) {
+    const result = await kernel.exportModel(format);
+    if (result.status === 'no-model') {
+      alert('No model has been shown yet — run a cell with show(...) first.');
+      return;
+    }
+    if (result.status !== 'ok' || !result.fileBytes) {
+      alert('Export did not produce a file.');
+      return;
+    }
+    const blob = new Blob([result.fileBytes], { type: 'application/octet-stream' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'model.' + format;
+    a.click();
+    setStatus(format.toUpperCase() + ' downloaded (' + result.fileBytes.byteLength + ' bytes)');
+  } catch (e) {
     const msg = errMsg(e);
-    dbg('downloadLastModel evaluate() CRASHED: ' + msg, 'error');
-    alert('Export crashed the kernel: ' + msg + '\nReloading WASM module…');
-    wasmReady = false;
-    setBadge('error', 'Kernel crashed — reloading…');
-    reloadWasmAfterCrash();
-    return;
+    dbg('downloadLastModel failed: ' + msg, 'error');
+    if (e && e.crashed) {
+      alert('Export crashed the kernel: ' + msg + '\nReloading WASM worker…');
+      wasmReady = false;
+      setBadge('error', 'Kernel crashed — reloading…');
+      reloadWasmAfterCrash();
+    } else {
+      alert('Export failed: ' + msg);
+    }
+  } finally {
+    setKernelBusy(false);
+    if (wasmReady) setBadge('ready', 'PySCAD/WASM');
   }
-  dbg('downloadLastModel evaluate() -> ' + JSON.stringify(ret) + ' stdout=' + JSON.stringify(stdoutBuf) + ' stderr=' + JSON.stringify(stderrBuf), 'info');
-
-  const combinedOut = stdoutBuf.join('\n');
-  if (combinedOut.includes('NO_MODEL_SHOWN_YET')) {
-    alert('No model has been shown yet — run a cell with show(...) first.');
-    return;
-  }
-
-  let fileBytes;
-  try {
-    fileBytes = mod.FS.readFile(path);
-  } catch(e) {
-    const msg = errMsg(e);
-    dbg('downloadLastModel FS.readFile failed: ' + msg, 'error');
-    alert('Export did not produce a file: ' + msg);
-    return;
-  }
-
-  const blob = new Blob([fileBytes], { type: 'application/octet-stream' });
-  const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
-  a.download = 'model.' + format;
-  a.click();
-  setStatus(format.toUpperCase() + ' downloaded (' + fileBytes.byteLength + ' bytes)');
 };
 
 window.saveNotebook = function() {
@@ -1683,10 +1576,17 @@ window.autoH = function(ta) {
   ta.style.height = Math.max(80, ta.scrollHeight) + 'px';
 };
 
-function enableUI() {
+function setControlsEnabled(enabled) {
   ['btn-run-all','btn-add-code','btn-add-md','btn-download-stl','export-format'].forEach(id => {
-    const el = document.getElementById(id); if(el) el.disabled = false;
+    const el = document.getElementById(id);
+    if (el) el.disabled = !enabled || kernelBusy;
   });
+}
+
+function setKernelBusy(busy) {
+  kernelBusy = busy;
+  setControlsEnabled(wasmReady);
+  document.querySelectorAll('.cell-run-btn').forEach(btn => { btn.disabled = busy; });
 }
 function setBadge(state, text) {
   const b = document.getElementById('kernel-badge');


### PR DESCRIPTION
## Summary

- move the persistent Emscripten/Python kernel, synchronous evaluation, and virtual filesystem exports into one serialized module Web Worker
- preserve download progress, cell state, output/geometry rendering, model downloads, and full worker respawn after a WASM crash
- package the worker runtime modules and add deterministic protocol/queue tests

Closes #936.

This PR is stacked on #935 because both refactor the notebook evaluation protocol. It can be retargeted to `master` after #935 merges.

## Test plan

- [x] `node --test wasm-test/notebook-geometry.test.mjs wasm-test/notebook-protocol.test.mjs`
- [x] `node --check` on worker/runtime modules
- [x] pre-commit hooks, including workflow lint and formatting
- [x] headless Chrome: PythonSCAD logo renders both colors through the worker
- [x] headless Chrome: 20.46s CPU-bound Python cell kept a 50ms main-thread heartbeat running (417 ticks, 338ms maximum observed gap including UI work)
- [x] headless Chrome: worker-side STL export downloaded a valid 1,501-byte file
- [ ] required CI

Made with [Cursor](https://cursor.com)