### PR TITLE
fix(python): skip non-matrix attributes in multmatrix

### DIFF
--- a/src/python/py_transform.cc
+++ b/src/python/py_transform.cc
@@ -526,7 +526,7 @@ PyObject *python_multmatrix_sub(PyObject *pyobj, PyObject *pymat, int div)
     Py_ssize_t pos = 0;
     while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
       Matrix4d raw;
-      if (python_tomatrix(value, raw)) return nullptr;
+      if (python_tomatrix(value, raw)) continue;
       PyObject *value1 = python_frommatrix(node->matrix * raw);
       if (value1 != nullptr) PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value1);
       else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);

--- a/src/python/py_transform.cc
+++ b/src/python/py_transform.cc
@@ -526,10 +526,17 @@ PyObject *python_multmatrix_sub(PyObject *pyobj, PyObject *pymat, int div)
     Py_ssize_t pos = 0;
     while (PyDict_Next(child_dict.get(), &pos, &key, &value)) {
       Matrix4d raw;
-      if (python_tomatrix(value, raw)) continue;
-      PyObject *value1 = python_frommatrix(node->matrix * raw);
-      if (value1 != nullptr) PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value1);
-      else PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, value);
+      auto value1 =
+        python_tomatrix(value, raw) ? py_owned() : py_owned(python_frommatrix(node->matrix * raw));
+      if (value1.get() == nullptr && PyErr_Occurred()) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
+      PyObject *to_insert = value1.get() != nullptr ? value1.get() : value;
+      if (PyDict_SetItem(((PyOpenSCADObject *)pyresult)->dict, key, to_insert) < 0) {
+        Py_DECREF(pyresult);
+        return nullptr;
+      }
     }
   }
   return pyresult;

--- a/src/python/py_transform.cc
+++ b/src/python/py_transform.cc
@@ -521,6 +521,7 @@ PyObject *python_multmatrix_sub(PyObject *pyobj, PyObject *pymat, int div)
   node->matrix = mat;
   node->children.push_back(child);
   PyObject *pyresult = PyOpenSCADObjectFromNode(type, node);
+  if (pyresult == nullptr) return nullptr;
   if (child_dict.get() != nullptr) {
     PyObject *key, *value;
     Py_ssize_t pos = 0;

--- a/tests/data/pythonscad-echo/solid-attributes.py
+++ b/tests/data/pythonscad-echo/solid-attributes.py
@@ -16,3 +16,12 @@ c.setattr("Hello","World")
 print(c.hasattr("Hello"))
 print(c.getattr("configuration"))
 print(c.Hello)
+
+transformed=c.multmatrix([
+    [1,0,0,1],
+    [0,1,0,2],
+    [0,0,1,3],
+    [0,0,0,1],
+])
+print(transformed.configuration)
+print(transformed.Hello)

--- a/tests/regression/pythonscadecho/solid-attributes-expected.echo
+++ b/tests/regression/pythonscadecho/solid-attributes-expected.echo
@@ -5,4 +5,6 @@ False
 True
 [1, 2]
 World
+[1, 2]
+World
 


### PR DESCRIPTION
## Summary
- Skip object attributes that cannot be converted to matrices while applying `multmatrix`.
- Continue processing matrix-compatible attributes instead of aborting with a silent null result.

## Test plan
- [x] Existing Linux, macOS, Windows, Python, formatting, tidy, and WASM checks pass.
- [ ] Commitlint passes with the corrected conventional PR title.
- [ ] Copilot review reports no unresolved issues.