### PR TITLE
feat(web): deploy master builds to test site

### DIFF
--- a/.github/actions/web-sftp-deploy/action.yml
+++ b/.github/actions/web-sftp-deploy/action.yml
@@ -1,0 +1,94 @@
+name: Web SFTP deploy
+description: >
+  Validate pinned-host SFTP credentials, rsync a local directory to the remote
+  web root (or a subtree), and clean up the temporary SSH key material.
+
+inputs:
+  config_label:
+    description: 'Human-readable label for error messages (e.g. "test website")'
+    required: true
+  ssh_key:
+    description: 'Private SSH key secret value'
+    required: true
+  host_key:
+    description: 'Pinned ssh-keyscan output for the deploy host'
+    required: true
+  host:
+    description: 'Deploy server hostname'
+    required: true
+  user:
+    description: 'SFTP/SSH username'
+    required: true
+  path:
+    description: 'Remote document root path'
+    required: true
+  port:
+    description: 'SSH port (defaults to 22 when empty)'
+    required: false
+    default: ''
+  source:
+    description: 'Local directory to upload (trailing slash recommended)'
+    required: true
+  remote_subpath:
+    description: 'Optional path segment under the remote root (e.g. playground/)'
+    required: false
+    default: ''
+  rsync_delete:
+    description: 'Pass --delete to rsync'
+    required: false
+    default: 'true'
+  rsync_exclude:
+    description: 'Optional rsync --exclude pattern (may be repeated via caller script if needed)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Validate deploy configuration
+      shell: bash
+      env:
+        DEPLOY_SSH_KEY: ${{ inputs.ssh_key }}
+        DEPLOY_HOST_KEY: ${{ inputs.host_key }}
+        DEPLOY_HOST: ${{ inputs.host }}
+        DEPLOY_USER: ${{ inputs.user }}
+        DEPLOY_PATH: ${{ inputs.path }}
+        CONFIG_LABEL: ${{ inputs.config_label }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../scripts/web-deploy-common.sh"
+        validate_web_deploy_config "$CONFIG_LABEL"
+
+    - name: Setup SSH key and known_hosts
+      shell: bash
+      env:
+        DEPLOY_SSH_KEY: ${{ inputs.ssh_key }}
+        DEPLOY_HOST_KEY: ${{ inputs.host_key }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../scripts/web-deploy-common.sh"
+        setup_web_deploy_ssh
+
+    - name: Deploy via rsync over SSH
+      shell: bash
+      env:
+        DEPLOY_PORT: ${{ inputs.port }}
+        DEPLOY_USER: ${{ inputs.user }}
+        DEPLOY_HOST: ${{ inputs.host }}
+        DEPLOY_PATH: ${{ inputs.path }}
+        DEPLOY_SOURCE: ${{ inputs.source }}
+        DEPLOY_REMOTE_SUBPATH: ${{ inputs.remote_subpath }}
+        RSYNC_DELETE: ${{ inputs.rsync_delete }}
+        RSYNC_EXCLUDE: ${{ inputs.rsync_exclude }}
+      run: |
+        set -euo pipefail
+        # shellcheck disable=SC1091
+        source "${GITHUB_ACTION_PATH}/../../scripts/web-deploy-common.sh"
+        web_sftp_rsync
+
+    - name: Cleanup SSH key
+      if: always()
+      shell: bash
+      run: rm -f ~/.ssh/deploy_key

--- a/.github/scripts/assemble-playground.sh
+++ b/.github/scripts/assemble-playground.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Assemble the /playground/ subtree from a downloaded WASM web bundle artifact.
+set -euo pipefail
+
+bundle_dir="${1:?WASM bundle directory required}"
+playground_dir="${2:-playground}"
+fonts_src="${3:-web/docs/fonts/IntelOneMono/IntelOneMono-Regular.woff2}"
+
+mkdir -p "${playground_dir}/vendor" "${playground_dir}/fonts"
+
+cp "${bundle_dir}/pythonscad.js" \
+   "${bundle_dir}/pythonscad.wasm" \
+   "${bundle_dir}/pythonscad.data" \
+   "${bundle_dir}/notebook-geometry.mjs" \
+   "${bundle_dir}/notebook-protocol.mjs" \
+   "${bundle_dir}/notebook-kernel.mjs" \
+   "${bundle_dir}/notebook-worker.mjs" \
+   "${playground_dir}/"
+
+cp "${bundle_dir}/vendor/three.module.min.js" \
+   "${bundle_dir}/vendor/three.core.min.js" \
+   "${playground_dir}/vendor/"
+
+cp "${bundle_dir}/notebook.html" "${playground_dir}/index.html"
+cp "${fonts_src}" "${playground_dir}/fonts/"
+cp wasm-test/playground.htaccess "${playground_dir}/.htaccess"
+
+ls -la "${playground_dir}" "${playground_dir}/vendor" "${playground_dir}/fonts"

--- a/.github/scripts/build-mkdocs-site.sh
+++ b/.github/scripts/build-mkdocs-site.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Build the mkdocs site for production or test deployment targets.
+set -euo pipefail
+
+target="${1:?production or test required}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+config="${repo_root}/web/mkdocs.yml"
+build_config="${config}"
+
+cleanup() {
+  rm -f "${repo_root}/web/.mkdocs-test.build.yml"
+}
+trap cleanup EXIT
+
+case "$target" in
+  production)
+    ;;
+  test)
+    build_config="${repo_root}/web/.mkdocs-test.build.yml"
+    sed -e 's|^site_url:.*|site_url: https://test.pythonscad.org/|' \
+        -e 's|^  test_site: false|  test_site: true|' \
+        "$config" > "$build_config"
+    ;;
+  *)
+    echo "Error: unknown mkdocs deploy target '${target}' (expected production or test)." >&2
+    exit 1
+    ;;
+esac
+
+cd "${repo_root}/web"
+uv run --project .. --no-sync mkdocs build --strict -f "$build_config"
+
+# shellcheck disable=SC1091
+source "${repo_root}/.github/scripts/web-deploy-common.sh"
+validate_website_build "${repo_root}/web/site"

