### PR TITLE
fix(macos): disable mimalloc to stop Apple Silicon startup crash

### DIFF
--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -81,6 +81,7 @@ jobs:
             -DENABLE_TBB=OFF \
             -DENABLE_LIBFIVE=ON \
             -DPORTABLE_BINARY=ON \
+            -DUSE_MIMALLOC=OFF \
             -DENABLE_GAMEPAD=OFF \
             -DUSE_BUILTIN_CLIPPER2=OFF \
             -DUSE_BUILTIN_MANIFOLD=ON
@@ -238,6 +239,7 @@ jobs:
             -DENABLE_TBB=OFF \
             -DENABLE_LIBFIVE=ON \
             -DPORTABLE_BINARY=ON \
+            -DUSE_MIMALLOC=OFF \
             -DENABLE_GAMEPAD=OFF \
             -DUSE_BUILTIN_CLIPPER2=OFF \
             -DUSE_BUILTIN_MANIFOLD=ON

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -59,7 +59,7 @@ jobs:
             runner: ubuntu-24.04
             timeout_minutes: 120
           - name: macOS smoke tests
-            runner: macos-15-intel
+            runner: macos-14
             timeout_minutes: 60
           - name: Windows smoke tests
             runner: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ option(USE_CCACHE "Use ccache to speed up compilation." ON)
 
 if(APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$" OR CMAKE_OSX_ARCHITECTURES MATCHES "(^|;)arm64($|;)"))
   set(USE_MIMALLOC OFF CACHE BOOL "Use mimalloc as malloc replacement." FORCE)
-  message(STATUS "Disabling mimalloc on Apple Silicon macOS")
+  message(STATUS "Disabling mimalloc for arm64 macOS target")
 endif()
 
 set(ENABLE_CAIRO "AUTO" CACHE STRING "Enable support for cairo vector graphics library")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ option(USE_MIMALLOC "Use mimalloc as malloc replacement." ON)
 option(USE_BUILTIN_OPENCSG "Use OpenCSG from submodule." OFF)
 option(USE_CCACHE "Use ccache to speed up compilation." ON)
 
-if(APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$" OR CMAKE_OSX_ARCHITECTURES STREQUAL "arm64"))
+if(APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$" OR CMAKE_OSX_ARCHITECTURES MATCHES "(^|;)arm64($|;)"))
   set(USE_MIMALLOC OFF CACHE BOOL "Use mimalloc as malloc replacement." FORCE)
   message(STATUS "Disabling mimalloc on Apple Silicon macOS")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,12 @@ option(OFFLINE_DOCS "Download Documentation for offline usage" OFF)
 option(USE_MIMALLOC "Use mimalloc as malloc replacement." ON)
 option(USE_BUILTIN_OPENCSG "Use OpenCSG from submodule." OFF)
 option(USE_CCACHE "Use ccache to speed up compilation." ON)
+
+if(APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$" OR CMAKE_OSX_ARCHITECTURES STREQUAL "arm64"))
+  set(USE_MIMALLOC OFF CACHE BOOL "Use mimalloc as malloc replacement." FORCE)
+  message(STATUS "Disabling mimalloc on Apple Silicon macOS")
+endif()
+
 set(ENABLE_CAIRO "AUTO" CACHE STRING "Enable support for cairo vector graphics library")
 set_property(CACHE ENABLE_CAIRO PROPERTY STRINGS "AUTO" "ON" "OFF")
 

--- a/scripts/release-smoke/test-macos.sh
+++ b/scripts/release-smoke/test-macos.sh
@@ -32,6 +32,7 @@ keep_workdir=0
 skip_download=0
 artifact_dir=""
 mountpoint=""
+gui_pid=""
 
 while (($#)); do
   case "$1" in
@@ -84,6 +85,10 @@ rs_require_command hdiutil
 workdir=$(rs_make_workdir "$workdir_arg")
 cleanup() {
   local status=$?
+  if [[ -n "$gui_pid" ]]; then
+    kill -TERM "$gui_pid" 2>/dev/null || true
+    wait "$gui_pid" 2>/dev/null || true
+  fi
   if [[ -n "$mountpoint" && -d "$mountpoint" ]]; then
     hdiutil detach "$mountpoint" >/dev/null 2>&1 || true
   fi
@@ -155,5 +160,33 @@ fi
 
 [[ -n "$exe" ]] || rs_die "could not locate PythonSCAD executable inside $app"
 rs_smoke_binary "$exe" "$(basename "$app")" "$workdir"
+
+gui_log="$workdir/gui-startup.log"
+gui_home="$workdir/gui-home"
+mkdir -p "$gui_home"
+rs_log "Smoke testing $(basename "$app"): native GUI startup"
+
+set +e
+env -u QT_QPA_PLATFORM HOME="$gui_home" "$exe" > "$gui_log" 2>&1 &
+gui_pid=$!
+set -e
+
+for _ in {1..10}; do
+  if ! kill -0 "$gui_pid" 2>/dev/null; then
+    set +e
+    wait "$gui_pid"
+    gui_status=$?
+    set -e
+    rs_print_log_excerpt "$gui_log"
+    rs_die "native GUI exited during startup with status $gui_status"
+  fi
+  sleep 1
+done
+
+kill -TERM "$gui_pid" 2>/dev/null || true
+set +e
+wait "$gui_pid"
+set -e
+gui_pid=""
 
 rs_log "macOS DMG smoke tests passed"

--- a/scripts/release-smoke/test-macos.sh
+++ b/scripts/release-smoke/test-macos.sh
@@ -83,11 +83,25 @@ rs_require_command find
 rs_require_command hdiutil
 
 workdir=$(rs_make_workdir "$workdir_arg")
+stop_gui() {
+  local pid=${1:-}
+  [[ -n "$pid" ]] || return 0
+  kill -TERM "$pid" 2>/dev/null || true
+  for _ in 1 2 3; do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 1
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+  wait "$pid" 2>/dev/null || true
+}
+
 cleanup() {
   local status=$?
   if [[ -n "$gui_pid" ]]; then
-    kill -TERM "$gui_pid" 2>/dev/null || true
-    wait "$gui_pid" 2>/dev/null || true
+    stop_gui "$gui_pid"
+    gui_pid=""
   fi
   if [[ -n "$mountpoint" && -d "$mountpoint" ]]; then
     hdiutil detach "$mountpoint" >/dev/null 2>&1 || true
@@ -167,7 +181,10 @@ mkdir -p "$gui_home"
 rs_log "Smoke testing $(basename "$app"): native GUI startup"
 
 set +e
-env -u QT_QPA_PLATFORM HOME="$gui_home" "$exe" > "$gui_log" 2>&1 &
+(
+  cd "$workdir"
+  exec env -u QT_QPA_PLATFORM HOME="$gui_home" "$exe" > "$gui_log" 2>&1 </dev/null
+) &
 gui_pid=$!
 set -e
 
@@ -183,10 +200,7 @@ for _ in {1..10}; do
   sleep 1
 done
 
-kill -TERM "$gui_pid" 2>/dev/null || true
-set +e
-wait "$gui_pid"
-set -e
+stop_gui "$gui_pid"
 gui_pid=""
 
 rs_log "macOS DMG smoke tests passed"


### PR DESCRIPTION
## Summary
- Disables mimalloc on Apple Silicon and in both macOS release slices so the universal DMG no longer ships a thin `libmimalloc.3.dylib`.
- Adds a native Cocoa GUI liveness check to macOS release smoke and runs that job on ARM64 `macos-14`.
- Fixes #965 (startup `EXC_BAD_ACCESS` in mimalloc `zone_free` on an M4 MacBook Pro). This is a conservative mitigation; the original crash did not reproduce on an M1 Mini running macOS 14.5.

## Why mimalloc, and what we lose
Mimalloc is not a feature. OpenSCAD added it in 2021 because CGAL/GMP exact rationals (`Gmpq`) allocate heavily; a faster heap sped up F6. Linux, Windows, and local Intel macOS builds still use it. This PR turns it off for Apple Silicon and for both slices of the shipping macOS DMG (universal-bundle consistency).

Same-tree Linux timings of `examples/Old/example024.scad` (Menger n=3, three runs each):

| Backend | mimalloc ON | mimalloc OFF | Change |
|---|---|---|---|
| **CGAL** | 71.2s (69.3 / 70.3 / 73.9) | 75.0s (76.6 / 73.7 / 74.6) | **~5% slower**, ~8% more RAM |
| **Manifold** (default) | 2.58s | 2.75s | noise (~0.2s); user-time slightly *faster* OFF |

That is much smaller than the ~35% CGAL win measured on glibc in 2021. Default Manifold renders should not notice.

On an M1 Mini, 1.1.2 *with* mimalloc rendered the same CGAL model in **9.25s** (Manifold 0.21s wall). A no-mimalloc Apple Silicon number was not collected (artifact copy over ZeroTier stalled). Apple's `libmalloc` is usually closer to mimalloc than glibc is, so the Mac CGAL hit is likely **at most** that ~5%.

## Test plan
- [x] macOS release build: arm64, x86_64, and universal merge all green ([run 32906505196](https://github.com/pythonscad/pythonscad/actions/runs/32906505196))
- [x] CMake reports `Use mimalloc: OFF` for both slices; no `libmimalloc.3.dylib` in the universal bundle
- [x] ARM64 `macos-14` smoke: native GUI stayed alive 10s ([run 32909188224](https://github.com/pythonscad/pythonscad/actions/runs/32909188224))
- [x] Same-tree Linux ON vs OFF timing of `example024.scad` (CGAL ~5% slower; Manifold unchanged)
- [ ] Confirm on an M4 Mac / macOS 15 that the new DMG starts (original reporter hardware)
- Linux/Windows smoke failures in that run are unrelated (AppImage `libOpenGL.so.0`; Windows jq quoting of a slash in the branch name)