### PR TITLE
fix(python): preserve int types for Customizer parameters

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -623,8 +623,15 @@ int cmdline(const CommandLine& cmd)
     }
     text = "\n";
   }
+  // For Python designs, -D overrides were already evaluated as Python above.
+  // Appending them here would feed Python into the SCAD parser and fail the run.
+  if (python_active) {
+    text += "\n\x03\n";
+  } else
 #endif  // ifdef ENABLE_PYTHON
-  text += "\n\x03\n" + commandline_commands;
+  {
+    text += "\n\x03\n" + commandline_commands;
+  }
 
   SourceFile *root_file = nullptr;
   if (!parse(root_file, text, cmd.filename, cmd.filename, false)) {

--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cmath>
 #include <iostream>
 #include <fstream>
 #include "genlang/genlang.h"
@@ -988,7 +989,15 @@ static PyObject *python_register_parameter_impl(PyObject *args, PyObject *kwargs
         auto expr = customizer_parameters_finished[i]->getExpr();
         const auto& lit = std::dynamic_pointer_cast<Literal>(expr);
         if (lit != nullptr) {
-          if (lit->isDouble()) value_effective = PyFloat_FromDouble(lit->toDouble());
+          // Finished values are stored as OpenSCAD NUMBER (double). Preserve the
+          // Python default's type so int parameters stay int across GUI re-previews.
+          if (lit->isDouble()) {
+            if (!is_bool && PyLong_Check(value)) {
+              value_effective = PyLong_FromLongLong(std::llround(lit->toDouble()));
+            } else {
+              value_effective = PyFloat_FromDouble(lit->toDouble());
+            }
+          }
           if (lit->isString()) value_effective = PyUnicode_FromString(lit->toString().c_str());
           if (lit->isBool()) value_effective = lit->toBool() ? Py_True : Py_False;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -301,6 +301,8 @@ file(GLOB PYTHONSCAD_OVERLAY_ECHO_FILES ${TEST_PYTHONSCAD_OVERLAY_ECHO_DIR}/*.py
 file(GLOB SCAD_3D_EXPORT_FILES      ${TEST_SCAD_DIR}/3d-export/*.scad)
 # Exclude add_parameter_pure.py as it has a separate test with feature flag
 list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_pure.py")
+# Exclude add_parameter_types.py: needs -D seeding of finished Customizer values
+list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_types.py")
 # GUI pointer callbacks are not exposed in headless builds.
 if(HEADLESS)
   list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/gui_callback_abi.py")
@@ -1381,6 +1383,8 @@ add_cmdline_test(pythonscadlaser     EXPERIMENTAL OPENSCAD SUFFIX svg FILES ${PY
 add_cmdline_test(pythonscadoverlay      EXPERIMENTAL OPENSCAD SUFFIX png FILES ${PYTHONSCAD_OVERLAY_FILES} ARGS --render --trust-python)
 add_cmdline_test(pythonscadoverlayecho  EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${PYTHONSCAD_OVERLAY_ECHO_FILES} ARGS --trust-python)
 add_cmdline_test(pythonscadecho_pure EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_pure.py ARGS --enable=add-parameter-pure-function --trust-python)
+# Seed customizer_parameters_finished via -D so int defaults are reapplied as doubles (GUI re-preview path).
+add_cmdline_test(pythonscadecho_types EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_types.py ARGS --trust-python "-Dfrom openscad import add_parameter as _ap$<SEMICOLON> _ap(\"int_param\", 256)$<SEMICOLON> _ap(\"float_param\", 256.0)$<SEMICOLON> _ap(\"str_param\", \"256\")")
 add_cmdline_test(echo EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${TEST_SCAD_DIR}/misc/vector-swizzling.scad ARGS --enable=vector-swizzle --trust-python)
 
 if(EXPERIMENTAL AND ENABLE_PYTHON)

--- a/tests/data/pythonscad-echo/add_parameter_types.py
+++ b/tests/data/pythonscad-echo/add_parameter_types.py
@@ -1,0 +1,17 @@
+"""Regression: int defaults must stay int when finished values are reapplied.
+
+The GUI dry-run / re-preview path stores Customizer numbers as OpenSCAD
+doubles and feeds them back through customizer_parameters_finished. This
+test seeds that finished-parameter path via -D (see CMake ARGS) and
+checks that Python int/float/str types are preserved on return.
+"""
+
+from openscad import add_parameter
+
+int_value = add_parameter("int_param", 256)
+float_value = add_parameter("float_param", 256.0)
+str_value = add_parameter("str_param", "256")
+
+print(f"int: {type(int_value).__name__} {int_value!r}")
+print(f"float: {type(float_value).__name__} {float_value!r}")
+print(f"str: {type(str_value).__name__} {str_value!r}")

--- a/tests/data/pythonscad-overlay-echo/customizer.py
+++ b/tests/data/pythonscad-overlay-echo/customizer.py
@@ -12,13 +12,17 @@ base = params.group("Base parameters")
 assert base is params.group("Base parameters")
 
 returned_diameter = base.add_parameter("diameter", 10, description="Diameter")
+returned_scale = params.add_parameter("scale", 1.0, description="Scale")
 label = params.add_parameter("label", "plate")
 
+assert type(returned_diameter) is int
+assert type(returned_scale) is float
 assert returned_diameter == 10
+assert returned_scale == 1.0
 assert label == "plate"
-assert dict(params) == {"diameter": 10.0, "label": "plate"}
-assert dict(base) == {"diameter": 10.0}
-assert len(params) == 2
+assert dict(params) == {"diameter": 10, "scale": 1.0, "label": "plate"}
+assert dict(base) == {"diameter": 10}
+assert len(params) == 3
 assert len(base) == 1
 
 assert "diameter" not in globals()

--- a/tests/regression/pythonscadecho_types/add_parameter_types-expected.echo
+++ b/tests/regression/pythonscadecho_types/add_parameter_types-expected.echo
@@ -1,0 +1,4 @@
+int: int 256
+float: float 256.0
+str: str '256'
+


### PR DESCRIPTION
## Summary
- Customizer/`add_parameter` stored finished numeric values as OpenSCAD doubles and always returned them to Python as `float`, so an `int` default became `float` after the GUI dry-run / re-preview path.
- Return finished numeric values as `int` when the declared default is a Python `int` (and keep `float` defaults as `float`).
- Skip appending Python `-D` overrides into the post-eval SCAD parse buffer so CLI can seed finished parameters for regression testing.

## Test plan
- [x] `ctest -R 'pythonscadecho_types|pythonscadoverlayecho_customizer'`
- [ ] GUI: open a design with `Customizer().add_parameter("n", 256)`, press F5 twice, confirm `type(params["n"]) is int`
- [ ] Confirm `add_parameter("x", 256.0)` still returns `float`


Made with [Cursor](https://cursor.com)