--- a/.github/scripts/build-mkdocs-site.sh
+++ b/.github/scripts/build-mkdocs-site.sh
@@ -17,9 +17,12 @@ case "$target" in
     ;;
   test)
     build_config="${repo_root}/web/.mkdocs-test.build.yml"
-    sed -e 's|^site_url:.*|site_url: https://test.pythonscad.org/|' \
-        -e 's|^  test_site: false|  test_site: true|' \
-        "$config" > "$build_config"
+    cat > "$build_config" <<'EOF'
+INHERIT: mkdocs.yml
+site_url: https://test.pythonscad.org/
+extra:
+  test_site: true
+EOF
     ;;
   *)
     echo "Error: unknown mkdocs deploy target '${target}' (expected production or test)." >&2

--- a/.github/scripts/wasm-playground-deploy-smoke.sh
+++ b/.github/scripts/wasm-playground-deploy-smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Post-deploy HTTP smoke checks for the /playground/ subtree only.
+set -euo pipefail
+
+base_url="${1:?base URL required (e.g. https://test.pythonscad.org/)}"
+
+playground="${base_url%/}/playground/"
+wasm_url="${playground}pythonscad.wasm"
+
+echo "Checking playground landing page ${playground}"
+curl -fsSL "$playground" | grep -q '<html'
+
+echo "Checking WASM MIME type for ${wasm_url}"
+content_type="$(
+  curl -fsSI "$wasm_url" | tr -d '\r' | awk -F': ' 'tolower($1)=="content-type"{print tolower($2); exit}'
+)"
+case "$content_type" in
+  application/wasm*)
+    echo "WASM Content-Type OK: ${content_type}"
+    ;;
+  *)
+    echo "Error: expected application/wasm, got '${content_type:-<missing>}'" >&2
+    exit 1
+    ;;
+esac
+
+echo "Playground smoke check passed."

