### PR TITLE
fix(python): osuse() searches OpenSCAD library path after local lookup (#966)

### DIFF
--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -36,6 +36,7 @@
 #include <ColorNode.h>
 #include <ColorUtil.h>
 #include <io/fileutils.h>
+#include <core/parsersettings.h>
 #include <GeometryEvaluator.h>
 #include <platform/PlatformUtils.h>
 #include <handle_dep.h>
@@ -1075,7 +1076,13 @@ PyObject *python_osuse_include(int mode, PyObject *self, PyObject *args, PyObjec
     PyErr_SetString(PyExc_ValueError, "osuse(): filename must not be empty");
     return NULL;
   }
-  const std::string includedfile = lookup_file(file, python_scriptpath.parent_path().u8string(), ".");
+  std::string includedfile = lookup_file(file, python_scriptpath.parent_path().u8string(), ".");
+  const fs::path requested_path = fs::u8path(file);
+  if (!requested_path.is_absolute() && !fs::exists(fs::u8path(includedfile))) {
+    // Fall back to OpenSCAD's library paths when file not found.
+    const fs::path libraryfile = search_libs(requested_path);
+    if (!libraryfile.empty()) includedfile = libraryfile.generic_string();
+  }
   {
     const fs::path fpath = fs::u8path(includedfile);
     if (!fs::exists(fpath)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1383,6 +1383,23 @@ add_cmdline_test(pythonscadoverlayecho  EXPERIMENTAL OPENSCAD SUFFIX echo FILES 
 add_cmdline_test(pythonscadecho_pure EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_pure.py ARGS --enable=add-parameter-pure-function --trust-python)
 add_cmdline_test(echo EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${TEST_SCAD_DIR}/misc/vector-swizzling.scad ARGS --enable=vector-swizzle --trust-python)
 
+if(EXPERIMENTAL AND ENABLE_PYTHON)
+# osuse() must search OpenSCAD's library paths after its existing script/CWD lookup.
+# Override only OPENSCADPATH for this fixture; retain the common CTest environment.
+  set(OSUSE_LIBRARY_TEST_NAME "pythonscadecho_osuse-library-path")
+  get_property(OSUSE_LIBRARY_TEST_ENV TEST ${OSUSE_LIBRARY_TEST_NAME} PROPERTY ENVIRONMENT)
+  set(OSUSE_LIBRARY_TEST_ENV_WITHOUT_PATH)
+  foreach(ENV_ENTRY IN LISTS OSUSE_LIBRARY_TEST_ENV)
+    if(NOT ENV_ENTRY MATCHES "^OPENSCADPATH=")
+      list(APPEND OSUSE_LIBRARY_TEST_ENV_WITHOUT_PATH "${ENV_ENTRY}")
+    endif()
+  endforeach()
+  list(APPEND OSUSE_LIBRARY_TEST_ENV_WITHOUT_PATH
+       "OPENSCADPATH=${TEST_DATA_DIR}/osuse-library-path")
+  set_property(TEST ${OSUSE_LIBRARY_TEST_NAME} PROPERTY
+               ENVIRONMENT "${OSUSE_LIBRARY_TEST_ENV_WITHOUT_PATH}")
+endif()
+
 #
 # 3D export tests (compare exported 3MF files)
 #

--- a/tests/data/osuse-library-path/pythonscad_osuse_library_path_precedence.scad
+++ b/tests/data/osuse-library-path/pythonscad_osuse_library_path_precedence.scad
@@ -1,0 +1,1 @@
+function library_answer() = 42;

--- a/tests/data/osuse-library-path/pythonscad_osuse_library_path_unique.scad
+++ b/tests/data/osuse-library-path/pythonscad_osuse_library_path_unique.scad
@@ -1,0 +1,5 @@
+module library_box() {
+    cube(1);
+}
+
+function library_answer() = 42;

--- a/tests/data/pythonscad-echo/osuse-library-path.py
+++ b/tests/data/pythonscad-echo/osuse-library-path.py
@@ -1,0 +1,10 @@
+"""Regression test for osuse() lookup through OPENSCADPATH."""
+
+from openscad import osuse, scad
+
+library = osuse("pythonscad_osuse_library_path_unique.scad")
+library.library_box()
+scad(f'echo("library path answer: {library.library_answer()}");')
+
+local = osuse("pythonscad_osuse_library_path_precedence.scad")
+scad(f'echo("local path answer: {local.library_answer()}");')

--- a/tests/data/pythonscad-echo/pythonscad_osuse_library_path_precedence.scad
+++ b/tests/data/pythonscad-echo/pythonscad_osuse_library_path_precedence.scad
@@ -1,0 +1,1 @@
+function library_answer() = 7;

--- a/tests/regression/pythonscadecho/osuse-library-path-expected.echo
+++ b/tests/regression/pythonscadecho/osuse-library-path-expected.echo
@@ -1,0 +1,2 @@
+ECHO: "library path answer: 42.0"
+ECHO: "local path answer: 7.0"


### PR DESCRIPTION
Try to fix the issue #966 I raised just now.

osuse() will search for the OpenSCAD library paths also when failed to find the file.