### PR TITLE
feat(python): support hidden MultiToolExporter cutters

### DIFF
--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -362,10 +362,10 @@ class MultiToolExporter(list[_MultiToolExporterItem]):
                     f"MultiToolExporter single-file export only supports .3mf: "
                     f"{single_file!r}"
                 )
-            exportable_parts = self.parts()
-            if not exportable_parts:
+            if not any(self._item_export(item) for item in self):
                 return
             self._check_unique_part_names()
+            exportable_parts = self.parts()
             self._ensure_parent_dir(single_file)
             export_multi = _typing.cast(
                 _typing.Callable[[_typing.Mapping[str, _typing.Any], str], None],

--- a/libraries/python/pythonscad/__init__.py
+++ b/libraries/python/pythonscad/__init__.py
@@ -65,14 +65,22 @@ def _normalize_filename_key(filename: str) -> str:
     return key
 
 
-class MultiToolExporter(list[tuple[str, _typing.Any]]):
+_MultiToolExporterItem = _typing.Union[
+    tuple[str, _typing.Any],
+    tuple[str, _typing.Any, bool],
+]
+
+
+class MultiToolExporter(list[_MultiToolExporterItem]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
-    Each item in the list is a ``(name, object)`` tuple, where ``name`` is a
-    label used to build the output filename and ``object`` is a PythonSCAD
-    geometry. The exporter is designed for workflows where a single model is
-    split into several parts (for example, one part per filament color on a
-    multi-tool 3D printer).
+    Each item in the list is a ``(name, object)`` or ``(name, object, export)``
+    tuple, where ``name`` is a label used to build the output filename,
+    ``object`` is a PythonSCAD geometry, and ``export`` is an optional
+    ``bool`` (default ``True``) controlling whether the item is written to
+    disk or shown in the preview. Items with ``export=False`` are *cutters*:
+    they still participate in cumulative subtraction for every earlier item,
+    but are omitted from :meth:`parts`, :meth:`show`, and all export paths.
 
     Item order matches :func:`dict.items` and the multi-object form of
     :func:`export` (``export({"part1": obj1, "part2": obj2}, "out.3mf")``),
@@ -84,11 +92,13 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
     ---------
     For each index ``i`` in the list, the exporter produces the geometry
     obtained by taking ``self[i]``'s object and subtracting every later
-    item's object from it. Overlapping regions are therefore assigned to
-    exactly one part: **later entries "win" over earlier ones**, so each
-    part only keeps the volume not claimed by any subsequent part. The
-    last entry is emitted as-is (no degenerate one-child ``difference``
-    node) and therefore "wins" everything that overlaps with it.
+    item's object from it — including later items with ``export=False``.
+    Cutters therefore affect only earlier list entries; ordering semantics
+    are unchanged. Overlapping regions are assigned to exactly one exported
+    part: **later entries "win" over earlier ones**, so each part only keeps
+    the volume not claimed by any subsequent item. The last list entry is
+    emitted as-is (no degenerate one-child ``difference`` node) when it is
+    exportable and therefore "wins" everything that overlaps with it.
 
     Attributes:
         prefix: String prepended to each output filename. Typically a path
@@ -104,19 +114,21 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
     ----------
     Items are validated on insertion (constructor argument, :meth:`append`,
     :meth:`extend`, :meth:`insert`, ``self[i] = ...``). A :class:`TypeError`
-    is raised if the item is not a 2-tuple of ``(str, object)``, and a
-    :class:`ValueError` is raised if the name is empty.
+    is raised if the item is not a 2- or 3-tuple of ``(str, object)`` or
+    ``(str, object, bool)``, and a :class:`ValueError` is raised if the name
+    is empty. The optional third element must be an actual :class:`bool`
+    (``0``/``1`` and other truthy values are rejected).
 
-    Output paths must be unique per item: at :meth:`export` time, every
-    item's full ``f"{prefix}{name}{suffix}"`` filename is normalised with
-    :func:`os.path.normcase` and :func:`os.path.normpath` (plus
-    :meth:`str.casefold` on macOS) and any collision raises
-    :class:`ValueError`. This rejects raw duplicate names on every
-    platform, plus path aliases such as ``"a/../b"`` vs ``"b"``, plus
-    case-only collisions (``"a.stl"`` vs ``"A.stl"``) on Windows and
-    macOS where the destination filesystem is typically case-insensitive.
-    On Linux such pairs are accepted because the kernel treats them as
-    distinct files.
+    Output paths must be unique among *exportable* items: at :meth:`export`
+    time, every exportable item's full ``f"{prefix}{name}{suffix}"`` filename
+    is normalised with :func:`os.path.normcase` and :func:`os.path.normpath`
+    (plus :meth:`str.casefold` on macOS) and any collision raises
+    :class:`ValueError`. Hidden (``export=False``) duplicate names are
+    allowed. This rejects raw duplicate exportable names on every platform,
+    plus path aliases such as ``"a/../b"`` vs ``"b"``, plus case-only
+    collisions (``"a.stl"`` vs ``"A.stl"``) on Windows and macOS where the
+    destination filesystem is typically case-insensitive. On Linux such
+    pairs are accepted because the kernel treats them as distinct files.
 
     Example:
         >>> # Append base/background parts first; later entries "win" overlap.
@@ -132,7 +144,7 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         prefix: str,
         suffix: str,
         mkdir: bool = False,
-        items: _typing.Iterable[tuple[str, _typing.Any]] = (),
+        items: _typing.Iterable[_MultiToolExporterItem] = (),
     ):
         """Initialize a (possibly empty) MultiToolExporter.
 
@@ -142,13 +154,12 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
                 extension.
             mkdir: If ``True``, create the output directory for each file
                 before exporting. Defaults to ``False``.
-            items: Optional iterable of initial ``(name, object)`` tuples
-                (e.g. ``a_dict.items()``). Each item is validated as if it
-                were appended.
+            items: Optional iterable of initial ``(name, object)`` or
+                ``(name, object, export)`` tuples (e.g. ``a_dict.items()``).
+                Each item is validated as if it were appended.
 
         Raises:
-            TypeError: If any item in ``items`` is not a 2-tuple of
-                ``(str, object)``.
+            TypeError: If any item in ``items`` is not a valid 2- or 3-tuple.
             ValueError: If any name in ``items`` is empty.
         """
         super().__init__()
@@ -159,20 +170,26 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
             self.append(item)
 
     @staticmethod
-    def _validate_item(item: _typing.Any) -> tuple[str, _typing.Any]:
-        """Return ``item`` if it is a valid ``(str, object)`` 2-tuple.
+    def _validate_item(item: _typing.Any) -> _MultiToolExporterItem:
+        """Return ``item`` if it is a valid exporter entry tuple.
+
+        Accepts ``(name, object)`` 2-tuples and ``(name, object, export)``
+        3-tuples. The input shape is preserved (2-tuples are not normalised
+        to 3-tuples).
 
         Raises:
-            TypeError: If ``item`` is not a 2-tuple whose first element is
-                a string. Lists and other sequences are rejected.
+            TypeError: If ``item`` is not a 2- or 3-tuple whose first
+                element is a string and whose optional third element is a
+                :class:`bool`. Lists and other sequences are rejected.
             ValueError: If the name is empty.
         """
-        if not isinstance(item, tuple) or len(item) != 2:
+        if not isinstance(item, tuple) or len(item) not in (2, 3):
             raise TypeError(
-                f"MultiToolExporter items must be (name, object) 2-tuples, "
-                f"got {type(item).__name__}: {item!r}"
+                f"MultiToolExporter items must be (name, object) or "
+                f"(name, object, export) tuples, got {type(item).__name__}: "
+                f"{item!r}"
             )
-        name, _ = item
+        name = item[0]
         if not isinstance(name, str):
             raise TypeError(
                 f"MultiToolExporter item name must be a str, "
@@ -180,14 +197,24 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
             )
         if not name:
             raise ValueError("MultiToolExporter item name must be a non-empty string")
+        if len(item) == 3 and type(item[2]) is not bool:
+            raise TypeError(
+                f"MultiToolExporter item export flag must be a bool, "
+                f"got {type(item[2]).__name__}: {item[2]!r}"
+            )
         return item
 
-    def append(self, item: tuple[str, _typing.Any]) -> None:
-        """Append a validated ``(name, object)`` tuple."""
+    @staticmethod
+    def _item_export(item: _MultiToolExporterItem) -> bool:
+        """Return whether ``item`` should appear in export/preview output."""
+        return True if len(item) == 2 else item[2]
+
+    def append(self, item: _MultiToolExporterItem) -> None:
+        """Append a validated ``(name, object)`` or ``(name, object, export)`` tuple."""
         super().append(self._validate_item(item))
 
-    def extend(self, items: _typing.Iterable[tuple[str, _typing.Any]]) -> None:
-        """Append each ``(name, object)`` tuple from ``items``.
+    def extend(self, items: _typing.Iterable[_MultiToolExporterItem]) -> None:
+        """Append each validated item tuple from ``items``.
 
         Atomic: every item is validated *before* anything is appended, so a
         bad item in the middle of the iterable leaves the exporter unchanged.
@@ -196,13 +223,13 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         super().extend(validated)
 
     def insert(
-        self, index: _typing.SupportsIndex, item: tuple[str, _typing.Any]
+        self, index: _typing.SupportsIndex, item: _MultiToolExporterItem
     ) -> None:
-        """Insert a validated ``(name, object)`` tuple at ``index``."""
+        """Insert a validated item tuple at ``index``."""
         super().insert(index, self._validate_item(item))
 
     def __setitem__(self, index, value):
-        """Replace one or more items, validating each new ``(name, object)``."""
+        """Replace one or more items, validating each new entry tuple."""
         if isinstance(index, slice):
             super().__setitem__(index, [self._validate_item(v) for v in value])
         else:
@@ -234,12 +261,13 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
             _os.makedirs(directory, exist_ok=True)
 
     def _part(self, i: int):
-        """Return the geometry for part ``i``: ``self[i]``'s object minus all later parts.
+        """Return the geometry for part ``i``: ``self[i]``'s object minus all later items.
 
-        For the last entry, the object is returned as-is rather than wrapped
-        in a one-child ``difference`` node.
+        Every later list entry participates, including ``export=False`` cutters.
+        For the last list entry, the object is returned as-is rather than
+        wrapped in a one-child ``difference`` node.
         """
-        rest = [obj for _name, obj in self[i:]]
+        rest = [item[1] for item in self[i:]]
         return rest[0] if len(rest) == 1 else difference(*rest)  # noqa: F405
 
     def _check_unique_filenames(self) -> None:
@@ -256,6 +284,8 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         """
         seen: dict[str, tuple[str, str]] = {}
         for i in range(len(self)):
+            if not self._item_export(self[i]):
+                continue
             name = self[i][0]
             filename = self._filename(i)
             key = _normalize_filename_key(filename)
@@ -271,7 +301,10 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
     def _check_unique_part_names(self) -> None:
         """Raise :class:`ValueError` if part names would collide in a dict export."""
         seen: set[str] = set()
-        for name, _geometry in self:
+        for item in self:
+            if not self._item_export(item):
+                continue
+            name = item[0]
             if name in seen:
                 raise ValueError(
                     f"MultiToolExporter items must have unique names for "
@@ -285,8 +318,9 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         Each geometry is the cumulative-difference result identical to
         what :meth:`export` would write or :meth:`show` would preview:
         for index ``i``, ``self[i]``'s object minus every later item's
-        object, with the last entry returned as-is (no degenerate
-        one-child ``difference`` node).
+        object (including ``export=False`` cutters), with the last list
+        entry returned as-is (no degenerate one-child ``difference``
+        node). Items with ``export=False`` are omitted from the result.
 
         This is the programmatic accessor used internally by
         :meth:`export` and :meth:`show`. It is also the natural input
@@ -294,9 +328,14 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         (``export(dict(exporter.parts()), "out.3mf")``).
 
         Returns:
-            A new list of ``(name, computed_geometry)`` tuples.
+            A new list of ``(name, computed_geometry)`` tuples for
+            exportable items only.
         """
-        return [(self[i][0], self._part(i)) for i in range(len(self))]
+        return [
+            (self[i][0], self._part(i))
+            for i in range(len(self))
+            if self._item_export(self[i])
+        ]
 
     def export(self, single_file: _typing.Optional[str] = None) -> None:
         """Export parts to per-part files or a single multi-object 3MF.
@@ -323,7 +362,8 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
                     f"MultiToolExporter single-file export only supports .3mf: "
                     f"{single_file!r}"
                 )
-            if not self:
+            exportable_parts = self.parts()
+            if not exportable_parts:
                 return
             self._check_unique_part_names()
             self._ensure_parent_dir(single_file)
@@ -331,7 +371,7 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
                 _typing.Callable[[_typing.Mapping[str, _typing.Any], str], None],
                 globals()["export"],
             )
-            export_multi(dict(self.parts()), single_file)
+            export_multi(dict(exportable_parts), single_file)
             return
 
         self._check_unique_filenames()

--- a/libraries/python/stubs/pythonscad-stubs/__init__.pyi
+++ b/libraries/python/stubs/pythonscad-stubs/__init__.pyi
@@ -60,18 +60,24 @@ class Matrix4x4(_np.ndarray[_typing.Any, _np.dtype[_np.float64]]):
     @classmethod
     def from_array(cls, array: _typing.Any) -> "Matrix4x4": ...
 
-class MultiToolExporter(list[tuple[str, _typing.Any]]):
+_MultiToolExporterItem = tuple[str, _typing.Any] | tuple[str, _typing.Any, bool]
+
+
+class MultiToolExporter(list[_MultiToolExporterItem]):
     """List-based helper for exporting multi-tool / multi-color 3D models.
 
-    Each item is a ``(name, object)`` 2-tuple (matching :func:`dict.items`
-    and the multi-object form of :func:`export`). For each index ``i``,
-    :meth:`export` writes the geometry obtained by subtracting every later
-    item's object from ``self[i]``'s object into either per-part files
-    named ``f"{prefix}{name}{suffix}"`` or one multi-object 3MF file when
-    ``single_file`` is provided. The last entry is emitted as-is (no
-    degenerate one-child ``difference`` node). Output paths and
-    single-file part names must be unique; collisions raise
-    :class:`ValueError` at export time.
+    Each item is a ``(name, object)`` 2-tuple or ``(name, object, export)``
+    3-tuple (matching :func:`dict.items` and the multi-object form of
+    :func:`export`). The optional ``export`` flag defaults to ``True``;
+    ``export=False`` entries are *cutters* that still subtract from earlier
+    items but are omitted from :meth:`parts`, :meth:`show`, and all export
+    paths. For each index ``i``, :meth:`export` writes the geometry obtained
+    by subtracting every later item's object from ``self[i]``'s object into
+    either per-part files named ``f"{prefix}{name}{suffix}"`` or one
+    multi-object 3MF file when ``single_file`` is provided. The last list
+    entry is emitted as-is (no degenerate one-child ``difference`` node).
+    Output paths and single-file part names must be unique among exportable
+    items; collisions raise :class:`ValueError` at export time.
     """
 
     prefix: str
@@ -88,34 +94,34 @@ class MultiToolExporter(list[tuple[str, _typing.Any]]):
         prefix: str,
         suffix: str,
         mkdir: bool = ...,
-        items: _typing.Iterable[tuple[str, _typing.Any]] = ...,
+        items: _typing.Iterable[_MultiToolExporterItem] = ...,
     ) -> None:
         """Initialize the exporter, optionally seeding it with ``items``."""
         ...
 
-    def append(self, item: tuple[str, _typing.Any]) -> None:
-        """Append a validated ``(name, object)`` tuple."""
+    def append(self, item: _MultiToolExporterItem) -> None:
+        """Append a validated ``(name, object)`` or ``(name, object, export)`` tuple."""
         ...
 
-    def extend(self, items: _typing.Iterable[tuple[str, _typing.Any]]) -> None:
-        """Append each validated ``(name, object)`` tuple from ``items``."""
+    def extend(self, items: _typing.Iterable[_MultiToolExporterItem]) -> None:
+        """Append each validated item tuple from ``items``."""
         ...
 
     def insert(
-        self, index: _typing.SupportsIndex, item: tuple[str, _typing.Any]
+        self, index: _typing.SupportsIndex, item: _MultiToolExporterItem
     ) -> None:
-        """Insert a validated ``(name, object)`` tuple at ``index``."""
+        """Insert a validated item tuple at ``index``."""
         ...
 
     def __iadd__(  # type: ignore[override]
         self,
-        other: _typing.Iterable[tuple[str, _typing.Any]],
+        other: _typing.Iterable[_MultiToolExporterItem],
     ) -> "MultiToolExporter":
         """Validate each item then in-place extend (``self += other``)."""
         ...
 
     def parts(self) -> list[tuple[str, _typing.Any]]:
-        """Return computed ``(name, geometry)`` pairs in declaration order."""
+        """Return computed ``(name, geometry)`` pairs for exportable items."""
         ...
 
     def export(self, single_file: str | None = ...) -> None:

--- a/tests/data/pythonscad-echo/multitool-hidden-cutters.py
+++ b/tests/data/pythonscad-echo/multitool-hidden-cutters.py
@@ -56,9 +56,11 @@ hidden_dup = MultiToolExporter("p-", ".stl", items=[
 hidden_dup._check_unique_filenames()
 hidden_dup._check_unique_part_names()
 print("hidden duplicate names export: ok")
+duplicate = MultiToolExporter("p-", ".stl", items=[("a", red), ("a", blue)])
+duplicate._part = lambda _i: (_ for _ in ()).throw(RuntimeError("geometry built"))
 expect(
     "exportable duplicate names",
-    MultiToolExporter("p-", ".stl", items=[("a", red), ("a", blue)]).export,
+    lambda: duplicate.export(single_file="duplicate.3mf"),
     ValueError,
 )
 

--- a/tests/data/pythonscad-echo/multitool-hidden-cutters.py
+++ b/tests/data/pythonscad-echo/multitool-hidden-cutters.py
@@ -1,0 +1,100 @@
+"""Echo test for ``MultiToolExporter`` hidden cutters (``export=False``).
+
+Exercises:
+  * mixed 2- and 3-tuples preserving stored shape
+  * strict ``bool`` validation for the export flag
+  * ``parts()`` / ``show()`` omitting hidden entries
+  * cumulative subtraction including hidden cutters
+  * hidden duplicate names allowed; exportable duplicates still rejected
+  * all-hidden ``export(single_file=...)`` no-op
+"""
+
+import pythonscad
+from pythonscad import MultiToolExporter, cube
+
+red = cube(10)
+blue = cube(10).right(5)
+green = cube(10).right(10)
+cutter = cube(4).right(2)
+
+exp = MultiToolExporter("p-", ".stl", items=[
+    ("red", red),
+    ("blue", blue),
+    ("slot", cutter, False),
+])
+print("stored shapes:", [len(item) for item in exp])
+print("parts len:", len(exp.parts()))
+print("parts names:", [name for name, _g in exp.parts()])
+print("part0 uses hidden cutter:", exp._part(0) is not exp[0][1])
+print("part1 uses hidden cutter:", exp._part(1) is not exp[1][1])
+print("part2 is bare object:", exp._part(2) is exp[2][1])
+
+def expect(label, fn, exc):
+    try:
+        fn()
+    except exc as e:
+        print(f"{label}: {type(e).__name__}")
+    else:
+        print(f"{label}: NO EXCEPTION (expected {exc.__name__})")
+
+expect("append export int", lambda: exp.append(("x", red, 1)), TypeError)
+expect("append export zero", lambda: exp.append(("x", red, 0)), TypeError)
+expect("append export str", lambda: exp.append(("x", red, "y")), TypeError)
+try:
+    exp.append(("hidden", green, False))
+    print("append export false ok: appended")
+    exp.pop()
+except Exception as e:
+    print(f"append export false ok: {type(e).__name__}")
+
+hidden_dup = MultiToolExporter("p-", ".stl", items=[
+    ("a", red),
+    ("a", cutter, False),
+    ("b", blue),
+    ("a", green, False),
+])
+hidden_dup._check_unique_filenames()
+hidden_dup._check_unique_part_names()
+print("hidden duplicate names export: ok")
+expect(
+    "exportable duplicate names",
+    MultiToolExporter("p-", ".stl", items=[("a", red), ("a", blue)]).export,
+    ValueError,
+)
+
+all_hidden = MultiToolExporter("p-", ".stl", items=[
+    ("only", red, False),
+    ("also", blue, False),
+])
+print("all-hidden parts len:", len(all_hidden.parts()))
+all_hidden.export(single_file="empty.3mf")
+print("all-hidden single-file no-op: ok")
+
+show_calls = []
+real_show = pythonscad.show
+pythonscad.show = lambda obj: show_calls.append(obj is not None)
+try:
+    exp.show()
+finally:
+    pythonscad.show = real_show
+print("show call count:", len(show_calls))
+
+export_calls = []
+real_export = pythonscad.export
+def recording_export(obj, filename):
+    if isinstance(obj, dict):
+        export_calls.append((list(obj.keys()), filename))
+    else:
+        export_calls.append((obj is not None, filename))
+pythonscad.export = recording_export
+try:
+    exp.export()
+    exp.export(single_file="assembly.3mf")
+finally:
+    pythonscad.export = real_export
+
+for obj_info, filename in export_calls:
+    if filename == "assembly.3mf":
+        print("single-file keys:", obj_info)
+    elif filename.startswith("p-"):
+        print("per-file export:", obj_info, filename)

--- a/tests/data/pythonscad-export-3mf/multitool-hidden-single-file.py
+++ b/tests/data/pythonscad-export-3mf/multitool-hidden-single-file.py
@@ -1,0 +1,16 @@
+"""Regression fixture for hidden cutters in ``export(single_file=...)``.
+
+The final hidden entry subtracts from earlier parts but must not appear as a
+named object in the output 3MF.
+"""
+from pythonscad import MultiToolExporter, cube
+
+red_part = cube([6, 6, 4]).color("red")
+slot = cube([4, 4, 4]).translate([1, 1, 0])
+blue_part = cube([6, 6, 4]).translate([8, 0, 0]).color("blue")
+
+MultiToolExporter("", ".stl", items=[
+    ("red", red_part),
+    ("blue", blue_part),
+    ("slot", slot, False),
+]).export(single_file="multitool-hidden.3mf")

--- a/tests/data/pythonscad-multitool-export/hidden-cutter-flag.py
+++ b/tests/data/pythonscad-multitool-export/hidden-cutter-flag.py
@@ -1,0 +1,16 @@
+"""MultiToolExporter regression fixture: hidden cutter between two colors.
+
+A final hidden ``export=False`` cutter subtracts from both printable colors but
+produces no output file, so only ``blue.stl`` and ``red.stl`` are written.
+"""
+from pythonscad import MultiToolExporter, cube
+
+background = cube([20, 20, 4])
+slot = cube([2, 20, 4]).translate([9, 0, 0])
+star = cube([8, 8, 4]).translate([6, 6, 0])
+
+MultiToolExporter("", ".stl", items=[
+    ("blue", background),
+    ("red", star),
+    ("slot", slot, False),
+]).export()

--- a/tests/regression/multitool-export/hidden-cutter-flag/blue.stl
+++ b/tests/regression/multitool-export/hidden-cutter-flag/blue.stl
@@ -1,0 +1,394 @@
+solid OpenSCAD_Model
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 4
+      vertex 0 20 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 0
+      vertex 6 14 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 20 4
+      vertex 0 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 6 6 0
+      vertex 9 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 6 14 0
+      vertex 6 6 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 9 0 0
+      vertex 9 0 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 9 0 4
+      vertex 0 0 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 4
+      vertex 6 6 4
+      vertex 0 20 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 4
+      vertex 9 0 4
+      vertex 6 6 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 0
+      vertex 0 20 4
+      vertex 9 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 20 0
+      vertex 9 20 0
+      vertex 6 14 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 4
+      vertex 6 6 4
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 20 4
+      vertex 6 14 4
+      vertex 9 20 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 20 4
+      vertex 9 20 4
+      vertex 9 20 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 6 4
+      vertex 9 6 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 0
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 4
+      vertex 6 6 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 6 0
+      vertex 9 6 0
+      vertex 9 0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 6 4
+      vertex 9 0 4
+      vertex 9 6 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 6 4
+      vertex 9 6 4
+      vertex 9 6 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 14 0
+      vertex 9 14 0
+      vertex 9 14 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 14 0
+      vertex 9 14 4
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 14 0
+      vertex 9 20 0
+      vertex 9 14 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 14 4
+      vertex 9 14 4
+      vertex 9 20 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 9 0 0
+      vertex 9 6 0
+      vertex 9 0 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 9 0 4
+      vertex 9 6 0
+      vertex 9 6 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 9 14 0
+      vertex 9 20 0
+      vertex 9 14 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 9 14 4
+      vertex 9 20 0
+      vertex 9 20 4
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 11 0 0
+      vertex 11 0 4
+      vertex 11 6 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11 0 0
+      vertex 11 6 0
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 11 0 0
+      vertex 11 6 4
+      vertex 11 6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11 0 0
+      vertex 14 6 0
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11 0 0
+      vertex 20 0 0
+      vertex 20 0 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11 0 0
+      vertex 20 0 4
+      vertex 11 0 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11 0 4
+      vertex 14 6 4
+      vertex 11 6 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11 0 4
+      vertex 20 0 4
+      vertex 14 6 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11 6 0
+      vertex 11 6 4
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11 6 4
+      vertex 14 6 4
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 11 14 0
+      vertex 11 14 4
+      vertex 11 20 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11 14 0
+      vertex 11 20 0
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 11 14 0
+      vertex 11 20 4
+      vertex 11 20 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11 14 0
+      vertex 14 14 0
+      vertex 14 14 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11 14 0
+      vertex 14 14 4
+      vertex 11 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11 14 4
+      vertex 14 14 4
+      vertex 11 20 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11 20 0
+      vertex 11 20 4
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11 20 0
+      vertex 20 20 0
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11 20 4
+      vertex 14 14 4
+      vertex 20 20 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11 20 4
+      vertex 20 20 4
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 14 6 0
+      vertex 14 6 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14 6 0
+      vertex 14 14 0
+      vertex 20 20 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14 6 0
+      vertex 20 20 0
+      vertex 20 0 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 14 6 4
+      vertex 14 14 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14 6 4
+      vertex 20 0 4
+      vertex 14 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14 14 4
+      vertex 20 0 4
+      vertex 20 20 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 0
+      vertex 20 20 0
+      vertex 20 0 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 20 0 4
+      vertex 20 20 0
+      vertex 20 20 4
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/tests/regression/multitool-export/hidden-cutter-flag/red.stl
+++ b/tests/regression/multitool-export/hidden-cutter-flag/red.stl
@@ -1,0 +1,170 @@
+solid OpenSCAD_Model
+  facet normal -1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 6 4
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 0
+      vertex 9 6 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 6 6 0
+      vertex 6 14 4
+      vertex 6 14 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 6 0
+      vertex 9 6 0
+      vertex 9 6 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 6 6 0
+      vertex 9 6 4
+      vertex 6 6 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 6 4
+      vertex 9 6 4
+      vertex 9 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6 6 4
+      vertex 9 14 4
+      vertex 6 14 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 14 0
+      vertex 6 14 4
+      vertex 9 14 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6 14 0
+      vertex 9 14 0
+      vertex 9 6 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6 14 4
+      vertex 9 14 4
+      vertex 9 14 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 9 6 0
+      vertex 9 14 0
+      vertex 9 6 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 9 6 4
+      vertex 9 14 0
+      vertex 9 14 4
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 11 6 0
+      vertex 11 6 4
+      vertex 11 14 4
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11 6 0
+      vertex 11 14 0
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 11 6 0
+      vertex 11 14 4
+      vertex 11 14 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11 6 0
+      vertex 14 6 0
+      vertex 14 6 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11 6 0
+      vertex 14 6 4
+      vertex 11 6 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11 6 4
+      vertex 14 6 4
+      vertex 14 14 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11 6 4
+      vertex 14 14 4
+      vertex 11 14 4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11 14 0
+      vertex 11 14 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11 14 0
+      vertex 14 14 0
+      vertex 14 6 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11 14 4
+      vertex 14 14 4
+      vertex 14 14 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 14 6 0
+      vertex 14 14 0
+      vertex 14 6 4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 14 6 4
+      vertex 14 14 0
+      vertex 14 14 4
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/tests/regression/pythonscad-export-3mf/multitool-hidden-single-file/multitool-hidden.3mf
+++ b/tests/regression/pythonscad-export-3mf/multitool-hidden-single-file/multitool-hidden.3mf
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" unit="millimeter" xml:lang="en-US" xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02" xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06" xmlns:b="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" xmlns:s="http://schemas.microsoft.com/3dmanufacturing/slice/2015/07">
+	<metadata name="Title">multitool-hidden.3mf</metadata>
+	<metadata name="Application">OpenSCAD (https://www.openscad.org/)</metadata>
+	<metadata name="CreationDate">XXXX-XX-XXTXXXXXXXXZ</metadata>
+	<resources>
+		<basematerials id="1">
+			<base name="Default" displaycolor="#F9D72CFF" />
+			<base name="Color 1" displaycolor="#FF0000FF" />
+			<base name="Color 2" displaycolor="#9DCB51FF" />
+			<base name="Color 3" displaycolor="#0000FFFF" />
+		</basematerials>
+		<object id="2" name="red" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" pid="1" pindex="0">
+			<mesh>
+				<vertices>
+					<vertex x="0" y="0" z="0" />
+					<vertex x="0" y="0" z="4.000000" />
+					<vertex x="0" y="6.000000" z="0" />
+					<vertex x="0" y="6.000000" z="4.000000" />
+					<vertex x="1.000000" y="1.000000" z="0" />
+					<vertex x="1.000000" y="1.000000" z="4.000000" />
+					<vertex x="1.000000" y="5.000000" z="0" />
+					<vertex x="1.000000" y="5.000000" z="4.000000" />
+					<vertex x="5.000000" y="1.000000" z="0" />
+					<vertex x="5.000000" y="1.000000" z="4.000000" />
+					<vertex x="5.000000" y="5.000000" z="0" />
+					<vertex x="5.000000" y="5.000000" z="4.000000" />
+					<vertex x="6.000000" y="0" z="0" />
+					<vertex x="6.000000" y="0" z="4.000000" />
+					<vertex x="6.000000" y="6.000000" z="0" />
+					<vertex x="6.000000" y="6.000000" z="4.000000" />
+				</vertices>
+				<triangles>
+					<triangle v1="0" v2="1" v3="3" pid="1" p1="1" />
+					<triangle v1="0" v2="2" v3="4" pid="1" p1="1" />
+					<triangle v1="0" v2="3" v3="2" pid="1" p1="1" />
+					<triangle v1="0" v2="4" v3="12" pid="1" p1="1" />
+					<triangle v1="0" v2="12" v3="13" pid="1" p1="1" />
+					<triangle v1="0" v2="13" v3="1" pid="1" p1="1" />
+					<triangle v1="1" v2="5" v3="7" pid="1" p1="1" />
+					<triangle v1="1" v2="7" v3="3" pid="1" p1="1" />
+					<triangle v1="1" v2="9" v3="5" pid="1" p1="1" />
+					<triangle v1="1" v2="13" v3="9" pid="1" p1="1" />
+					<triangle v1="2" v2="3" v3="14" pid="1" p1="1" />
+					<triangle v1="2" v2="6" v3="4" pid="1" p1="1" />
+					<triangle v1="2" v2="10" v3="6" pid="1" p1="1" />
+					<triangle v1="2" v2="14" v3="10" pid="1" p1="1" />
+					<triangle v1="3" v2="7" v3="15" pid="1" p1="1" />
+					<triangle v1="3" v2="15" v3="14" pid="1" p1="1" />
+					<triangle v1="4" v2="5" v3="9" pid="1" p1="2" />
+					<triangle v1="4" v2="6" v3="7" pid="1" p1="2" />
+					<triangle v1="4" v2="7" v3="5" pid="1" p1="2" />
+					<triangle v1="4" v2="8" v3="12" pid="1" p1="1" />
+					<triangle v1="4" v2="9" v3="8" pid="1" p1="2" />
+					<triangle v1="6" v2="10" v3="7" pid="1" p1="2" />
+					<triangle v1="7" v2="10" v3="11" pid="1" p1="2" />
+					<triangle v1="7" v2="11" v3="15" pid="1" p1="1" />
+					<triangle v1="8" v2="9" v3="10" pid="1" p1="2" />
+					<triangle v1="8" v2="10" v3="12" pid="1" p1="1" />
+					<triangle v1="9" v2="11" v3="10" pid="1" p1="2" />
+					<triangle v1="9" v2="13" v3="15" pid="1" p1="1" />
+					<triangle v1="9" v2="15" v3="11" pid="1" p1="1" />
+					<triangle v1="10" v2="14" v3="12" pid="1" p1="1" />
+					<triangle v1="12" v2="14" v3="13" pid="1" p1="1" />
+					<triangle v1="13" v2="14" v3="15" pid="1" p1="1" />
+				</triangles>
+			</mesh>
+		</object>
+		<object id="3" name="blue" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" pid="1" pindex="0">
+			<mesh>
+				<vertices>
+					<vertex x="8.000000" y="0" z="0" />
+					<vertex x="8.000000" y="0" z="4.000000" />
+					<vertex x="8.000000" y="6.000000" z="0" />
+					<vertex x="8.000000" y="6.000000" z="4.000000" />
+					<vertex x="14.000000" y="0" z="0" />
+					<vertex x="14.000000" y="0" z="4.000000" />
+					<vertex x="14.000000" y="6.000000" z="0" />
+					<vertex x="14.000000" y="6.000000" z="4.000000" />
+				</vertices>
+				<triangles>
+					<triangle v1="0" v2="1" v3="3" pid="1" p1="3" />
+					<triangle v1="0" v2="2" v3="6" pid="1" p1="3" />
+					<triangle v1="0" v2="3" v3="2" pid="1" p1="3" />
+					<triangle v1="0" v2="4" v3="5" pid="1" p1="3" />
+					<triangle v1="0" v2="5" v3="1" pid="1" p1="3" />
+					<triangle v1="0" v2="6" v3="4" pid="1" p1="3" />
+					<triangle v1="1" v2="5" v3="3" pid="1" p1="3" />
+					<triangle v1="2" v2="3" v3="6" pid="1" p1="3" />
+					<triangle v1="3" v2="5" v3="7" pid="1" p1="3" />
+					<triangle v1="3" v2="7" v3="6" pid="1" p1="3" />
+					<triangle v1="4" v2="6" v3="5" pid="1" p1="3" />
+					<triangle v1="5" v2="6" v3="7" pid="1" p1="3" />
+				</triangles>
+			</mesh>
+		</object>
+	</resources>
+	<build p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX">
+		<item objectid="2" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" />
+		<item objectid="3" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" />
+	</build>
+</model>

--- a/tests/regression/pythonscadecho/multitool-hidden-cutters-expected.echo
+++ b/tests/regression/pythonscadecho/multitool-hidden-cutters-expected.echo
@@ -1,0 +1,19 @@
+stored shapes: [2, 2, 3]
+parts len: 2
+parts names: ['red', 'blue']
+part0 uses hidden cutter: True
+part1 uses hidden cutter: True
+part2 is bare object: True
+append export int: TypeError
+append export zero: TypeError
+append export str: TypeError
+append export false ok: appended
+hidden duplicate names export: ok
+exportable duplicate names: ValueError
+all-hidden parts len: 0
+all-hidden single-file no-op: ok
+show call count: 2
+per-file export: True p-red.stl
+per-file export: True p-blue.stl
+single-file keys: ['red', 'blue']
+

--- a/web/docs/reference/multitool.md
+++ b/web/docs/reference/multitool.md
@@ -19,8 +19,12 @@ so it is available under either of these imports:
 ## MultiToolExporter
 
 `MultiToolExporter` is a `list` subclass whose items are
-`(name, object)` 2-tuples. The `name` is a label used to build the output
-filename and must be a non-empty string; output paths must be unique.
+`(name, object)` 2-tuples or optional `(name, object, export)` 3-tuples.
+The `name` is a label used to build the output filename and must be a
+non-empty string. The optional `export` flag defaults to `True`; set it to
+`False` for *cutters* that participate in cumulative subtraction but are
+omitted from `parts()`, `show()`, and all export paths. Output paths must be
+unique among exportable items; hidden duplicate names are allowed.
 Item order matches `dict.items()` and the multi-object form of
 [`export`](display.md#export), so a `MultiToolExporter` and a `dict` of
 parts are interchangeable (`MultiToolExporter(..., items=parts.items())`
@@ -41,12 +45,14 @@ exported is
 self[i].object − self[i+1].object − self[i+2].object − ... − self[-1].object
 ```
 
-i.e. each entry's volume minus every later entry's volume.
-This guarantees that overlapping regions are claimed by exactly one part:
+i.e. each entry's volume minus every later entry's volume, **including
+later entries with `export=False`**. Cutters therefore affect only earlier
+list entries; ordering semantics are unchanged. This guarantees that
+overlapping regions are claimed by exactly one exported part:
 **later entries "win" over earlier ones**, so each part only keeps the
-volume not claimed by any subsequent part. The last entry is exported
-as-is (no degenerate one-child `difference` node) and therefore claims
-everything that overlaps with it.
+volume not claimed by any subsequent item. The last list entry is exported
+as-is (no degenerate one-child `difference` node) when it is exportable and
+therefore claims everything that overlaps with it.
 
 **Constructor:**
 
@@ -63,7 +69,7 @@ everything that overlaps with it.
 | `prefix`  | `str`                           | —       | Prepended to every output filename                                                     |
 | `suffix`  | `str`                           | —       | Appended to every output filename (typically the extension, e.g. `".stl"`, `".3mf"`)   |
 | `mkdir`   | `bool`                          | `False` | If `True`, create each output file's directory with `os.makedirs(..., exist_ok=True)`. See note below. |
-| `items`   | iterable of `(name, object)`    | `()`    | Optional initial items (e.g. `a_dict.items()`), validated as if they were appended one at a time. |
+| `items`   | iterable of `(name, object)` or `(name, object, export)` | `()` | Optional initial items, validated as if appended. `export` must be `bool` (`0`/`1` rejected). |
 
 When `mkdir=True`, filenames without a directory component (e.g.
 `"flag-"` rather than `"out/flag-"`) are exported as-is - no directory
@@ -73,21 +79,23 @@ is created and no error is raised.
 
 | Method            | Description                                                                                                              |
 |-------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `append(item)`    | Append a single `(name, object)` 2-tuple. Validates the shape.                                                           |
-| `extend(items)`   | Append each `(name, object)` from an iterable.                                                                           |
-| `insert(i, item)` | Insert a single `(name, object)` 2-tuple at position `i`.                                                                |
-| `parts()`         | Return computed `(name, geometry)` pairs in declaration order. Useful for lower-level `dict(exporter.parts())` 3MF export. |
-| `export()`        | Write each part to its own file. Raises `ValueError` if any two items would write to the same output path.              |
-| `export(single_file="out/model.3mf")` | Write all computed parts into one multi-object 3MF file. Raises `ValueError` for non-`.3mf` paths or duplicate part names. |
-| `show()`          | Render each part into the preview viewport (same cumulative-difference semantics as `export`).                           |
+| `append(item)`    | Append a single `(name, object)` or `(name, object, export)` tuple. Validates the shape.                                                           |
+| `extend(items)`   | Append each item tuple from an iterable.                                                                           |
+| `insert(i, item)` | Insert a single item tuple at position `i`.                                                                |
+| `parts()`         | Return computed `(name, geometry)` pairs for exportable items only. Useful for lower-level `dict(exporter.parts())` 3MF export. |
+| `export()`        | Write each exportable part to its own file. Raises `ValueError` if any two exportable items would write to the same output path.              |
+| `export(single_file="out/model.3mf")` | Write exportable parts into one 3MF file. No-ops when all hidden. Raises `ValueError` for non-`.3mf` paths or duplicate exportable names. |
+| `show()`          | Render each exportable part into the preview viewport (same cumulative-difference semantics as `export`).                           |
 
 **Validation:**
 
-* Every inserted item must be a 2-tuple of `(str, object)`. Anything else
-  raises `TypeError`.
+* Every inserted item must be a 2-tuple of `(str, object)` or a 3-tuple of
+  `(str, object, bool)`. Anything else raises `TypeError`.
 * The `name` must be a non-empty string. Empty names raise `ValueError`.
+* The optional third element must be an actual `bool` (`0`/`1` and other
+  truthy values are rejected).
 * At `export()` time, the full output filename
-  (`f"{prefix}{name}{suffix}"`) of every item is normalised with
+  (`f"{prefix}{name}{suffix}"`) of every **exportable** item is normalised with
   `os.path.normcase(os.path.normpath(filename))` (plus an extra
   `.casefold()` on macOS) and any collision raises `ValueError` rather
   than letting later parts silently overwrite earlier ones. This rejects
@@ -95,9 +103,29 @@ is created and no error is raised.
   `"b"`, plus case-only collisions like `"a.stl"` vs `"A.stl"` on
   Windows and macOS (whose default filesystems are case-insensitive).
   Linux treats such case-only pairs as distinct files and is left
-  alone.
+  alone. Hidden (`export=False`) duplicate names are allowed.
 
 **Examples:**
+
+A two-color flag with a hidden slot cutter after both printable parts (the
+slot subtracts from both colors but is not exported):
+
+=== "Python"
+
+    ```python
+    from pythonscad import *
+
+    background = cube([200, 100, 1]).color("blue")
+    slot       = cube([40, 40, 2]).translate([80, 30, -0.5])
+    star       = cylinder(r=20, h=2, fn=5).translate([100, 50, -0.5]).color("red")
+
+    exporter = MultiToolExporter("out/flag-", ".stl", mkdir=True)
+    exporter.append(("blue", background))         # blue minus slot and star
+    exporter.append(("red", star))                # red minus slot
+    exporter.append(("slot", slot, False))        # cuts both; no file
+    exporter.export()
+    # -> writes out/flag-blue.stl and out/flag-red.stl only
+    ```
 
 A two-color flag (red star cut out of a blue background):
 
@@ -169,7 +197,9 @@ object can be assigned to a different tool or filament color:
     exporter.export(single_file="flag.3mf")
     ```
 
-For single-file export, item names become 3MF object names and must be unique.
+For single-file export, exportable item names become 3MF object names and must
+be unique among exportable items. Hidden cutters are omitted. If every item
+is hidden, single-file export is a no-op.
 `single_file` currently supports only `.3mf`; use plain `export()` when you
 want one output file per part.
 


### PR DESCRIPTION
## Summary
- accept `(name, object, export)` entries while preserving existing two-item tuples and defaulting export to `True`
- keep `export=False` cutters in cumulative subtraction but omit them from previews, split files, and multi-object 3MF output
- validate the flag as a strict boolean, scope collision checks to printable entries, and no-op all-hidden 3MF exports
- document ordering semantics and the recommended pattern of placing cutters after the printable parts they should affect

## Test plan
- [x] new API/validation echo regression covers mixed tuple shapes, strict booleans, hidden duplicates, previews, split/single-file filtering, and all-hidden input
- [x] new split-file golden exports only `blue.stl` and `red.stl`, with a final hidden slot subtracted from both
- [x] new single-file 3MF golden contains only `red` and `blue` objects
- [x] existing split-file and single-file MultiToolExporter regressions remain unchanged
- [x] repository pre-commit hooks, including Ruff, Markdown, MkDocs, and fixture checks

Made with [Cursor](https://cursor.com)