--- a/.github/scripts/web-deploy-common.sh
+++ b/.github/scripts/web-deploy-common.sh
@@ -1,0 +1,90 @@
+# shellcheck shell=bash
+# Shared helpers for pythonscad.org website and playground SFTP deploys.
+# Sourced by composite actions and workflow steps; not executed directly.
+
+validate_web_deploy_config() {
+  local label="${1:?config label required}"
+  local missing=""
+  local var
+
+  for var in DEPLOY_SSH_KEY DEPLOY_HOST_KEY DEPLOY_HOST DEPLOY_USER DEPLOY_PATH; do
+    if [ -z "${!var:-}" ]; then
+      missing="${missing} ${var}"
+    fi
+  done
+
+  if [ -n "$missing" ]; then
+    {
+      echo "Error: required ${label} deploy configuration is missing:${missing}"
+      echo
+      echo "Populate the matching Settings → Secrets and variables → Actions entries."
+      echo "Optional port variable defaults to 22 when unset."
+    } >&2
+    return 1
+  fi
+}
+
+setup_web_deploy_ssh() {
+  mkdir -p ~/.ssh
+  # `printf` (not `echo`) so backslash escapes / option-looking leading bytes
+  # in the key material are written byte-faithfully.
+  printf '%s' "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+  chmod 600 ~/.ssh/deploy_key
+
+  if [ -z "${DEPLOY_HOST_KEY:-}" ]; then
+    echo "Error: deploy host key pin is unset." >&2
+    return 1
+  fi
+  printf '%s\n' "$DEPLOY_HOST_KEY" >> ~/.ssh/known_hosts
+  chmod 644 ~/.ssh/known_hosts
+}
+
+web_sftp_rsync() {
+  local port="${DEPLOY_PORT:-22}"
+  local remote="${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH%/}"
+  local delete_flag=()
+  local exclude_flag=()
+  local remote_dest
+
+  if [ "${RSYNC_DELETE:-true}" = "true" ]; then
+    delete_flag=(--delete)
+  fi
+  if [ -n "${RSYNC_EXCLUDE:-}" ]; then
+    exclude_flag=(--exclude="${RSYNC_EXCLUDE}")
+  fi
+
+  if [ -n "${DEPLOY_REMOTE_SUBPATH:-}" ]; then
+    remote_dest="${remote}/${DEPLOY_REMOTE_SUBPATH#/}"
+  else
+    remote_dest="${remote}/"
+  fi
+
+  rsync -avz "${delete_flag[@]}" "${exclude_flag[@]}" \
+    -e "ssh -i ~/.ssh/deploy_key -p ${port}" \
+    "${DEPLOY_SOURCE}" \
+    "${remote_dest}"
+}
+
+validate_website_build() {
+  local site_dir="${1:?site directory required}"
+
+  if [ ! -d "$site_dir" ]; then
+    echo "Error: mkdocs output directory ${site_dir} is missing." >&2
+    return 1
+  fi
+  if [ ! -f "${site_dir%/}/index.html" ]; then
+    echo "Error: ${site_dir%/}/index.html is missing." >&2
+    return 1
+  fi
+}
+
+validate_playground_dir() {
+  local playground_dir="${1:?playground directory required}"
+
+  for required in index.html pythonscad.wasm pythonscad.js pythonscad.data; do
+    if [ ! -f "${playground_dir%/}/${required}" ]; then
+      echo "Error: playground artifact ${required} is missing under ${playground_dir}." >&2
+      return 1
+    fi
+  done
+}

--- a/.github/scripts/website-deploy-smoke.sh
+++ b/.github/scripts/website-deploy-smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Post-deploy HTTP smoke checks for the mkdocs website root only.
+# Playground checks live in the WASM workflow because the two deploys are independent.
+set -euo pipefail
+
+base_url="${1:?base URL required (e.g. https://test.pythonscad.org/)}"
+expect_test_banner="${2:-false}"
+
+homepage="${base_url%/}/"
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+echo "Checking homepage ${homepage}"
+curl -fsSL "$homepage" -o "$body"
+grep -q '<html' "$body"
+
+if [ "$expect_test_banner" = "true" ]; then
+  grep -q 'test-site-banner' "$body"
+  grep -q 'tracks' "$body"
+  grep -q 'master' "$body"
+  echo "Test-site banner present."
+else
+  if grep -q 'test-site-banner' "$body"; then
+    echo "Error: production homepage unexpectedly contains the test-site banner." >&2
+    exit 1
+  fi
+  echo "Production homepage has no test-site banner."
+fi
+
+echo "Homepage smoke check passed."

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -13,6 +13,13 @@ on:
         description: 'Release tag to upload artifacts to (leave empty for CI-only build)'
         required: false
         default: ''
