### PR TITLE
build: export compile commands for later CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,10 @@ set_target_properties(OpenSCADLibInternal svg OpenSCADExe PROPERTIES
   CXX_EXTENSIONS OFF
   CXX_STANDARD_REQUIRED ON
 )
+# The property above only applies to targets that already exist. Seed the
+# same default for every target created later (OpenSCADPy, tests, …) so
+# clangd / IntelliSense see Python.h and other per-target include paths.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Verbose link step
 if(("${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "GNU") OR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,11 @@ endif()
 # Note: CMAKE_OSX_DEPLOYMENT_TARGET must be set before the project() invocation
 set(CMAKE_OSX_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET} CACHE STRING "Minimum OS X deployment version")
 
+# Default ON so later targets (OpenSCADPy, tests, …) appear in
+# compile_commands.json. No FORCE: -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF wins.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL
+  "Generate compile_commands.json for clangd/clang-tidy")
+
 project(OpenSCAD
   VERSION ${PROJECT_VERSION}
   DESCRIPTION "The Programmer's Solid 3D CAD Modeler"
@@ -284,13 +289,6 @@ set_target_properties(OpenSCADLibInternal svg OpenSCADExe PROPERTIES
   CXX_EXTENSIONS OFF
   CXX_STANDARD_REQUIRED ON
 )
-# The property above only applies to targets that already exist. Seed the
-# same default for every target created later (OpenSCADPy, tests, …) so
-# clangd / IntelliSense see Python.h and other per-target include paths.
-# CACHE+FORCE updates cmake-gui; CMake already put OFF in the cache by
-# this point, so a non-FORCE cache set() would be a no-op.
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL
-  "Generate compile_commands.json for clangd/clang-tidy" FORCE)
 
 # Verbose link step
 if(("${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "GNU") OR
@@ -1037,6 +1035,7 @@ if(ENABLE_PYTHON)
   set_property(TARGET OpenSCADPy PROPERTY CXX_STANDARD 17)
   set_property(TARGET OpenSCADPy PROPERTY CXX_EXTENSIONS OFF)
   set_property(TARGET OpenSCADPy PROPERTY CXX_STANDARD_REQUIRED ON)
+  set_property(TARGET OpenSCADPy PROPERTY EXPORT_COMPILE_COMMANDS ON)
   target_compile_definitions(OpenSCADPy PRIVATE "STACKSIZE=${STACKSIZE}")
   target_compile_options(OpenSCADPy PRIVATE "$<$<CONFIG:DEBUG>:-DDEBUG>")
   target_compile_definitions(OpenSCADPy PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,10 @@ set_target_properties(OpenSCADLibInternal svg OpenSCADExe PROPERTIES
 # The property above only applies to targets that already exist. Seed the
 # same default for every target created later (OpenSCADPy, tests, …) so
 # clangd / IntelliSense see Python.h and other per-target include paths.
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# CACHE+FORCE updates cmake-gui; CMake already put OFF in the cache by
+# this point, so a non-FORCE cache set() would be a no-op.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL
+  "Generate compile_commands.json for clangd/clang-tidy" FORCE)
 
 # Verbose link step
 if(("${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "GNU") OR


### PR DESCRIPTION
Fixes #1013.

## Summary
- Default `CMAKE_EXPORT_COMPILE_COMMANDS` to ON in the cache *before* `project()`, without `FORCE`, so `-DCMAKE_EXPORT_COMPILE_COMMANDS=OFF` still wins.
- Always set `EXPORT_COMPILE_COMMANDS` on `OpenSCADPy`, matching `OpenSCADLibInternal` / `svg` / `OpenSCADExe`, so clangd can resolve `#include <Python.h>` even on existing build dirs whose cache still has CMake's default OFF.

## Test plan
- [x] Reconfigure CMake and confirm `src/python/py_io.cc` is in `build/compile_commands.json` with `-I/usr/include/python3.14`.
- [ ] Restart clangd and confirm the `Python.h` squiggle is gone.
- [x] CI green (CMake-only change; no runtime behavior).