### PR TITLE
fix(wasm): correct Python keyword callback signatures

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -112,6 +112,23 @@ jobs:
               echo 'PASS'
             "
 
+      - name: Smoke test Python callback ABI
+        run: |
+          docker run --rm -i \
+            -v "$PWD:/src:rw" \
+            -v "$PWD/libraries/python:/cpython-wasm/lib/pythonscad/libraries/python:ro" \
+            -w /src/build-wasm-node \
+            pythonscad-wasm-python-base:local \
+            bash -c "
+              set -euo pipefail
+              node pythonscad.js -o /tmp/add-parameter.stl --trust-python \
+                /src/wasm-test/python-callback-abi.py
+              SIZE=\$(wc -c < /tmp/add-parameter.stl)
+              echo \"add_parameter STL output: \${SIZE} bytes\"
+              [ \"\${SIZE}\" -gt 1000 ] || { echo 'FAIL: STL too small or missing'; exit 1; }
+              echo 'PASS'
+            "
+
       - name: Smoke test Minkowski logo
         run: |
           docker run --rm -i \

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -741,7 +741,7 @@ PyObject *python_str(PyObject *self)
   return PyUnicode_FromStringAndSize(stream.str().c_str(), stream.str().size());
 }
 
-PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs, ImportType type)
+PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   char *kwlist[] = {"name", "default",    "description", "group", "range",
                     "step", "max_length", "options",     NULL};
@@ -1126,7 +1126,7 @@ PyObject *python_osinclude(PyObject *self, PyObject *args, PyObject *kwargs)
 
 #ifndef OPENSCAD_NOGUI
 extern void add_menuitem_trampoline(const char *menuname, const char *itemname, const char *callback);
-PyObject *python_add_menuitem(PyObject *self, PyObject *args, PyObject *kwargs, int mode)
+PyObject *python_add_menuitem(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   char *kwlist[] = {"menuname", "itemname", "callback", NULL};
   const char *menuname = nullptr, *itemname = nullptr, *callback = nullptr;
@@ -1151,7 +1151,7 @@ PyObject *python_mainwindow_ptr(PyObject *, PyObject *)
 
 #endif
 
-PyObject *python_model(PyObject *self, PyObject *args, PyObject *kwargs, int mode)
+PyObject *python_model(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   char *kwlist[] = {NULL};
 

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -345,7 +345,7 @@ PyObject *python_oo_setattr(PyObject *self, PyObject *args, PyObject *kwargs)
   Py_RETURN_NONE;
 }
 
-PyObject *python_modelpath(PyObject *self, PyObject *args, PyObject *kwargs, int mode)
+PyObject *python_modelpath(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   char *kwlist[] = {NULL};
 

--- a/src/python/pyfunctions.h
+++ b/src/python/pyfunctions.h
@@ -207,7 +207,7 @@ PyObject *do_import_python(PyObject *self, PyObject *args, PyObject *kwargs, Imp
 
 #ifndef OPENSCAD_NOGUI
 PyObject *python_nimport(PyObject *self, PyObject *args, PyObject *kwargs);
-PyObject *python_add_menuitem(PyObject *self, PyObject *args, PyObject *kwargs, int mode);
+PyObject *python_add_menuitem(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject *python_qapp_ptr(PyObject *, PyObject *);
 PyObject *python_mainwindow_ptr(PyObject *, PyObject *);
 #endif
@@ -245,10 +245,10 @@ PyObject *python_osversion_num(PyObject *self, PyObject *args, PyObject *kwargs)
 PyObject *python_osversion_string(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject *python_osuse(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject *python_osinclude(PyObject *self, PyObject *args, PyObject *kwargs);
-PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs, ImportType type);
+PyObject *python_add_parameter(PyObject *self, PyObject *args, PyObject *kwargs);
 PyObject *python_scad(PyObject *self, PyObject *args, PyObject *kwargs);
-PyObject *python_model(PyObject *self, PyObject *args, PyObject *kwargs, int mode);
-PyObject *python_modelpath(PyObject *self, PyObject *args, PyObject *kwargs, int mode);
+PyObject *python_model(PyObject *self, PyObject *args, PyObject *kwargs);
+PyObject *python_modelpath(PyObject *self, PyObject *args, PyObject *kwargs);
 
 // Object methods
 PyObject *python_oo_clone(PyObject *self, PyObject *args, PyObject *kwargs);

--- a/wasm-test/python-callback-abi.py
+++ b/wasm-test/python-callback-abi.py
@@ -1,0 +1,7 @@
+from pythonscad import *
+
+assert model() is None
+assert modelpath().endswith("python-callback-abi.py")
+x = add_parameter("x", 1, range=range(0, 101))
+assert x == 1
+cube(1 + x).show()


### PR DESCRIPTION
## Summary

- remove unused fourth parameters from four Python keyword callbacks so their native signatures exactly match CPython's three-argument callback ABI
- preserve existing `add_parameter` behavior: GUI builds still populate the Customizer, while headless/WASM callers receive the supplied default value
- add a WASM node smoke test covering `add_parameter`, `model`, and `modelpath`

Closes #939.

## Root cause

Desktop ABIs tolerated CPython calling the incorrectly registered four-argument functions through a three-argument pointer. WebAssembly type-checks indirect calls and aborted immediately at `add_parameter(...)` with a function-signature mismatch.

## Test plan

- [x] reproduced the failure with a minimal `add_parameter` WASM script before the fix
- [x] rebuilt node and web WASM variants after the fix
- [x] node WASM callback smoke produced a 1,447-byte STL
- [x] reported icosahedron/dodecahedron script produced a 12,094-byte STL in node WASM
- [x] reported script rendered 20 vertices / 36 faces in the local worker playground and downloaded the 12,094-byte STL
- [x] native GUI build completed, including the GUI-only `add_menuitem` callback
- [x] native `add_parameter`, extended Customizer, and pure-function regression tests passed
- [x] pre-commit formatting and workflow checks passed
- [ ] required CI

Made with [Cursor](https://cursor.com)