+      deploy_target:
+        type: choice
+        description: 'Playground deploy target (production requires explicit choice; default is test)'
+        options:
+          - test
+          - production
+        default: test
       debug_enabled:
         type: boolean
         description: 'Run the build with tmate debugging enabled'
@@ -235,16 +242,68 @@ jobs:
           gh release upload "$RELEASE_TAG" "$WASM_ZIP" \
             -R "$GH_REPO" --clobber
 
-  deploy-playground:
-    name: Deploy WASM playground to website
+  resolve-playground-targets:
+    name: Resolve playground deploy targets
     runs-on: ubuntu-latest
-    needs: build-test
+    outputs:
+      skip: ${{ steps.targets.outputs.skip }}
+      targets: ${{ steps.targets.outputs.targets }}
+    steps:
+      - id: targets
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          INPUT_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy_target || '' }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo 'targets={"target":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          targets=()
+          case "$EVENT" in
+            release)
+              targets+=("production" "test")
+              ;;
+            push)
+              if [ "$REF" = "refs/heads/master" ]; then
+                targets+=("test")
+              fi
+              ;;
+            workflow_dispatch)
+              targets+=("$INPUT_TARGET")
+              ;;
+          esac
+
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo 'targets={"target":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          joined=""
+          for target in "${targets[@]}"; do
+            joined="${joined}\"${target}\","
+          done
+          echo "targets={\"target\":[${joined%,}]}" >> "$GITHUB_OUTPUT"
+
+  deploy-playground:
+    name: Deploy ${{ matrix.target }} playground
+    runs-on: ubuntu-latest
+    needs: [build-test, resolve-playground-targets]
     if: >
-      github.event_name == 'release' ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_to_release != '')
-    # No write-capable GitHub token here. Deployment is over SFTP using the same
-    # pinned-host-key credentials as the website deploy. Never runs on
-    # pull_request, so fork PRs cannot reach the secrets.
+      always() &&
+      needs.resolve-playground-targets.outputs.skip != 'true' &&
+      needs.build-test.result == 'success'
+    concurrency:
+      group: wasm-playground-${{ matrix.target }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve-playground-targets.outputs.targets) }}
     permissions:
       contents: read
 
@@ -254,27 +313,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate deploy configuration
-        env:
-          WEB_SFTP_SSH_KEY: ${{ secrets.WEB_SFTP_SSH_KEY }}
-          WEB_SFTP_HOST_KEY: ${{ vars.WEB_SFTP_HOST_KEY }}
-          WEB_SFTP_HOST: ${{ vars.WEB_SFTP_HOST }}
-          WEB_SFTP_USER: ${{ vars.WEB_SFTP_USER }}
-          WEB_SFTP_PATH: ${{ vars.WEB_SFTP_PATH }}
-        run: |
-          missing=""
-          for var in WEB_SFTP_SSH_KEY WEB_SFTP_HOST_KEY \
-                     WEB_SFTP_HOST WEB_SFTP_USER WEB_SFTP_PATH; do
-            if [ -z "${!var}" ]; then
-              missing="${missing} ${var}"
-            fi
-          done
-          if [ -n "$missing" ]; then
-            echo "Error: required deploy configuration is missing:${missing}" >&2
-            echo "Populate them under Settings -> Secrets and variables -> Actions." >&2
-            exit 1
-          fi
-
       - name: Download WASM web bundle
         uses: actions/download-artifact@v8
         with:
@@ -282,63 +320,33 @@ jobs:
           path: wasm-bundle
 
       - name: Assemble playground directory
+        run: ./.github/scripts/assemble-playground.sh wasm-bundle
+
+      - name: Validate playground artifacts
         run: |
           set -euo pipefail
