### PR TITLE
fix(python): correct GUI callback registrations

### DIFF
--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -928,10 +928,10 @@ PyMethodDef PyOpenSCADFunctions[] = {
   {"nimport", (PyCFunction)python_nimport, METH_VARARGS | METH_KEYWORDS,
    "Import a Python model from a URL (not an STL).\n"
    "nimport(url=\"https://example.com/model.py\")"},
-  {"qapp_ptr", (PyCFunction)python_qapp_ptr, METH_VARARGS | METH_KEYWORDS,
+  {"qapp_ptr", python_qapp_ptr, METH_NOARGS,
    "Get raw pointer to the Qt application.\n"
    "qapp_ptr()"},
-  {"mainwindow_ptr", (PyCFunction)python_mainwindow_ptr, METH_VARARGS | METH_KEYWORDS,
+  {"mainwindow_ptr", python_mainwindow_ptr, METH_NOARGS,
    "Get raw pointer to the main window.\n"
    "mainwindow_ptr()"},
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -301,6 +301,10 @@ file(GLOB PYTHONSCAD_OVERLAY_ECHO_FILES ${TEST_PYTHONSCAD_OVERLAY_ECHO_DIR}/*.py
 file(GLOB SCAD_3D_EXPORT_FILES      ${TEST_SCAD_DIR}/3d-export/*.scad)
 # Exclude add_parameter_pure.py as it has a separate test with feature flag
 list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_pure.py")
+# GUI pointer callbacks are not exposed in headless builds.
+if(HEADLESS)
+  list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/gui_callback_abi.py")
+endif()
 # Exclude libfive tests if libfive is not enabled
 if(NOT ENABLE_LIBFIVE)
   list(REMOVE_ITEM PYTHONSCAD_FILES "${TEST_PYTHONSCAD_DIR}/libfive-union-stairs.py")

--- a/tests/data/pythonscad-echo/gui_callback_abi.py
+++ b/tests/data/pythonscad-echo/gui_callback_abi.py
@@ -1,7 +1,9 @@
 from openscad import *
 
-assert isinstance(qapp_ptr(), int)
-assert isinstance(mainwindow_ptr(), int)
+if not isinstance(qapp_ptr(), int):
+    raise AssertionError("qapp_ptr() must return an integer pointer")
+if not isinstance(mainwindow_ptr(), int):
+    raise AssertionError("mainwindow_ptr() must return an integer pointer")
 
 for callback in (qapp_ptr, mainwindow_ptr):
     try:

--- a/tests/data/pythonscad-echo/gui_callback_abi.py
+++ b/tests/data/pythonscad-echo/gui_callback_abi.py
@@ -1,0 +1,21 @@
+from openscad import *
+
+assert isinstance(qapp_ptr(), int)
+assert isinstance(mainwindow_ptr(), int)
+
+for callback in (qapp_ptr, mainwindow_ptr):
+    try:
+        callback(1)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("positional arguments must be rejected")
+
+    try:
+        callback(unexpected=True)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("keyword arguments must be rejected")
+
+print("GUI callback ABI: OK")

--- a/tests/regression/pythonscadecho/gui_callback_abi-expected.echo
+++ b/tests/regression/pythonscadecho/gui_callback_abi-expected.echo
@@ -1,0 +1,1 @@
+GUI callback ABI: OK


### PR DESCRIPTION
## Summary
- register `qapp_ptr()` and `mainwindow_ptr()` as no-argument CPython methods so their callback ABIs match their implementations
- reject accidental positional and keyword arguments instead of silently accepting them through an incompatible registration
- add a GUI-only regression test covering successful calls and argument rejection

Closes #942

## Test plan
- [x] Build `OpenSCADExe` in the native Qt6 debug build
- [x] Run `ctest --test-dir build-sandbox-check -R '^pythonscadecho_gui_callback_abi$' --output-on-failure`
- [x] Run pre-commit and commit-message hooks

Made with [Cursor](https://cursor.com)