### PR TITLE
feat(web): clarify playground navigation

### DIFF
--- a/wasm-test/notebook.html
+++ b/wasm-test/notebook.html
@@ -45,6 +45,11 @@
   }
   .logo { font-family: var(--mono); font-size: 15px; color: var(--accent2); font-weight: 500; }
   .logo span { color: var(--accent); }
+  .docs-link {
+    color: var(--text-muted); font-size: 12px; text-decoration: none;
+    border-bottom: 1px solid transparent; white-space: nowrap;
+  }
+  .docs-link:hover, .docs-link:focus-visible { color: var(--text); border-bottom-color: var(--accent); }
   .header-sep { flex: 1; }
   .toolbar { display: flex; gap: 6px; align-items: center; }
   .toolbar button {
@@ -304,6 +309,7 @@
 <header>
   <button class="menu-toggle" id="menu-toggle" aria-label="Toggle sidebar" onclick="toggleSidebar()">☰</button>
   <div class="logo"><span>Python</span>SCAD <span style="color:var(--text-muted);font-weight:400">notebook</span></div>
+  <a class="docs-link" href="/" aria-label="PythonSCAD documentation">Docs</a>
   <div class="header-sep"></div>
   <div class="toolbar">
     <button id="btn-run-all" onclick="runAllCells()" disabled>▶ Run all</button>

--- a/web/docs/index.md
+++ b/web/docs/index.md
@@ -32,7 +32,7 @@ to STL, 3MF, and other formats for 3D printing and manufacturing.
   <div class="hero-download-enhanced" hidden></div>
 </div>
 
-[Try in browser](https://www.pythonscad.org/playground/){ .md-button .md-button--primary }
+[Try in browser ↗](https://www.pythonscad.org/playground/){ .md-button .md-button--primary target="_blank" rel="noopener" aria-label="Try in browser (opens in a new tab)" }
 [Get started](get_started.md){ .md-button }
 [Tutorial](tutorial/getting_started.md){ .md-button }
 [All downloads](downloads.md)


### PR DESCRIPTION
## Summary
- open the homepage “Try in browser” CTA in a new tab with the conventional ↗ indicator and an accessible label
- add a same-origin Docs link to the standalone playground header so visitors can return to the matching production or test documentation
- leave the generated MkDocs navigation item as a normal same-tab link because MkDocs/Material Community has no supported per-item `target` attribute

## Rationale
Embedding the notebook inside Material would introduce nested scrolling, competing headers, instant-navigation exceptions, and limited mobile height. URL injection, custom JavaScript, and theme partial overrides for one nav item would be brittle, so this uses only supported Markdown attributes and normal links.

## Test plan
- [x] strict MkDocs build
- [x] rendered CTA contains `target=\"_blank\"` and `rel=\"noopener\"`
- [x] `node --test wasm-test/notebook-protocol.test.mjs wasm-test/notebook-geometry.test.mjs`
- [x] repository pre-commit hooks for both changed files
- [x] verify the root-relative Docs link returns to the matching site origin

Made with [Cursor](https://cursor.com)