-          mkdir -p playground/vendor playground/fonts
-          # WASM binaries + runtime from the freshly built web bundle.
-          cp wasm-bundle/pythonscad.js \
-             wasm-bundle/pythonscad.wasm \
-             wasm-bundle/pythonscad.data \
-             wasm-bundle/notebook-geometry.mjs \
-             wasm-bundle/notebook-protocol.mjs \
-             wasm-bundle/notebook-kernel.mjs \
-             wasm-bundle/notebook-worker.mjs \
-             playground/
-          cp wasm-bundle/vendor/three.module.min.js \
-             wasm-bundle/vendor/three.core.min.js \
-             playground/vendor/
-          # The notebook is the playground's landing page.
-          cp wasm-bundle/notebook.html playground/index.html
-          # Site code font (matches the rest of pythonscad.org) + Apache MIME
-          # config so .wasm/.data are served with the right Content-Type.
-          cp web/docs/fonts/IntelOneMono/IntelOneMono-Regular.woff2 playground/fonts/
-          cp wasm-test/playground.htaccess playground/.htaccess
-          ls -la playground playground/vendor playground/fonts
-
-      - name: Setup SSH key and known_hosts for SFTP
-        env:
-          WEB_SFTP_SSH_KEY: ${{ secrets.WEB_SFTP_SSH_KEY }}
-          WEB_SFTP_HOST_KEY: ${{ vars.WEB_SFTP_HOST_KEY }}
-        run: |
-          mkdir -p ~/.ssh
-          printf '%s' "$WEB_SFTP_SSH_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          # Pin the deploy server's host key from the trusted repository
-          # variable instead of TOFU-ing whatever answers at deploy time.
-          if [ -z "$WEB_SFTP_HOST_KEY" ]; then
-            echo "Error: WEB_SFTP_HOST_KEY repository variable is unset." >&2
-            exit 1
-          fi
-          printf '%s\n' "$WEB_SFTP_HOST_KEY" >> ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
+          # shellcheck disable=SC1091
+          source ./.github/scripts/web-deploy-common.sh
+          validate_playground_dir playground
 
       - name: Deploy playground to SFTP server
-        env:
-          WEB_SFTP_PORT: ${{ vars.WEB_SFTP_PORT }}
-          VARS_WEB_SFTP_USER: ${{ vars.WEB_SFTP_USER }}
-          VARS_WEB_SFTP_HOST: ${{ vars.WEB_SFTP_HOST }}
-          VARS_WEB_SFTP_PATH: ${{ vars.WEB_SFTP_PATH }}
-        run: |
-          PORT="${WEB_SFTP_PORT:-22}"
-          # --delete is scoped to the /playground/ subtree only (we sync into
-          # .../playground/), so it cleans stale playground files without
-          # touching the rest of the site. The website deploy in turn excludes
-          # /playground/ from its own --delete.
-          rsync -avz --delete \
-            -e "ssh -i ~/.ssh/deploy_key -p $PORT" \
-            playground/ \
-            "${VARS_WEB_SFTP_USER}@${VARS_WEB_SFTP_HOST}:${VARS_WEB_SFTP_PATH}/playground/"
+        uses: ./.github/actions/web-sftp-deploy
+        with:
+          config_label: ${{ matrix.target == 'production' && 'production playground' || 'test playground' }}
+          ssh_key: ${{ secrets[matrix.target == 'production' && 'WEB_SFTP_SSH_KEY' || 'TEST_WEB_SFTP_SSH_KEY'] }}
+          host_key: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_HOST_KEY' || 'TEST_WEB_SFTP_HOST_KEY'] }}
+          host: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_HOST' || 'TEST_WEB_SFTP_HOST'] }}
+          user: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_USER' || 'TEST_WEB_SFTP_USER'] }}
+          path: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_PATH' || 'TEST_WEB_SFTP_PATH'] }}
+          port: ${{ matrix.target == 'production' && vars.WEB_SFTP_PORT || '' }}
+          source: playground/
+          remote_subpath: playground/
 
-      - name: Cleanup SSH key
-        if: always()
-        run: rm -f ~/.ssh/deploy_key
+      - name: Post-deploy smoke check
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.target }}" = "test" ]; then
+            ./.github/scripts/wasm-playground-deploy-smoke.sh https://test.pythonscad.org/
+          else
+            ./.github/scripts/wasm-playground-deploy-smoke.sh https://www.pythonscad.org/
+          fi

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -3,25 +3,81 @@ name: Deploy Website
 on:
   release:
     types: [created]
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
+      target:
+        type: choice
+        description: 'Deploy target (production requires an explicit choice; default is test)'
+        options:
+          - test
+          - production
+        default: test
       debug_enabled:
         type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
 
