### PR TITLE
docs(web): add imprint

### DIFF
--- a/web/docs/imprint.md
+++ b/web/docs/imprint.md
@@ -1,10 +1,10 @@
 # Imprint according to §24 MedienG Austria
 
 
-**Name:** nomike Postmann</br>
-**Address:** Johannagasse 2/1/8</br>
-1050 Wien</br>
-Austria</br>
+**Name:** nomike Postmann<br>
+**Address:** Johannagasse 2/1/8<br>
+1050 Wien<br>
+Austria<br>
 
 
 **Editorial policy:** This is the website for the open source project

--- a/web/docs/imprint.md
+++ b/web/docs/imprint.md
@@ -8,6 +8,6 @@ Austria<br>
 
 
 **Editorial policy:** This is the website for the open source project
-PythonSCAD, which is developed by nomike Postmann and others. It's purpose is to
+PythonSCAD, which is developed by nomike Postmann and others. Its purpose is to
 host information, documentation and other resources about PythonSCAD and related
 projects.

--- a/web/docs/imprint.md
+++ b/web/docs/imprint.md
@@ -1,4 +1,4 @@
-# Imprint according to §24 MedienG Austria
+# Imprint according to §24 MedienG (Austria)
 
 
 **Name:** nomike Postmann<br>

--- a/web/docs/imprint.md
+++ b/web/docs/imprint.md
@@ -1,0 +1,13 @@
+# Imprint according to §24 MedienG Austria
+
+
+**Name:** nomike Postmann</br>
+**Address:** Johannagasse 2/1/8</br>
+1050 Wien</br>
+Austria</br>
+
+
+**Editorial policy:** This is the website for the open source project
+PythonSCAD, which is developed by nomike Postmann and others. It's purpose is to
+host information, documentation and other resources about PythonSCAD and related
+projects.

--- a/web/mkdocs.yml
+++ b/web/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
   - Resources: resources.md
   - Jupyter Setup: jupyter.md
   - Contact: contact.md
+  - Imprint: imprint.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Adds an Imprint page required under §24 MedienG (Austria), with publisher details and editorial policy.
- Exposes the page in the MkDocs site navigation.

## Test plan
- [ ] Confirm **Imprint** appears in the site nav and opens `imprint.md`.
- [ ] Confirm publisher details render with line breaks and the editorial-policy grammar is correct.