### PR TITLE
fix(web): avoid broken-pipe smoke failure

### DIFF
--- a/.github/scripts/wasm-playground-deploy-smoke.sh
+++ b/.github/scripts/wasm-playground-deploy-smoke.sh
@@ -6,9 +6,12 @@ base_url="${1:?base URL required (e.g. https://test.pythonscad.org/)}"
 
 playground="${base_url%/}/playground/"
 wasm_url="${playground}pythonscad.wasm"
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
 
 echo "Checking playground landing page ${playground}"
-curl -fsSL "$playground" | grep -q '<html'
+curl -fsSL "$playground" -o "$body"
+grep -q '<html' "$body"
 
 echo "Checking WASM MIME type for ${wasm_url}"
 content_type="$(

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -66,6 +66,9 @@ jobs:
           submodules: 'recursive'
           persist-credentials: false
 
+      - name: Test playground deploy smoke check
+        run: python3 wasm-test/wasm-playground-deploy-smoke.test.py
+
       - name: Fetch tags for version detection
         run: |
           git fetch --unshallow --tags || git fetch --tags

--- a/wasm-test/wasm-playground-deploy-smoke.test.py
+++ b/wasm-test/wasm-playground-deploy-smoke.test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+class PlaygroundDeploySmokeTest(unittest.TestCase):
+    def test_smoke_script_downloads_before_searching(self):
+        repo_root = pathlib.Path(__file__).resolve().parents[1]
+        script = repo_root / ".github/scripts/wasm-playground-deploy-smoke.sh"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_curl = pathlib.Path(temp_dir) / "curl"
+            fake_curl.write_text(
+                """#!/usr/bin/env python3
+import pathlib
+import sys
+
+args = sys.argv[1:]
+if any(arg.startswith("-") and "I" in arg[1:] for arg in args):
+    print("HTTP/1.1 200 OK\\r\\nContent-Type: application/wasm\\r\\n")
+    sys.exit()
+
+body = b"<html>" + (b"x" * (2 * 1024 * 1024))
+if "-o" in args:
+    pathlib.Path(args[args.index("-o") + 1]).write_bytes(body)
+    sys.exit()
+
+try:
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+except BrokenPipeError:
+    pass
+sys.exit(23)
+"""
+            )
+            fake_curl.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{temp_dir}:{env['PATH']}"
+            result = subprocess.run(
+                [script, "https://example.test/"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Playground smoke check passed.", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- download the deployed playground page to a temporary file before inspecting it
- preserve strict curl HTTP/download error handling while avoiding `grep -q` closing curl's pipe early
- clean up the temporary response body automatically

## Test plan
- [x] Reproduced the original `curl: (23) Failure writing output to destination` against the deployed playground
- [x] Ran the fixed smoke script against https://test.pythonscad.org/
- [x] Ran shellcheck through pre-commit
- [x] Ran `bash -n` on the modified script

Closes #948

Made with [Cursor](https://cursor.com)