-concurrency:
-  group: deploy-website
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
 jobs:
-  deploy-website:
-    name: Build and deploy mkdocs website
+  resolve-targets:
+    name: Resolve deploy targets
     runs-on: ubuntu-24.04
+    outputs:
+      skip: ${{ steps.targets.outputs.skip }}
+      targets: ${{ steps.targets.outputs.targets }}
+    steps:
+      - id: targets
+        env:
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          INPUT_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || '' }}
+        run: |
+          set -euo pipefail
+          targets=()
+          case "$EVENT" in
+            release)
+              targets+=("production" "test")
+              ;;
+            push)
+              if [ "$REF" = "refs/heads/master" ]; then
+                targets+=("test")
+              fi
+              ;;
+            workflow_dispatch)
+              targets+=("$INPUT_TARGET")
+              ;;
+          esac
+
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo 'targets={"target":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          joined=""
+          for target in "${targets[@]}"; do
+            joined="${joined}\"${target}\","
+          done
+          echo "targets={\"target\":[${joined%,}]}" >> "$GITHUB_OUTPUT"
+
+  deploy-website:
+    name: Deploy ${{ matrix.target }} website
+    runs-on: ubuntu-24.04
+    needs: resolve-targets
+    if: needs.resolve-targets.outputs.skip != 'true'
+    concurrency:
+      group: deploy-website-${{ matrix.target }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve-targets.outputs.targets) }}
 
     steps:
       - name: Checkout code
@@ -37,48 +93,6 @@ jobs:
           detached: true
           limit-access-to-actor: true
 
-      - name: Validate deploy configuration
-        # Verify every secret/variable the deploy step needs is
-        # populated before doing the (relatively expensive) mkdocs
-        # build. Without this pre-flight, a missing
-        # `WEB_SFTP_SSH_KEY` would write an empty `deploy_key` and
-        # only fail during `rsync` with a confusing
-        # `Permission denied (publickey)` — well after the site
-        # build has already run. Same logic for the host/user/path
-        # variables: any of them missing would let the workflow
-        # fall through to a broken `rsync URL`. Failing fast here
-        # turns those into a clear "this repo isn't configured for
-        # deploys" message that points the maintainer straight at
-        # the Settings page.
-        env:
-          WEB_SFTP_SSH_KEY: ${{ secrets.WEB_SFTP_SSH_KEY }}
-          WEB_SFTP_HOST_KEY: ${{ vars.WEB_SFTP_HOST_KEY }}
-          WEB_SFTP_HOST: ${{ vars.WEB_SFTP_HOST }}
-          WEB_SFTP_USER: ${{ vars.WEB_SFTP_USER }}
-          WEB_SFTP_PATH: ${{ vars.WEB_SFTP_PATH }}
-        run: |
-          missing=""
-          for var in WEB_SFTP_SSH_KEY WEB_SFTP_HOST_KEY \
-                     WEB_SFTP_HOST WEB_SFTP_USER WEB_SFTP_PATH; do
-            if [ -z "${!var}" ]; then
-              missing="${missing} ${var}"
-            fi
-          done
-          if [ -n "$missing" ]; then
-            {
-              echo "Error: required deploy configuration is missing:${missing}"
-              echo
-              echo "Populate them under Settings → Secrets and variables → Actions:"
-              echo "  - WEB_SFTP_SSH_KEY:  Secret  (private SSH key for the deploy account)"
-              echo "  - WEB_SFTP_HOST_KEY: Variable (output of \`ssh-keyscan -p <PORT> <HOST>\`)"
-              echo "  - WEB_SFTP_HOST:     Variable (deploy server hostname)"
-              echo "  - WEB_SFTP_USER:     Variable (SFTP username)"
-              echo "  - WEB_SFTP_PATH:     Variable (target path on the deploy server)"
-              echo "  - WEB_SFTP_PORT:     Variable (optional; defaults to 22)"
-            } >&2
-            exit 1
-          fi
-
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -92,81 +106,26 @@ jobs:
         run: uv sync --frozen --only-group docs --no-install-project
 
       - name: Build mkdocs site
