### PR TITLE
fix(customizer): preserve scroll, focus and group state on re-render

### DIFF
--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -34,6 +34,7 @@
 #include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
+#include <QScrollBar>
 #include <QString>
 #include <QToolButton>
 #include <QWidget>
@@ -43,9 +44,11 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "core/customizer/ParameterObject.h"
@@ -58,6 +61,80 @@
 #include "gui/parameter/ParameterText.h"
 #include "gui/parameter/ParameterVector.h"
 #include "gui/parameter/ParameterVirtualWidget.h"
+
+namespace {
+
+void appendOptional(std::ostringstream& out, const boost::optional<double>& value)
+{
+  if (value) {
+    out << *value;
+  }
+  out << '\x1f';
+}
+
+// Identity of the Customizer's *shape*: the parameter list plus everything that decides
+// which widget each parameter gets and how that widget is configured. Current values are
+// excluded on purpose - they are owned by the parameter set and restored by loadSet(), so
+// editing a value must not count as a shape change.
+std::string parameterShapeSignature(const ParameterObjects& parameters)
+{
+  std::ostringstream out;
+  out.precision(17);
+  for (const auto& parameter : parameters) {
+    out << parameter->name() << '\x1f' << parameter->description() << '\x1f' << parameter->group()
+        << '\x1f' << static_cast<int>(parameter->type()) << '\x1f';
+    switch (parameter->type()) {
+    case ParameterObject::ParameterType::Bool:
+      out << static_cast<const BoolParameter *>(parameter.get())->defaultValue;
+      break;
+    case ParameterObject::ParameterType::String: {
+      const auto *p = static_cast<const StringParameter *>(parameter.get());
+      out << p->defaultValue << '\x1f';
+      if (p->maximumSize) {
+        out << *p->maximumSize;
+      }
+      break;
+    }
+    case ParameterObject::ParameterType::Number: {
+      const auto *p = static_cast<const NumberParameter *>(parameter.get());
+      out << p->defaultValue << '\x1f';
+      appendOptional(out, p->minimum);
+      appendOptional(out, p->maximum);
+      appendOptional(out, p->step);
+      break;
+    }
+    case ParameterObject::ParameterType::Vector: {
+      const auto *p = static_cast<const VectorParameter *>(parameter.get());
+      for (const double element : p->defaultValue) {
+        out << element << ',';
+      }
+      out << '\x1f';
+      appendOptional(out, p->minimum);
+      appendOptional(out, p->maximum);
+      appendOptional(out, p->step);
+      break;
+    }
+    case ParameterObject::ParameterType::Enum: {
+      const auto *p = static_cast<const EnumParameter *>(parameter.get());
+      out << p->defaultValueIndex << '\x1f';
+      for (const auto& item : p->items) {
+        out << item.key << '\x1e';
+        if (std::holds_alternative<double>(item.value)) {
+          out << std::get<double>(item.value);
+        } else {
+          out << std::get<std::string>(item.value);
+        }
+        out << ',';
+      }
+      break;
+    }
+    }
+    out << '\x1e';
+  }
+  return out.str();
+}
+
+}  // namespace
 
 ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
 {
@@ -92,6 +169,9 @@ void ParameterWidget::resetForNewDocument()
   pendingSessionState.clear();
   invalidJsonFile.clear();
   source.clear();
+  parameterShape.clear();
+  savedGroupStates.clear();
+  savedScrollValue = 0;
   setModified(false);
 
   if (comboBoxPreset->isEditable() && comboBoxPreset->lineEdit()) {
@@ -177,6 +257,30 @@ void ParameterWidget::setParameters(const SourceFile *sourceFile, const std::str
 {
   this->source = source;
 
+  // Build the incoming set first so its shape can be compared with what is on screen. This
+  // is a pure AST walk; no widget is touched and nothing existing is modified.
+  ParameterObjects newParameters = ParameterObjects::fromSourceFile(sourceFile);
+  const std::string newShape = parameterShapeSignature(newParameters);
+
+  // Fast path: same shape as the widgets already built. This is the common case, because a
+  // re-render triggered from the Customizer re-declares exactly the same parameters. Keep
+  // the widgets so scroll offset, keyboard focus and group expansion survive, and let
+  // loadSet() below push the current set's values into them. The existing ParameterObjects
+  // have to be kept too, since every widget holds a raw pointer to its own; the incoming
+  // ones carry no information the kept ones lack, the shape being identical.
+  //
+  // Programmatic setValue() is safe here: it is the same call loadSet() already makes when
+  // switching presets. The spin box widgets guard re-entry with lastSent/lastApplied, and
+  // the check box and combo box listen on clicked/activated, which only user input emits.
+  if (!widgets.empty() && pendingSessionState.isEmpty() && newShape == this->parameterShape) {
+    loadSet(comboBoxPreset->currentIndex());
+    return;
+  }
+
+  // Shape really changed, so a rebuild is unavoidable. Snapshot the UI state now:
+  // rebuildWidgets() cannot read it itself, the group widgets being gone by the time it runs.
+  captureUiState();
+
   // Store old parameters temporarily - they must stay alive until widgets using them
   // are fully deleted. Using deleteLater() defers widget deletion until the event
   // loop, but if the parameters are destroyed first, the widgets will access freed
@@ -203,7 +307,8 @@ void ParameterWidget::setParameters(const SourceFile *sourceFile, const std::str
 
   // Now it's safe to load new parameters - old widgets have been deleted
   // and oldParameters will be destroyed when this function returns.
-  this->parameters = ParameterObjects::fromSourceFile(sourceFile);
+  this->parameters = std::move(newParameters);
+  this->parameterShape = newShape;
 
   if (!pendingSessionState.isEmpty()) {
     const QJsonDocument doc = QJsonDocument::fromJson(pendingSessionState);
@@ -451,12 +556,27 @@ void ParameterWidget::updateSetEditability()
   }
 }
 
+// Snapshot the UI state a rebuild would otherwise discard. Does nothing when no group
+// widget is alive to read, so a snapshot taken before a teardown is not clobbered by the
+// captureUiState() call at the top of rebuildWidgets().
+void ParameterWidget::captureUiState()
+{
+  const auto groupWidgets = this->findChildren<GroupWidget *>();
+  if (groupWidgets.isEmpty()) {
+    return;
+  }
+  savedGroupStates.clear();
+  for (GroupWidget *groupWidget : groupWidgets) {
+    savedGroupStates[groupWidget->title()] = groupWidget->isExpanded();
+  }
+  savedScrollValue = scrollArea->verticalScrollBar()->value();
+}
+
 void ParameterWidget::rebuildWidgets()
 {
-  std::map<QString, bool> expandedGroups;
-  for (GroupWidget *groupWidget : this->findChildren<GroupWidget *>()) {
-    expandedGroups.emplace(groupWidget->title(), groupWidget->isExpanded());
-  }
+  // Reads current state when the widgets are still up (the detail-level combo box path),
+  // and otherwise falls through to what setParameters() captured before its teardown.
+  captureUiState();
 
   widgets.clear();
   QLayout *layout = this->scrollAreaWidgetContents->layout();
@@ -480,10 +600,20 @@ void ParameterWidget::rebuildWidgets()
       widgets[parameter].push_back(parameterWidget);
       groupWidget->addWidget(parameterWidget);
     }
-    auto it = expandedGroups.find(group.name);
-    groupWidget->setExpanded(it == expandedGroups.end() || it->second);
+    auto it = savedGroupStates.find(group.name);
+    groupWidget->setExpanded(it == savedGroupStates.end() || it->second);
     layout->addWidget(groupWidget);
   }
+
+  // The new contents have not been laid out yet, so the scroll bar's range is still stale
+  // and setValue() would clamp to 0. Defer until the layout has settled.
+  if (savedScrollValue > 0) {
+    const int scrollValue = savedScrollValue;
+    QTimer::singleShot(0, this, [this, scrollValue]() {
+      scrollArea->verticalScrollBar()->setValue(scrollValue);
+    });
+  }
+  savedScrollValue = 0;
 }
 
 std::vector<ParameterWidget::ParameterGroup> ParameterWidget::getParameterGroups()

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -73,6 +73,16 @@ void appendOptional(std::ostringstream& out, const boost::optional<double>& valu
   out << '\x1f';
 }
 
+// Length-prefix anything that originated from the user. Delimiters alone are not enough:
+// a name, description, group, string default or enum key containing \x1f or \x1e could
+// forge a field boundary, letting two genuinely different parameter sets produce the same
+// signature. setParameters() would then take the fast path and skip a rebuild it actually
+// needed, leaving the Customizer out of sync with the declarations.
+void appendString(std::ostringstream& out, const std::string& value)
+{
+  out << value.size() << ':' << value;
+}
+
 // Identity of the Customizer's *shape*: the parameter list plus everything that decides
 // which widget each parameter gets and how that widget is configured. Current values are
 // excluded on purpose - they are owned by the parameter set and restored by loadSet(), so
@@ -82,15 +92,18 @@ std::string parameterShapeSignature(const ParameterObjects& parameters)
   std::ostringstream out;
   out.precision(17);
   for (const auto& parameter : parameters) {
-    out << parameter->name() << '\x1f' << parameter->description() << '\x1f' << parameter->group()
-        << '\x1f' << static_cast<int>(parameter->type()) << '\x1f';
+    appendString(out, parameter->name());
+    appendString(out, parameter->description());
+    appendString(out, parameter->group());
+    out << static_cast<int>(parameter->type()) << '\x1f';
     switch (parameter->type()) {
     case ParameterObject::ParameterType::Bool:
       out << static_cast<const BoolParameter *>(parameter.get())->defaultValue;
       break;
     case ParameterObject::ParameterType::String: {
       const auto *p = static_cast<const StringParameter *>(parameter.get());
-      out << p->defaultValue << '\x1f';
+      appendString(out, p->defaultValue);
+      out << '\x1f';
       if (p->maximumSize) {
         out << *p->maximumSize;
       }
@@ -119,11 +132,12 @@ std::string parameterShapeSignature(const ParameterObjects& parameters)
       const auto *p = static_cast<const EnumParameter *>(parameter.get());
       out << p->defaultValueIndex << '\x1f';
       for (const auto& item : p->items) {
-        out << item.key << '\x1e';
+        appendString(out, item.key);
         if (std::holds_alternative<double>(item.value)) {
-          out << std::get<double>(item.value);
+          out << 'd' << std::get<double>(item.value);
         } else {
-          out << std::get<std::string>(item.value);
+          out << 's';
+          appendString(out, std::get<std::string>(item.value));
         }
         out << ',';
       }

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -35,6 +35,7 @@
 #include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
+#include <QScrollBar>
 #include <QString>
 #include <QToolButton>
 #include <QWidget>
@@ -44,9 +45,11 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "core/customizer/ParameterObject.h"
@@ -59,6 +62,80 @@
 #include "gui/parameter/ParameterText.h"
 #include "gui/parameter/ParameterVector.h"
 #include "gui/parameter/ParameterVirtualWidget.h"
+
+namespace {
+
+void appendOptional(std::ostringstream& out, const boost::optional<double>& value)
+{
+  if (value) {
+    out << *value;
+  }
+  out << '\x1f';
+}
+
+// Identity of the Customizer's *shape*: the parameter list plus everything that decides
+// which widget each parameter gets and how that widget is configured. Current values are
+// excluded on purpose - they are owned by the parameter set and restored by loadSet(), so
+// editing a value must not count as a shape change.
+std::string parameterShapeSignature(const ParameterObjects& parameters)
+{
+  std::ostringstream out;
+  out.precision(17);
+  for (const auto& parameter : parameters) {
+    out << parameter->name() << '\x1f' << parameter->description() << '\x1f' << parameter->group()
+        << '\x1f' << static_cast<int>(parameter->type()) << '\x1f';
+    switch (parameter->type()) {
+    case ParameterObject::ParameterType::Bool:
+      out << static_cast<const BoolParameter *>(parameter.get())->defaultValue;
+      break;
+    case ParameterObject::ParameterType::String: {
+      const auto *p = static_cast<const StringParameter *>(parameter.get());
+      out << p->defaultValue << '\x1f';
+      if (p->maximumSize) {
+        out << *p->maximumSize;
+      }
+      break;
+    }
+    case ParameterObject::ParameterType::Number: {
+      const auto *p = static_cast<const NumberParameter *>(parameter.get());
+      out << p->defaultValue << '\x1f';
+      appendOptional(out, p->minimum);
+      appendOptional(out, p->maximum);
+      appendOptional(out, p->step);
+      break;
+    }
+    case ParameterObject::ParameterType::Vector: {
+      const auto *p = static_cast<const VectorParameter *>(parameter.get());
+      for (const double element : p->defaultValue) {
+        out << element << ',';
+      }
+      out << '\x1f';
+      appendOptional(out, p->minimum);
+      appendOptional(out, p->maximum);
+      appendOptional(out, p->step);
+      break;
+    }
+    case ParameterObject::ParameterType::Enum: {
+      const auto *p = static_cast<const EnumParameter *>(parameter.get());
+      out << p->defaultValueIndex << '\x1f';
+      for (const auto& item : p->items) {
+        out << item.key << '\x1e';
+        if (std::holds_alternative<double>(item.value)) {
+          out << std::get<double>(item.value);
+        } else {
+          out << std::get<std::string>(item.value);
+        }
+        out << ',';
+      }
+      break;
+    }
+    }
+    out << '\x1e';
+  }
+  return out.str();
+}
+
+}  // namespace
 
 ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
 {
@@ -93,6 +170,9 @@ void ParameterWidget::resetForNewDocument()
   pendingSessionState.clear();
   invalidJsonFile.clear();
   source.clear();
+  parameterShape.clear();
+  savedGroupStates.clear();
+  savedScrollValue = 0;
   setModified(false);
 
   if (comboBoxPreset->isEditable() && comboBoxPreset->lineEdit()) {
@@ -178,6 +258,30 @@ void ParameterWidget::setParameters(const SourceFile *sourceFile, const std::str
 {
   this->source = source;
 
+  // Build the incoming set first so its shape can be compared with what is on screen. This
+  // is a pure AST walk; no widget is touched and nothing existing is modified.
+  ParameterObjects newParameters = ParameterObjects::fromSourceFile(sourceFile);
+  const std::string newShape = parameterShapeSignature(newParameters);
+
+  // Fast path: same shape as the widgets already built. This is the common case, because a
+  // re-render triggered from the Customizer re-declares exactly the same parameters. Keep
+  // the widgets so scroll offset, keyboard focus and group expansion survive, and let
+  // loadSet() below push the current set's values into them. The existing ParameterObjects
+  // have to be kept too, since every widget holds a raw pointer to its own; the incoming
+  // ones carry no information the kept ones lack, the shape being identical.
+  //
+  // Programmatic setValue() is safe here: it is the same call loadSet() already makes when
+  // switching presets. The spin box widgets guard re-entry with lastSent/lastApplied, and
+  // the check box and combo box listen on clicked/activated, which only user input emits.
+  if (!widgets.empty() && pendingSessionState.isEmpty() && newShape == this->parameterShape) {
+    loadSet(comboBoxPreset->currentIndex());
+    return;
+  }
+
+  // Shape really changed, so a rebuild is unavoidable. Snapshot the UI state now:
+  // rebuildWidgets() cannot read it itself, the group widgets being gone by the time it runs.
+  captureUiState();
+
   // Store old parameters temporarily - they must stay alive until widgets using them
   // are fully deleted. Using deleteLater() defers widget deletion until the event
   // loop, but if the parameters are destroyed first, the widgets will access freed
@@ -204,7 +308,8 @@ void ParameterWidget::setParameters(const SourceFile *sourceFile, const std::str
 
   // Now it's safe to load new parameters - old widgets have been deleted
   // and oldParameters will be destroyed when this function returns.
-  this->parameters = ParameterObjects::fromSourceFile(sourceFile);
+  this->parameters = std::move(newParameters);
+  this->parameterShape = newShape;
 
   if (!pendingSessionState.isEmpty()) {
     const QJsonDocument doc = QJsonDocument::fromJson(pendingSessionState);
@@ -452,12 +557,27 @@ void ParameterWidget::updateSetEditability()
   }
 }
 
+// Snapshot the UI state a rebuild would otherwise discard. Does nothing when no group
+// widget is alive to read, so a snapshot taken before a teardown is not clobbered by the
+// captureUiState() call at the top of rebuildWidgets().
+void ParameterWidget::captureUiState()
+{
+  const auto groupWidgets = this->findChildren<GroupWidget *>();
+  if (groupWidgets.isEmpty()) {
+    return;
+  }
+  savedGroupStates.clear();
+  for (GroupWidget *groupWidget : groupWidgets) {
+    savedGroupStates[groupWidget->title()] = groupWidget->isExpanded();
+  }
+  savedScrollValue = scrollArea->verticalScrollBar()->value();
+}
+
 void ParameterWidget::rebuildWidgets()
 {
-  std::map<QString, bool> expandedGroups;
-  for (GroupWidget *groupWidget : this->findChildren<GroupWidget *>()) {
-    expandedGroups.emplace(groupWidget->title(), groupWidget->isExpanded());
-  }
+  // Reads current state when the widgets are still up (the detail-level combo box path),
+  // and otherwise falls through to what setParameters() captured before its teardown.
+  captureUiState();
 
   widgets.clear();
   QLayout *layout = this->scrollAreaWidgetContents->layout();
@@ -481,10 +601,20 @@ void ParameterWidget::rebuildWidgets()
       widgets[parameter].push_back(parameterWidget);
       groupWidget->addWidget(parameterWidget);
     }
-    auto it = expandedGroups.find(group.name);
-    groupWidget->setExpanded(it == expandedGroups.end() || it->second);
+    auto it = savedGroupStates.find(group.name);
+    groupWidget->setExpanded(it == savedGroupStates.end() || it->second);
     layout->addWidget(groupWidget);
   }
+
+  // The new contents have not been laid out yet, so the scroll bar's range is still stale
+  // and setValue() would clamp to 0. Defer until the layout has settled.
+  if (savedScrollValue > 0) {
+    const int scrollValue = savedScrollValue;
+    QTimer::singleShot(0, this, [this, scrollValue]() {
+      scrollArea->verticalScrollBar()->setValue(scrollValue);
+    });
+  }
+  savedScrollValue = 0;
 }
 
 std::vector<ParameterWidget::ParameterGroup> ParameterWidget::getParameterGroups()

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -624,9 +624,8 @@ void ParameterWidget::rebuildWidgets()
   // and setValue() would clamp to 0. Defer until the layout has settled.
   if (savedScrollValue > 0) {
     const int scrollValue = savedScrollValue;
-    QTimer::singleShot(0, this, [this, scrollValue]() {
-      scrollArea->verticalScrollBar()->setValue(scrollValue);
-    });
+    QTimer::singleShot(
+      0, this, [this, scrollValue]() { scrollArea->verticalScrollBar()->setValue(scrollValue); });
   }
   savedScrollValue = 0;
 }

--- a/src/gui/parameter/ParameterWidget.h
+++ b/src/gui/parameter/ParameterWidget.h
@@ -47,12 +47,18 @@ private:
   ParameterSets sets;
   std::string source;
   ParameterObjects parameters;
+  // Shape of `parameters`: everything that decides which widgets exist and how they are
+  // configured. Current values are deliberately excluded - loadSet() restores those.
+  std::string parameterShape;
   std::map<ParameterObject *, std::vector<ParameterVirtualWidget *>> widgets;
 
   QString invalidJsonFile;  // set if a json file was read that could not be parsed
   QTimer autoPreviewTimer;
   bool modified = false;
   QByteArray pendingSessionState;  // customizer state to apply on next setParameters()
+  // UI state captured before a teardown and reapplied by rebuildWidgets().
+  std::map<QString, bool> savedGroupStates;
+  int savedScrollValue = 0;
 
 public:
   ParameterWidget(QWidget *parent = nullptr);
@@ -106,6 +112,7 @@ protected:
   std::vector<ParameterGroup> getParameterGroups();
   ParameterVirtualWidget *createParameterWidget(ParameterObject *parameter,
                                                 DescriptionStyle descriptionStyle);
+  void captureUiState();
   QString getJsonFile(const QString& scadFile);
   void cleanSets();
 };


### PR DESCRIPTION
## Problem

With a design that declares parameters through `add_parameter()`, changing **any**
value in the Customizer tears the whole panel down and rebuilds it. The scroll
offset resets to 0, keyboard focus is lost, and every collapsed group springs
back open.

On a model with ~40 parameters across 8 groups this makes tuning painful: you
scroll down to a parameter, nudge it, and the panel throws you back to the top.

## Root cause

`ParameterWidget::setParameters()` unconditionally destroys every widget and
rebuilds from scratch, and a fresh layout starts at scroll 0.

Upstream OpenSCAD does not have this problem, because it guards the rebuild:

```cpp
if (this->source == source) {
  return;
}
```

That guard was removed in 86737000f ("sync with openscad/python", Dec 2024).
The removal was justified — Python parameters are declared at *runtime*, so they
cannot be known from the source text alone, and the guard would have prevented
the Customizer from ever updating. But nothing replaced it, so every re-render
now rebuilds.

This is also why the symptom is much worse here than in stock OpenSCAD: a
Customizer edit triggers a re-render, and each run re-emits the entire parameter
set via `customizer_parameters`.

## Fix

Compare the incoming parameter set by **shape** — name, type, group, description,
defaults, and per-type constraints (min/max/step, enum items, string max length) —
and when it matches what is already on screen, push values into the existing
widgets and return early.

This is strictly more general than the source-text guard it replaces:

- it survives value edits, because values are deliberately excluded from the
  signature (they are owned by the parameter set and restored by `loadSet()`);
- it still rebuilds correctly for **dynamic** parameter sets, where
  `add_parameter()` calls are conditional — a case the old guard could not
  handle at all.

When the shape genuinely did change, a rebuild is still required. In that case
the scroll offset and group expansion are snapshotted beforehand and restored
afterwards.

### Also fixes a latent bug

`rebuildWidgets()` already tried to preserve group expansion, collecting it via
`findChildren<GroupWidget*>()`. But `setParameters()` had already destroyed those
widgets and pumped the event loop, so that map was **always empty** and every
group silently re-expanded on every rebuild. The preservation code was there; it
just never fired on the path that mattered.

## Why writing to live widgets is safe

The fast path calls `loadSet()`, which writes values into existing widgets. That
is not a new code path — it is exactly what already happens on every preset
switch. No feedback loop results:

- `ParameterSlider`, `ParameterSpinBox` and `ParameterVector` set
  `lastApplied`/`lastSent` *before* touching the Qt widget, and `commitChange()`
  will not emit unless the value actually differs;
- `ParameterCheckBox` connects to `QCheckBox::clicked` and `ParameterComboBox` to
  `QComboBox::activated` — both user-input-only, so programmatic
  `setChecked()`/`setCurrentIndex()` cannot re-fire them.

## Known limitation

A design whose parameter *declarations* depend on other parameter values, e.g.

```python
add_parameter("width", 10, range=(1, 100))
add_parameter("height", width * 2)
```

still rebuilds when `width` changes, because `height`'s declared default really
did change. That is arguably correct — the widget's configuration genuinely
moved — and such models fall back to today's behaviour, now with scroll and group
state preserved across the rebuild. Models with independent parameters (the
common case) never rebuild.

## Testing

Verified manually on a Linux build (Qt6, `EXPERIMENTAL=ON`, `ENABLE_PYTHON=ON`)
and on a Windows build produced by `build-windows-native.yml`, using a test model
with 40 parameters across 8 groups covering every widget type (slider, spin box,
check box, dropdown, text, vector):

- scroll position holds when changing any value;
- collapsed groups stay collapsed;
- keyboard focus stays in the edited field;
- values still apply on every change (verified by echoing all live values to the
  console on each re-render);
- adding a new `add_parameter()` still rebuilds the panel and shows the new group.

No unit test is included, because the `OpenSCADUnitTests` target is currently
commented out in `CMakeLists.txt` (lines 2791-2795) — `TEST_SOURCES` and
`GUI_TEST_SOURCES` are globbed but never consumed, so the existing `*_test.cc`
files are not compiled either. A test over the shape signature would be
straightforward to add if that target is re-enabled; happy to do so. (Note that
`CLAUDE.md` still documents `./OpenSCADUnitTests` as runnable.)

## Scope

Two files, +144/-7, entirely within `ParameterWidget`. No header ABI change, no
signal/slot changes, and no changes outside `src/gui/parameter/`. The existing
`deleteLater()` / `processEvents()` / `oldParameters` lifetime handling from #368
is left intact on the rebuild path.
