### PR TITLE
fix(python): skip export() file writes during F5 preview

### DIFF
--- a/src/python/py_io.cc
+++ b/src/python/py_io.cc
@@ -248,7 +248,10 @@ static bool python_export_obj_att_pre_encode()
 
 PyObject *python_export_core(PyObject *obj, char *file)
 {
-  if (pythonDryRun) {
+  if (pythonDryRun || pythonPreview) {
+    /* Customizer dummy parse, GUI F5, and CLI preview (echo/PNG without
+     * --render) must not write files. F6 / --render / mesh -o set
+     * pythonPreview false. */
     Py_RETURN_NONE;
   }
   std::string filename;

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -758,7 +758,7 @@ PyMethodDef PyOpenSCADFunctions[] = {
    "Split a compound object into its parts.\n"
    "separate(obj)"},
   {"export", (PyCFunction)python_export, METH_VARARGS | METH_KEYWORDS,
-   "Write object to a file (STL, etc.).\n"
+   "Write object to a file (STL, etc.). No-op during F5 preview.\n"
    "export(obj, file=\"out.stl\")"},
 
   {"linear_extrude", (PyCFunction)python_linear_extrude, METH_VARARGS | METH_KEYWORDS,

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -287,6 +287,7 @@ std::list<std::string> pythonInventory;
 AssignmentList customizer_parameters;
 AssignmentList customizer_parameters_finished;
 bool pythonDryRun = false;
+bool pythonPreview = false;
 PyObject *python_result_obj = nullptr;
 std::vector<SelectedObject> python_result_handle;
 bool python_runipython = false;
@@ -1560,6 +1561,7 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
   }
   std::ostringstream stream;
   if (r != nullptr) {
+    pythonPreview = r->preview;
     stream << "preview=" << (r->preview ? "True" : "False") << "\n";
 
     stream << "t=" << r->time << "\n";

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -1560,8 +1560,11 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
     PyGILState_Release(pathGil);
   }
   std::ostringstream stream;
+  /* Always refresh pythonPreview. Call sites that pass nullptr (REPL,
+   * IPython, Emscripten, GUI startup) must not keep a stale true from a
+   * previous F5 and suppress later export() writes. */
+  pythonPreview = r != nullptr && r->preview;
   if (r != nullptr) {
-    pythonPreview = r->preview;
     stream << "preview=" << (r->preview ? "True" : "False") << "\n";
 
     stream << "t=" << r->time << "\n";
@@ -1578,6 +1581,8 @@ void initPython(const std::string& binDir, const std::string& scriptpath, const 
 
     const auto vpf = r->camera.fovValue();
     stream << "vpf=" << vpf << "\n";
+  } else {
+    stream << "preview=False\n";
   }
   stream << commandline_commands << "\n";
   {

--- a/src/python/python_public.h
+++ b/src/python/python_public.h
@@ -58,6 +58,7 @@ Outline2d python_getprofile(void *v_cbfunc, int fn, double arg);
 extern bool pythonMainModuleInitialized;
 extern bool pythonRuntimeInitialized;
 extern bool pythonDryRun;
+extern bool pythonPreview;
 extern std::shared_ptr<AbstractNode> genlang_result_node;
 extern std::vector<SelectedObject> python_result_handle;
 extern std::string commandline_commands;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -303,6 +303,14 @@ file(GLOB SCAD_3D_EXPORT_FILES      ${TEST_SCAD_DIR}/3d-export/*.scad)
 list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_pure.py")
 # Exclude add_parameter_types.py: needs -D seeding of finished Customizer values
 list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/add_parameter_types.py")
+# export() is a no-op when preview=true (GUI F5 / CLI echo without --render).
+# Fixtures that must actually invoke python_export_core() run with --render.
+set(PYTHONSCAD_ECHO_EXPORT_FILES
+  "${TEST_PYTHONSCAD_ECHO_DIR}/export-error-handling.py"
+  "${TEST_PYTHONSCAD_ECHO_DIR}/issue587-export-non-str-keys.py"
+  "${TEST_PYTHONSCAD_ECHO_DIR}/issue232-lookup-file-export-deprecation.py"
+)
+list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES ${PYTHONSCAD_ECHO_EXPORT_FILES})
 # GUI pointer callbacks are not exposed in headless builds.
 if(HEADLESS)
   list(REMOVE_ITEM PYTHONSCAD_ECHO_FILES "${TEST_PYTHONSCAD_ECHO_DIR}/gui_callback_abi.py")
@@ -1380,6 +1388,8 @@ add_cmdline_test(previewmanifoldtest EXPERIMENTAL OPENSCAD SUFFIX png FILES ${EX
 add_cmdline_test(throwntogethertest  EXPERIMENTAL OPENSCAD SUFFIX png FILES ${EXPERIMENTAL_SKIN_FILES} ARGS --preview=throwntogether --enable=skin --trust-python)
 add_cmdline_test(pythonscad          EXPERIMENTAL OPENSCAD SUFFIX png FILES ${PYTHONSCAD_FILES} ARGS --render --trust-python)
 add_cmdline_test(pythonscadecho      EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${PYTHONSCAD_ECHO_FILES} ARGS --trust-python)
+# Same group name so goldens stay under tests/regression/pythonscadecho/.
+add_cmdline_test(pythonscadecho      EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${PYTHONSCAD_ECHO_EXPORT_FILES} ARGS --trust-python --render)
 add_cmdline_test(pythonscadlaser     EXPERIMENTAL OPENSCAD SUFFIX svg FILES ${PYTHONSCAD_LASER_FILES}            ARGS --trust-python)
 add_cmdline_test(pythonscadoverlay      EXPERIMENTAL OPENSCAD SUFFIX png FILES ${PYTHONSCAD_OVERLAY_FILES} ARGS --render --trust-python)
 add_cmdline_test(pythonscadoverlayecho  EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${PYTHONSCAD_OVERLAY_ECHO_FILES} ARGS --trust-python)

--- a/tests/data/pythonscad-echo/export-skipped-in-preview.py
+++ b/tests/data/pythonscad-echo/export-skipped-in-preview.py
@@ -1,0 +1,18 @@
+"""Echo test: export() must not write files when preview is true.
+
+CLI echo tests run with -o *.echo and without --render, so preview=True
+(the same flag as GUI F5). export() is a no-op in that mode: it returns
+without creating the target file.
+"""
+
+import os
+import tempfile
+
+from openscad import cube, export
+
+with tempfile.TemporaryDirectory() as tmp:
+    out = os.path.join(tmp, "should-not-exist.stl")
+    result = export(cube(10), out)
+    exists = os.path.exists(out)
+    print(f"return: {result!r}")
+    print(f"wrote file: {exists}")

--- a/tests/data/pythonscad-overlay-echo/numpy-api.py
+++ b/tests/data/pythonscad-overlay-echo/numpy-api.py
@@ -1,9 +1,5 @@
 """Check NumPy inputs and PythonSCAD-only vector helpers."""
 
-import atexit as _atexit
-import os as _os
-import tempfile as _tempfile
-
 import openscad as _openscad
 import pythonscad as _pythonscad
 from pythonscad import (
@@ -32,29 +28,25 @@ else:
     assert isinstance(Vector3([1, 2, 3]), list)
     assert isinstance(Matrix4x4(), list)
 
-_tmpdir_ctx = _tempfile.TemporaryDirectory(prefix="numpy_api_")
-_atexit.register(_tmpdir_ctx.cleanup)
-_tmpdir = _tmpdir_ctx.name
-_counter = 0
 
+def _geom(obj):
+    """Return a comparable (points, triangles) snapshot of ``obj``.
 
-def _stl(obj):
-    """Export obj to a fresh STL file and return its bytes."""
-    global _counter
-    _counter += 1
-    path = _os.path.join(_tmpdir, f"obj_{_counter}.stl")
-    obj.export(path)
-    with open(path, "rb") as fh:
-        data = fh.read()
-    _os.remove(path)
-    return data
+    Uses :meth:`mesh` rather than :func:`export` so this fixture still
+    runs under CLI echo / F5 preview, where ``export()`` is a no-op.
+    """
+    pts, tris = obj.mesh()
+    return (
+        tuple(tuple(float(c) for c in p) for p in pts),
+        tuple(tuple(int(i) for i in t) for t in tris),
+    )
 
 
 def _assert_same(name, obj_list, obj_variant):
-    list_stl = _stl(obj_list)
-    variant_stl = _stl(obj_variant)
-    assert list_stl, f"{name}: empty export"
-    assert list_stl == variant_stl, f"{name}: variant differs from list result"
+    list_geom = _geom(obj_list)
+    variant_geom = _geom(obj_variant)
+    assert list_geom[0] and list_geom[1], f"{name}: empty mesh"
+    assert list_geom == variant_geom, f"{name}: variant differs from list result"
 
 
 def _assert_type_error(name, func):

--- a/tests/regression/pythonscadecho/export-skipped-in-preview-expected.echo
+++ b/tests/regression/pythonscadecho/export-skipped-in-preview-expected.echo
@@ -1,0 +1,2 @@
+return: None
+wrote file: False

--- a/web/docs/reference/display.md
+++ b/web/docs/reference/display.md
@@ -43,6 +43,11 @@ Passing a list of solids implicitly creates a union.
 
 Export an object to a file. Supports STL, 3MF, OFF, AMF, and other formats based on the file extension.
 
+`export()` writes the file only when `preview` is false: F6 in the GUI,
+CLI `--render`, or a CLI mesh `-o` format such as STL/3MF. During F5
+preview (and CLI echo/PNG without `--render`) it is a no-op, so use
+`show()` for the viewport.
+
 **Syntax:**
 
 === "Python"


### PR DESCRIPTION
## Summary
- `export()` was writing files on GUI F5 (and CLI echo/PNG without `--render`) because `python_export_core()` only skipped dry-run customizer parses, not preview mode.
- Gate writes on the existing `preview` render flag (same meaning as `$preview`): no-op on F5, write on F6 / `--render` / mesh `-o`.
- Echo fixtures that must actually invoke `export()` now run with `--render`. Numpy overlay comparison uses `mesh()` so it still works in preview.

Fixes #1009

## Test plan
- [x] `pythonscadecho_export-skipped-in-preview` (preview no-op)
- [x] `pythonscadecho_export-error-handling`, `issue587`, `issue232` with `--render`
- [x] `pythonscadoverlayecho_numpy-api`
- [x] `pythonscad-export-stl_cube`, `pythonscadecho_multitool-*`
- [x] Copilot review + CI green


Made with [Cursor](https://cursor.com)