-        working-directory: web
-        run: uv run --project .. --no-sync mkdocs build --strict
-
-      - name: Setup SSH key and known_hosts for SFTP
-        run: |
-          mkdir -p ~/.ssh
-          # `printf` (not `echo`) so backslash escapes / option-looking
-          # leading bytes in the key material are written byte-faithfully.
-          printf '%s' "$WEB_SFTP_SSH_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-
-          # Pin the deploy server's host key from a trusted source
-          # (the `WEB_SFTP_HOST_KEY` repository variable, populated
-          # out-of-band by a maintainer) instead of discovering it
-          # via `ssh-keyscan` at deploy time. Live discovery would
-          # re-fetch over the network on every run and silently
-          # accept whatever answers, which an active MITM could
-          # exploit to relay our authenticated SSH session to a
-          # host of their choosing — letting them upload arbitrary
-          # content to the public site under our credentials.
-          # With this pin, a host-key change is a hard failure
-          # that requires a maintainer to consciously update the
-          # variable.
-          #
-          # To populate / rotate, run from a trusted network:
-          #   ssh-keyscan -p "$PORT" "$HOST"
-          # (no `-H`, so the hostname stays in plaintext and is
-          # easier to eyeball-verify later) and paste the
-          # multi-line output verbatim into the `WEB_SFTP_HOST_KEY`
-          # variable under Settings → Secrets and variables →
-          # Actions → Variables.
-          #
-          # Fail loudly if the variable is missing rather than
-          # falling through to an empty `known_hosts` — OpenSSH's
-          # `accept-new` default would otherwise silently TOFU the
-          # first key the server presents, which is exactly the
-          # live-discovery behaviour this pin replaces.
-          if [ -z "$WEB_SFTP_HOST_KEY" ]; then
-            echo "Error: WEB_SFTP_HOST_KEY repository variable is unset." >&2
-            echo "Populate it via Settings → Secrets and variables → Actions → Variables." >&2
-            exit 1
-          fi
-          printf '%s\n' "$WEB_SFTP_HOST_KEY" >> ~/.ssh/known_hosts
-          chmod 644 ~/.ssh/known_hosts
-        env:
-          WEB_SFTP_SSH_KEY: ${{ secrets.WEB_SFTP_SSH_KEY }}
-          WEB_SFTP_HOST_KEY: ${{ vars.WEB_SFTP_HOST_KEY }}
+        run: ./.github/scripts/build-mkdocs-site.sh ${{ matrix.target }}
 
       - name: Deploy to SFTP server
+        uses: ./.github/actions/web-sftp-deploy
+        with:
+          config_label: ${{ matrix.target == 'production' && 'production website' || 'test website' }}
+          ssh_key: ${{ secrets[matrix.target == 'production' && 'WEB_SFTP_SSH_KEY' || 'TEST_WEB_SFTP_SSH_KEY'] }}
+          host_key: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_HOST_KEY' || 'TEST_WEB_SFTP_HOST_KEY'] }}
+          host: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_HOST' || 'TEST_WEB_SFTP_HOST'] }}
+          user: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_USER' || 'TEST_WEB_SFTP_USER'] }}
+          path: ${{ vars[matrix.target == 'production' && 'WEB_SFTP_PATH' || 'TEST_WEB_SFTP_PATH'] }}
+          port: ${{ matrix.target == 'production' && vars.WEB_SFTP_PORT || '' }}
+          source: web/site/
+          rsync_exclude: /playground/
+
+      - name: Post-deploy smoke check
         run: |
-          PORT="${WEB_SFTP_PORT:-22}"
-
-          # Don't pass `StrictHostKeyChecking=no` here: the previous
-          # step populated `~/.ssh/known_hosts` with the trusted
-          # host key from the `WEB_SFTP_HOST_KEY` repository
-          # variable, and ssh's default behaviour
-          # (`StrictHostKeyChecking=accept-new`/`yes` depending on
-          # version) honours that pin. Disabling strict checking
-          # would silently accept any key that happens to answer
-          # on the deploy host's address — i.e. defeat the entire
-          # point of pinning.
-          # Protect the WASM Playground subtree: it is deployed separately by
-          # the "Build WebAssembly" workflow (deploy-playground job) and is not
-          # part of the mkdocs `web/site/` output. Without this exclude,
-          # `--delete` would wipe /playground/ on every website deploy.
-          rsync -avz --delete --exclude='/playground/' \
-            -e "ssh -i ~/.ssh/deploy_key -p $PORT" \
-            web/site/ \
-            "${VARS_WEB_SFTP_USER}@${VARS_WEB_SFTP_HOST}:${VARS_WEB_SFTP_PATH}/"
-        env:
-          WEB_SFTP_PORT: ${{ vars.WEB_SFTP_PORT }}
-          VARS_WEB_SFTP_USER: ${{ vars.WEB_SFTP_USER }}
-          VARS_WEB_SFTP_HOST: ${{ vars.WEB_SFTP_HOST }}
-          VARS_WEB_SFTP_PATH: ${{ vars.WEB_SFTP_PATH }}
-
-      - name: Cleanup SSH key
-        if: always()
-        run: rm -f ~/.ssh/deploy_key
+          set -euo pipefail
+          if [ "${{ matrix.target }}" = "test" ]; then
+            ./.github/scripts/website-deploy-smoke.sh https://test.pythonscad.org/ true
+          else
+            ./.github/scripts/website-deploy-smoke.sh https://www.pythonscad.org/ false
+          fi

--- a/web/docs/stylesheets/extra.css
+++ b/web/docs/stylesheets/extra.css
@@ -1,3 +1,19 @@
+.test-site-banner {
+  margin: 0;
+  padding: 0.75em 1.25em;
+  background-color: #ffeb3b;
+  color: #1a1a1a;
+  border-bottom: 2px solid #f9a825;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.test-site-banner code {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: inherit;
+}
+
 .md-grid {
   max-width: initial;
 }

--- a/web/mkdocs.yml
+++ b/web/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: PythonSCAD
 site_url: https://www.pythonscad.org/
+
+extra:
+  test_site: false
 repo_url: https://github.com/pythonscad/pythonscad/
 repo_name: pythonscad/pythonscad
 theme:
@@ -54,7 +57,7 @@ nav:
       - PythonSCAD v0.18.0: releases/PythonSCAD v0.18.0.md
       - PythonSCAD v0.17.0: releases/PythonSCAD v0.17.0.md
       - PythonSCAD v0.16.0: releases/PythonSCAD v0.16.0.md
-  - Playground: https://www.pythonscad.org/playground/
+  - Playground: /playground/
   - Installation: installation.md
   - Development:
       - Release Smoke Tests: development/release-smoke-tests.md

--- a/web/overrides/main.html
+++ b/web/overrides/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  {% if config.extra.test_site %}
+  <div class="test-site-banner" role="note" aria-label="Test site notice">
+    <strong>Test site:</strong>
+    This site tracks <code>master</code>, is useful for source builds,
+    and can differ from the latest official PythonSCAD release.
+  </div>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- deploy MkDocs and WASM outputs to `test.pythonscad.org` on every push to `master`, while keeping production release-only
- keep website and WASM workflows independent while sharing pinned-host SFTP setup and rsync behavior
- build test docs with a canonical test URL and a visible notice that content tracks `master`
- add pre-deploy artifact validation and post-deploy HTTP/MIME smoke checks

## Deployment behavior
- `push` to `master`: test website and test playground
- release creation: production and test website/playground
- manual dispatch: test by default, production only by explicit selection
- pull request: WASM build/test only; no deployment credentials are used

## Test plan
- [x] `actionlint .github/workflows/deploy-website.yml .github/workflows/build-wasm.yml`
- [x] `shellcheck --severity=warning .github/scripts/*.sh`
- [x] repository pre-commit hooks, including MkDocs and Actions validation
- [x] strict production MkDocs build contains no test banner
- [x] strict test MkDocs build contains the banner and test canonical URL
- [ ] manually dispatch the test website deployment and verify the live endpoint
- [ ] manually dispatch the test WASM deployment and verify the playground and WASM MIME type

Made with [Cursor](https://cursor.com)